### PR TITLE
Initial xlf files

### DIFF
--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.pt.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -1,0 +1,274 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.shared.resx">
+    <body>
+      <group id="SHARED/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="BuildAborted">
+        <source>MSB4188: Build was canceled.</source>
+        <target state="new">MSB4188: Build was canceled.</target>
+        <note>{StrBegin="MSB4188: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildEngineCallbacksInTaskHostUnsupported">
+        <source>MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</source>
+        <target state="new">MSB5022: The MSBuild task host does not support running tasks that perform IBuildEngine callbacks. If you wish to perform these operations, please run your task in the core MSBuild process instead.  A task will automatically execute in the task host if the UsingTask has been attributed with a "Runtime" or "Architecture" value, or the task invocation has been attributed with an "MSBuildRuntime" or "MSBuildArchitecture" value, that does not match the current runtime or architecture of MSBuild.</target>
+        <note>{StrBegin="MSB5022: "} "Runtime", "Architecture", "MSBuildRuntime", and "MSBuildArchitecture" are all attributes in the project file, and thus should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ConflictingTaskAssembly">
+        <source>MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</source>
+        <target state="new">MSB4008: A conflicting assembly for the task assembly "{0}" has been found at "{1}".</target>
+        <note>{StrBegin="MSB4008: "}UE: This message is shown when the type/class of a task cannot be resolved uniquely from a single assembly.</note>
+      </trans-unit>
+      <trans-unit id="ExpectedEventToBeSerializable">
+        <source>Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</source>
+        <target state="new">Event type "{0}" was expected to be serializable using the .NET serializer. The event was not serializable and has been ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentHeader">
+        <source>Making the following modifications to the environment received from the parent node before applying it to the task host:</source>
+        <target state="new">Making the following modifications to the environment received from the parent node before applying it to the task host:</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="ModifyingTaskHostEnvironmentVariable">
+        <source>  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</source>
+        <target state="new">  Setting '{0}' to '{1}' rather than the parent environment's value, '{2}'.</target>
+        <note>Only ever used when MSBuild is run under a "secret" environment variable switch, MSBuildTaskHostUpdateEnvironmentAndLog=1</note>
+      </trans-unit>
+      <trans-unit id="InvalidProjectFile">
+        <source>MSB4025: The project file could not be loaded. {0}</source>
+        <target state="new">MSB4025: The project file could not be loaded. {0}</target>
+        <note>{StrBegin="MSB4025: "}UE: This message is shown when the project file given to the engine cannot be loaded because the filename/path is
+    invalid, or due to lack of permissions, or incorrect XML. The project filename is not part of the message because it is
+    provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosity">
+        <source>MSB4103: "{0}" is not a valid logger verbosity level.</source>
+        <target state="new">MSB4103: "{0}" is not a valid logger verbosity level.</target>
+        <note>{StrBegin="MSB4103: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingProject">
+        <source>MSBuild is expecting a valid "{0}" object.</source>
+        <target state="new">MSBuild is expecting a valid "{0}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedToolsVersion">
+        <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
+        <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>
+        <note>{StrBegin="MSB4132: "}LOCALIZATION: {1} contains a comma separated list.</note>
+      </trans-unit>
+      <trans-unit id="NameInvalid">
+        <source>MSB5016: The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">MSB5016: The name "{0}" contains an invalid character "{1}".</target>
+        <note>{StrBegin="MSB5016: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotChangeItemSpecModifiers">
+        <source>"{0}" is a reserved item metadata, and cannot be modified or deleted.</source>
+        <target state="new">"{0}" is a reserved item metadata, and cannot be modified or deleted.</target>
+        <note>UE: Tasks and OM users are not allowed to remove or change the value of the built-in metadata on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="Shared.CannotConvertStringToBool">
+        <source>The string "{0}" cannot be converted to a boolean (true/false) value.</source>
+        <target state="new">The string "{0}" cannot be converted to a boolean (true/false) value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedCreatingTempFile">
+        <source>MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</source>
+        <target state="new">MSB5003: Failed to create a temporary file. Temporary files folder is full or its path is incorrect. {0}</target>
+        <note>{StrBegin="MSB5003: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.FailedDeletingTempFile">
+        <source>MSB5018: Failed to delete the temporary file "{0}". {1}</source>
+        <target state="new">MSB5018: Failed to delete the temporary file "{0}". {1}</target>
+        <note>{StrBegin="MSB5018: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidFilespecForTransform">
+        <source>The item metadata "%({0})" cannot be applied to the path "{1}". {2}</source>
+        <target state="new">The item metadata "%({0})" cannot be applied to the path "{1}". {2}</target>
+        <note>UE: This message is shown when the user tries to perform path manipulations using one of the built-in item metadata e.g. %(RootDir), on an item-spec that's not a valid path. LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskNotMarshalByRef">
+        <source>MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</source>
+        <target state="new">MSB4077: The "{0}" task has been marked with the attribute LoadInSeparateAppDomain, but does not derive from MarshalByRefObject. Check that the task derives from MarshalByRefObject or AppDomainIsolatedTask.</target>
+        <note>{StrBegin="MSB4077: "}LOCALIZATION: &lt;LoadInSeparateAppDomain&gt;, &lt;MarshalByRefObject&gt;, &lt;AppDomainIsolatedTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FrameworkLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotFound">
+        <source>Could not find directory path: {0}</source>
+        <target state="new">Could not find directory path: {0}</target>
+        <note>Directory must exist</note>
+      </trans-unit>
+      <trans-unit id="UnauthorizedAccess">
+        <source>You do not have access to: {0}</source>
+        <target state="new">You do not have access to: {0}</target>
+        <note>Directory must have access</note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSchemaValidationErrors">
+        <source>Schema validation</source>
+        <target state="new">Schema validation</target>
+        <note>
+      UE: this fragment is used to describe errors that are caused by schema validation. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from schema validation would look like this:
+      "MSBUILD : Schema validation error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcess">
+        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
+        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <note>{StrBegin="MSB5002: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotBeNull">
+        <source>Parameter "{0}" cannot be null.</source>
+        <target state="new">Parameter "{0}" cannot be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParameterCannotHaveZeroLength">
+        <source>Parameter "{0}" cannot have zero length.</source>
+        <target state="new">Parameter "{0}" cannot have zero length.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.ParametersMustHaveTheSameLength">
+        <source>Parameters "{0}" and "{1}" must have the same number of elements.</source>
+        <target state="new">Parameters "{0}" and "{1}" must have the same number of elements.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourceNotFound">
+        <source>The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</source>
+        <target state="new">The resource string "{0}" for the "{1}" task cannot be found. Confirm that the resource name "{0}" is correctly spelled, and the resource exists in the task's assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Shared.TaskResourcesNotRegistered">
+        <source>The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</source>
+        <target state="new">The "{0}" task has not registered its resources. In order to use the "TaskLoggingHelper.FormatResourceString()" method this task needs to register its resources either during construction, or via the "TaskResources" property.</target>
+        <note>LOCALIZATION: "TaskLoggingHelper.FormatResourceString()" and "TaskResources" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseDuplicateProject">
+        <source>MSB5004: The solution file has two projects named "{0}".</source>
+        <target state="new">MSB5004: The solution file has two projects named "{0}".</target>
+        <note>{StrBegin="MSB5004: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameCharacters">
+        <source>MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</source>
+        <target state="new">MSB5005: Error parsing project section for project "{0}". The project file name "{1}" contains invalid characters.</target>
+        <note>{StrBegin="MSB5005: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileNameEmpty">
+        <source>MSB5006: Error parsing project section for project "{0}". The project file name is empty.</source>
+        <target state="new">MSB5006: Error parsing project section for project "{0}". The project file name is empty.</target>
+        <note>{StrBegin="MSB5006: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectSolutionConfigurationEntry">
+        <source>MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5007: Error parsing the project configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5007: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidSolutionConfigurationEntry">
+        <source>MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</source>
+        <target state="new">MSB5008: Error parsing the solution configuration section in solution file. The entry "{0}" is invalid.</target>
+        <note>{StrBegin="MSB5008: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectError">
+        <source>MSB5009: Error parsing the nested project section in solution file.</source>
+        <target state="new">MSB5009: Error parsing the nested project section in solution file.</target>
+        <note>{StrBegin="MSB5009: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNestedProjectUndefinedError">
+        <source>MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</source>
+        <target state="new">MSB5023: Error parsing the nested project section in solution file. A project with the GUID "{0}" is listed as being nested under project "{1}", but does not exist in the solution.</target>
+        <note>{StrBegin="MSB5023: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseNoHeaderError">
+        <source>MSB5010: No file format header found.</source>
+        <target state="new">MSB5010: No file format header found.</target>
+        <note>{StrBegin="MSB5010: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepGuidError">
+        <source>MSB5011: Parent project GUID not found in "{0}" project dependency section.</source>
+        <target state="new">MSB5011: Parent project GUID not found in "{0}" project dependency section.</target>
+        <note>{StrBegin="MSB5011: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectEofError">
+        <source>MSB5012: Unexpected end-of-file reached inside "{0}" project section.</source>
+        <target state="new">MSB5012: Unexpected end-of-file reached inside "{0}" project section.</target>
+        <note>{StrBegin="MSB5012: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectError">
+        <source>MSB5013: Error parsing a project section.</source>
+        <target state="new">MSB5013: Error parsing a project section.</target>
+        <note>{StrBegin="MSB5013: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseVersionMismatchError">
+        <source>MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</source>
+        <target state="new">MSB5014: File format version is not recognized.  MSBuild can only read solution files between versions {0}.0 and {1}.0, inclusive.</target>
+        <note>{StrBegin="MSB5014: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseWebProjectPropertiesError">
+        <source>MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</source>
+        <target state="new">MSB5015: The properties could not be read from the WebsiteProperties section of the "{0}" project.</target>
+        <note>{StrBegin="MSB5015: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedSolutionComment">
+        <source>Unrecognized solution version "{0}", attempting to continue.</source>
+        <target state="new">Unrecognized solution version "{0}", attempting to continue.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubCategoryForSolutionParsingErrors">
+        <source>Solution file</source>
+        <target state="new">Solution file</target>
+        <note>UE: this fragment is used to describe errors found while parsing solution files. For example, if a normal error is
+      displayed like this: "MSBUILD : error MSB0000: This is an error.", then an error from solution parsing would look like this:
+      "MSBUILD : Solution file error MSB0000: This is an error."
+      LOCALIZATION: This fragment needs to be localized.</note>
+      </trans-unit>
+      <trans-unit id="Shared.InvalidProjectFile">
+        <source>MSB5019: The project file is malformed: "{0}". {1}</source>
+        <target state="new">MSB5019: The project file is malformed: "{0}". {1}</target>
+        <note>{StrBegin="MSB5019: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.ProjectFileCouldNotBeLoaded">
+        <source>MSB5020: Could not load the project file: "{0}". {1}</source>
+        <target state="new">MSB5020: Could not load the project file: "{0}". {1}</target>
+        <note>{StrBegin="MSB5020: "}</note>
+      </trans-unit>
+      <trans-unit id="Shared.KillingProcessByCancellation">
+        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
+        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <note>{StrBegin="MSB5021: "}</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedReadOnlyCollection">
+        <source>This collection is read-only.</source>
+        <target state="new">This collection is read-only.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.cs.xlf
+++ b/src/Utilities/Resources/xlf/Strings.cs.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.de.xlf
+++ b/src/Utilities/Resources/xlf/Strings.de.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.es.xlf
+++ b/src/Utilities/Resources/xlf/Strings.es.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.fr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.fr.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.it.xlf
+++ b/src/Utilities/Resources/xlf/Strings.it.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.ja.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ja.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.ko.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ko.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.pl.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pl.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.pt.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pt.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.ru.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ru.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.tr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.tr.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.UTILITIES/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="General.InvalidToolSwitch">
+        <source>MSB6001: Invalid command line switch for "{0}". {1}</source>
+        <target state="new">MSB6001: Invalid command line switch for "{0}". {1}</target>
+        <note>{StrBegin="MSB6001: "}UE: This message is shown when a tool-based task (i.e. the task is a wrapper for an .exe) is given a parameter value that converts into an invalid command line switch for the tool. "{0}" is the name of the tool e.g. "csc.exe", and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameter">
+        <source>Illegal quote passed to the command line switch named "{0}". The value was [{1}].</source>
+        <target state="new">Illegal quote passed to the command line switch named "{0}". The value was [{1}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.QuotesNotAllowedInThisKindOfTaskParameterNoSwitchName">
+        <source>Illegal quote in the command line value [{0}].</source>
+        <target state="new">Illegal quote in the command line value [{0}].</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.StringsCannotContainOddNumberOfDoubleQuotes">
+        <source>The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</source>
+        <target state="new">The value [{0}] contains an odd number of double-quote characters. Only even numbers of literal double-quote characters are acceptable to command line tools.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailedNoErrorCode">
+        <source>The command exited with code {0}.</source>
+        <target state="new">The command exited with code {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="LoggingBeforeTaskInitialization">
+        <source>MSB6005: Task attempted to log before it was initialized. Message was: {0}</source>
+        <target state="new">MSB6005: Task attempted to log before it was initialized. Message was: {0}</target>
+        <note>{StrBegin="MSB6005: "}UE: This occurs if the task attempts to log something in its own constructor.</note>
+      </trans-unit>
+      <trans-unit id="PlatformManifest.MissingPlatformXml">
+        <source>MSB6010: Could not find platform manifest file at "{0}".</source>
+        <target state="new">MSB6010: Could not find platform manifest file at "{0}".</target>
+        <note>{StrBegin="MSB6010: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersion">
+        <source>.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</source>
+        <target state="new">.NET Framework version "{0}" is not supported. Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedFrameworkVersionForWindowsSdk">
+        <source>.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</source>
+        <target state="new">.NET Framework version "{0}" is not supported when explicitly targeting the Windows SDK, which is only supported on .NET 4.5 and later.  Please specify a value from the enumeration Microsoft.Build.Utilities.TargetDotNetFrameworkVersion that is Version45 or above.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolLocationHelper.UnsupportedVisualStudioVersion">
+        <source>Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</source>
+        <target state="new">Visual Studio version "{0}" is not supported.  Please specify a value from the enumeration Microsoft.Build.Utilities.VisualStudioVersion.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CommandTooLong">
+        <source>MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</source>
+        <target state="new">MSB6002: The command-line for the "{0}" task is too long. Command-lines longer than 32000 characters are likely to fail. Try reducing the length of the command-line by breaking down the call to "{0}" into multiple calls with fewer parameters per call.</target>
+        <note>{StrBegin="MSB6002: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.CouldNotStartToolExecutable">
+        <source>MSB6003: The specified task executable "{0}" could not be run. {1}</source>
+        <target state="new">MSB6003: The specified task executable "{0}" could not be run. {1}</target>
+        <note>{StrBegin="MSB6003: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolCommandFailed">
+        <source>MSB6006: "{0}" exited with code {1}.</source>
+        <target state="new">MSB6006: "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB6006: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.ToolExecutableNotFound">
+        <source>MSB6004: The specified task executable location "{0}" is invalid.</source>
+        <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
+        <note>{StrBegin="MSB6004: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
+        <source>There was an error reading the redist list file "{0}". {1}</source>
+        <target state="new">There was an error reading the redist list file "{0}". {1}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotCreateChain">
+        <source>The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</source>
+        <target state="new">The Framework at path "{0}" tried to include the framework at path "{1}" as part of its reference assembly paths but there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolsLocationHelper.CouldNotGenerateReferenceAssemblyDirectory">
+        <source>When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</source>
+        <target state="new">When attempting to generate a reference assembly path from the path "{0}" and the framework moniker "{1}" there was an error. {2}</target>
+        <note>No Error code because this resource will be used in an exception. The error code is discarded if it is included</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.InvalidEnvironmentParameter">
+        <source>MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</source>
+        <target state="new">MSB6007: The "{0}" value passed to the Environment property is not in the format "name=value", where the value part may be empty.</target>
+        <note>{StrBegin="MSB6007: "}</note>
+      </trans-unit>
+      <trans-unit id="ToolTask.EnvironmentVariableHeader">
+        <source>Environment Variables passed to tool:</source>
+        <target state="new">Environment Variables passed to tool:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_LogFilesNotAvailable">
+        <source>Tracking logs are not available, minimal rebuild will be disabled.</source>
+        <target state="new">Tracking logs are not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingInputs">
+        <source>Missing input files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing input files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_MissingOutputs">
+        <source>Missing output files detected, minimal rebuild will be disabled.</source>
+        <target state="new">Missing output files detected, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_UpToDate">
+        <source>Skipping task because it is up-to-date.</source>
+        <target state="new">Skipping task because it is up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogNotAvailable">
+        <source>Write Tracking log not available, minimal rebuild will be disabled.</source>
+        <target state="new">Write Tracking log not available, minimal rebuild will be disabled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingLogs">
+        <source>Write Tracking Logs:</source>
+        <target state="new">Write Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteTrackingCached">
+        <source>Using cached output dependency table built from:</source>
+        <target state="new">Using cached output dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingLogs">
+        <source>Tracking Logs:</source>
+        <target state="new">Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_TrackingCached">
+        <source>Using cached dependency table built from:</source>
+        <target state="new">Using cached dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsFor">
+        <source>Outputs for {0}:</source>
+        <target state="new">Outputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsFor">
+        <source>Inputs for {0}:</source>
+        <target state="new">Inputs for {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputsNotShown">
+        <source>Output details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Output details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputsNotShown">
+        <source>Input details ({0} of them) were not logged for performance reasons.</source>
+        <target state="new">Input details ({0} of them) were not logged for performance reasons.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SingleLogFileNotAvailable">
+        <source>Tracking log {0} is not available.</source>
+        <target state="new">Tracking log {0} is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledAsNoTrackingLog">
+        <source>{0} will be compiled as the tracking log is not available.</source>
+        <target state="new">{0} will be compiled as the tracking log is not available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceNotInTrackingLog">
+        <source>{0} will be compiled as it was not found in the tracking log.</source>
+        <target state="new">{0} will be compiled as it was not found in the tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceOutputsNotAvailable">
+        <source>{0} will be compiled as not all outputs are available.</source>
+        <target state="new">{0} will be compiled as not all outputs are available.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledMissingDependency">
+        <source>{0} will be compiled as dependency {1} was missing.</source>
+        <target state="new">{0} will be compiled as dependency {1} was missing.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledDependencyWasModifiedAt">
+        <source>{0} will be compiled as {1} was modified at {2}.</source>
+        <target state="new">{0} will be compiled as {1} was modified at {2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiled">
+        <source>{0} will be compiled.</source>
+        <target state="new">{0} will be compiled.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_AllOutputsAreUpToDate">
+        <source>All outputs are up-to-date.</source>
+        <target state="new">All outputs are up-to-date.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependencyWasModifiedAt">
+        <source>File {0} was modified at {1} which is newer than {2} modified at {3}.</source>
+        <target state="new">File {0} was modified at {1} which is newer than {2} modified at {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputDoesNotExist">
+        <source>{0} does not exist; source compilation required.</source>
+        <target state="new">{0} does not exist; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourceWillBeCompiledOutputDoesNotExist">
+        <source>{0} will be compiled as output {1} does not exist.</source>
+        <target state="new">{0} will be compiled as output {1} does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingLogs">
+        <source>Read Tracking Logs:</source>
+        <target state="new">Read Tracking Logs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadTrackingCached">
+        <source>Using cached input dependency table built from:</source>
+        <target state="new">Using cached input dependency table built from:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_OutputForRootNotFound">
+        <source>No output for {0} was found in the tracking log; source compilation required.</source>
+        <target state="new">No output for {0} was found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_DependenciesForRootNotFound">
+        <source>No dependencies for output {0} were found in the tracking log; source compilation required.</source>
+        <target state="new">No dependencies for output {0} were found in the tracking log; source compilation required.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_WriteLogEntryNotFound">
+        <source>Could not find {0} in the write tracking log.</source>
+        <target state="new">Could not find {0} in the write tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_ReadLogEntryNotFound">
+        <source>Could not find {0} in the read tracking log.</source>
+        <target state="new">Could not find {0} in the read tracking log.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_SourcesAndCorrespondingOutputMismatch">
+        <source>The number of source files and corresponding outputs must match.</source>
+        <target state="new">The number of source files and corresponding outputs must match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_InputNewerThanOutput">
+        <source>Source compilation required: input {0} is newer than output {1}.</source>
+        <target state="new">Source compilation required: input {0} is newer than output {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLog">
+        <source>MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</source>
+        <target state="new">MSB6008: Forcing a rebuild of all sources due to an error with the tracking logs. {0}</target>
+        <note>{StrBegin="MSB6008: "}</note>
+      </trans-unit>
+      <trans-unit id="Tracking_RebuildingDueToInvalidTLogContents">
+        <source>MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</source>
+        <target state="new">MSB6009: Forcing a rebuild of all source files due to the contents of "{0}" being invalid.</target>
+        <note>{StrBegin="MSB6009: "}</note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MuxLogger_BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.cs.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.cs.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.de.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.de.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.es.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.es.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.fr.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.fr.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.it.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.it.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.ja.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.ja.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.ko.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.ko.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.pl.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.pl.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.pt.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.pt.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.ru.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.ru.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.tr.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.tr.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeBuildEngine/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/XMakeBuildEngine/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,0 +1,1927 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousTaskParameterError">
+        <source>MSB4001: The "{0}" task has more than one parameter called "{1}".</source>
+        <target state="new">MSB4001: The "{0}" task has more than one parameter called "{1}".</target>
+        <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
+    those properties the task wants to use as a parameter in project files.</note>
+      </trans-unit>
+      <trans-unit id="AttributeTypeLoadError">
+        <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
+        <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>
+        <note>{StrBegin="MSB4002: "}UE: This message is shown when the .NET attributes that a task's .NET properties are decorated with, cannot be
+    retrieved -- this is typically because the .NET classes that define the .NET attributes cannot be loaded because the assembly
+    they are defined in cannot be found, or the classes themselves cannot be found.</note>
+      </trans-unit>
+      <trans-unit id="BadlyCasedSpecialTaskAttribute">
+        <source>MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</source>
+        <target state="new">MSB4003: "{0}" is a reserved attribute of the &lt;{1}&gt; element, and must be spelled with the correct casing. This attribute cannot be used as a parameter to the "{2}" task.</target>
+        <note>{StrBegin="MSB4003: "}UE: Tasks are not allowed to use incorrect case for reserved attributes on the task nodes e.g. "continueonerror"
+    instead of the "ContinueOnError".</note>
+      </trans-unit>
+      <trans-unit id="BuildInProgress">
+        <source>The operation cannot be completed because a build is already in progress.</source>
+        <target state="new">The operation cannot be completed because a build is already in progress.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="NoBuildInProgress">
+        <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
+        <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WaitingForEndOfBuild">
+        <source>The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</source>
+        <target state="new">The operation cannot be completed because EndBuild has already been called but existing submissions have not yet completed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SubmissionAlreadyComplete">
+        <source>The operation cannot be completed because the submission has already been executed.</source>
+        <target state="new">The operation cannot be completed because the submission has already been executed.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ShouldNotDisposeWhenBuildManagerActive">
+        <source>Cannot dispose the build manager because it is not idle.</source>
+        <target state="new">Cannot dispose the build manager because it is not idle.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildAbortedWithMessage">
+        <source>MSB4197: Build was canceled. {0}</source>
+        <target state="new">MSB4197: Build was canceled. {0}</target>
+        <note>{StrBegin="MSB4197: "} Error when the build stops suddenly for some reason. For example, because a child node died.</note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedFailure">
+        <source>Build FAILED.</source>
+        <target state="new">Build FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildFinishedSuccess">
+        <source>Build succeeded.</source>
+        <target state="new">Build succeeded.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildStartedWithTime">
+        <source>Build started {0}.</source>
+        <target state="new">Build started {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletely">
+        <source>Building target "{0}" completely.</source>
+        <target state="new">Building target "{0}" completely.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyNoInputsSpecified">
+        <source>No input files were specified.</source>
+        <target state="new">No input files were specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputNewer">
+        <source>Input file "{0}" is newer than output file "{1}".</source>
+        <target state="new">Input file "{0}" is newer than output file "{1}".</target>
+        <note>{0} and {1} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyOutputDoesntExist">
+        <source>Output file "{0}" does not exist.</source>
+        <target state="new">Output file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetCompletelyInputDoesntExist">
+        <source>Input file "{0}" does not exist.</source>
+        <target state="new">Input file "{0}" does not exist.</target>
+        <note>{0} is a filename on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartially">
+        <source>Building target "{0}" partially, because some output files are out of date with respect to their input files.</source>
+        <target state="new">Building target "{0}" partially, because some output files are out of date with respect to their input files.</target>
+        <note>{0} is the name of the target.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputNewer">
+        <source>[{0}: Input={1}, Output={2}] Input file is newer than output file.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file is newer than output file.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyOutputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Output file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Output file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="BuildTargetPartiallyInputDoesntExist">
+        <source>[{0}: Input={1}, Output={2}] Input file does not exist.</source>
+        <target state="new">[{0}: Input={1}, Output={2}] Input file does not exist.</target>
+        <note>{0} is the name of an MSBuild item.  {1} and {2} are filenames on disk.</note>
+      </trans-unit>
+      <trans-unit id="CannotAccessKnownAttributes">
+        <source>The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</source>
+        <target state="new">The attribute "{0}" is a known MSBuild attribute, and cannot be accessed using this method.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CannotEvaluateItemMetadata">
+        <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
+        <target state="new">MSB4023: Cannot evaluate the item metadata "%({0})". {1}</target>
+        <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
+    %(RootDir) to an item-spec that's not a valid path, would result in this error.
+    LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindMSBuildExe">
+        <source>MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4193: MSBuild.exe could not be launched as a child node as it could not be found at the location "{0}". If necessary, specify the correct location in the BuildParameters, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4193: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotConnectToMSBuildExe">
+        <source>MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</source>
+        <target state="new">MSB4218: Failed to successfully launch or connect to a child MSBuild.exe process. Verify that the MSBuild.exe "{0}" launches successfully, and that it is loading the same microsoft.build.dll that the launching process loaded. If the location seems incorrect, try specifying the correct location in the BuildParameters object, or with the MSBUILD_EXE_PATH environment variable.</target>
+        <note>{StrBegin="MSB4218: "}</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItem">
+        <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
+        <target state="new">MSB4117: The "{0}" item name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedItemMetadata">
+        <source>MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</source>
+        <target state="new">MSB4118: The "{0}" item metadata name is reserved, and cannot be used.</target>
+        <note>{StrBegin="MSB4118: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild item metadata names e.g. %(FullPath). Only MSBuild can set those.</note>
+      </trans-unit>
+      <trans-unit id="CannotModifyReservedProperty">
+        <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
+        <target state="new">MSB4004: The "{0}" property is reserved, and cannot be modified.</target>
+        <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
+        <source>MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</source>
+        <target state="new">MSB4094: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. Multiple items cannot be passed into a parameter of type "{2}".</target>
+        <note>{StrBegin="MSB4094: "}
+            UE: This error is shown when a project tries to pass multiple items into a task parameter of type ITaskItem (singular).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotPassMultipleItemsIntoScalarFunction">
+        <source>MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</source>
+        <target state="new">MSB4115: The "{0}" function only accepts a scalar value, but its argument "{1}" evaluates to "{2}" which is not a scalar value.</target>
+        <note>{StrBegin="MSB4115: "}
+        UE: This error is shown when a project tries to pass multiple items into a function in a conditional expression, that can only accept a scalar value (such as the "exists()" function).
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
+        <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
+        <target state="new">MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</target>
+        <note>{StrBegin="MSB4095: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildElementsBelowRemoveNotAllowed">
+        <source>MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</source>
+        <target state="new">MSB4162: &lt;{0}&gt; is not valid. Child elements are not allowed below a item remove element.</target>
+        <note>{StrBegin="MSB4162: "}</note>
+      </trans-unit>
+      <trans-unit id="ChildExitedPrematurely">
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <note>{StrBegin="MSB4166: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseMustContainWhen">
+        <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>
+        <target state="new">MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</target>
+        <note>{StrBegin="MSB4085: "}</note>
+      </trans-unit>
+      <trans-unit id="ChooseOverflow">
+        <source>MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</source>
+        <target state="new">MSB4114: &lt;Choose&gt; elements cannot be nested more than {0} levels deep.</target>
+        <note>{StrBegin="MSB4114: "}UE: This message appears if the project file contains unreasonably nested Choose elements.
+    LOCALIZATION: Do not localize "Choose" as it is an XML element name.</note>
+      </trans-unit>
+      <trans-unit id="CircularDependency">
+        <source>MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</source>
+        <target state="new">MSB4006: There is a circular dependency in the target dependency graph involving target "{0}".</target>
+        <note>{StrBegin="MSB4006: "}UE: This message is shown when the build engine detects a target referenced in a circular manner -- a project cannot
+    request a target to build itself (perhaps via a chain of other targets).</note>
+      </trans-unit>
+      <trans-unit id="ComparisonOnNonNumericExpression">
+        <source>MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</source>
+        <target state="new">MSB4086: A numeric comparison was attempted on "{1}" that evaluates to "{2}" instead of a number, in condition "{0}".</target>
+        <note>{StrBegin="MSB4086: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionMaybeEvaluatedIncorrectly">
+        <source>MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</source>
+        <target state="new">MSB4130: The condition "{0}" may have been evaluated incorrectly in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To avoid this warning, add parentheses to make the evaluation order explicit.</target>
+        <note>{StrBegin="MSB4130: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBoolean">
+        <source>MSB4087: Specified condition "{0}" does not evaluate to a boolean.</source>
+        <target state="new">MSB4087: Specified condition "{0}" does not evaluate to a boolean.</target>
+        <note>{StrBegin="MSB4087: "}</note>
+      </trans-unit>
+      <trans-unit id="ConditionNotBooleanDetail">
+        <source>MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</source>
+        <target state="new">MSB4113: Specified condition "{0}" evaluates to "{1}" instead of a boolean.</target>
+        <note>{StrBegin="MSB4113: "}</note>
+      </trans-unit>
+      <trans-unit id="ConfigFileReadError">
+        <source>MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</source>
+        <target state="new">MSB4136: Error reading the toolset information from the configuration file "{0}". {1}</target>
+        <note>{StrBegin="MSB4136: "}</note>
+      </trans-unit>
+      <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
+        <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
+        <target state="new">MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</target>
+        <note>{StrBegin="MSB4142: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomNamespaceNotAllowedOnThisChildElement">
+        <source>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</source>
+        <target state="new">MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</target>
+        <note>{StrBegin="MSB4097: "}</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileFailure">
+        <source>MSB4009: The default tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4009: The default tasks file could not be successfully loaded. {0}</target>
+        <note>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
+    be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+    separately to loggers.
+    LOCALIZATION: "{0}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="DefaultTasksFileLoadFailureWarning">
+        <source>MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</source>
+        <target state="new">MSB4010: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be available. {2}</target>
+        <note>{StrBegin="MSB4010: "}UE: This message is shown when the default tasks files that are located alongside the MSBuild binaries cannot be
+    found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+    LOCALIZATION: "{2}" is a message from some FX method and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportIntroducesCircularity">
+        <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
+        <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
+        <note>
+       {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+    </note>
+      </trans-unit>
+      <trans-unit id="SearchPathsForMSBuildExtensionsPath">
+        <source>Search paths being used for {0} are {1}</source>
+        <target state="new">Search paths being used for {0} are {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TryingExtensionsPath">
+        <source>Trying to import {0} using extensions path {1}</source>
+        <target state="new">Trying to import {0} using extensions path {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileFailure">
+        <source>MSB4194: The override tasks file could not be successfully loaded. {0}</source>
+        <target state="new">MSB4194: The override tasks file could not be successfully loaded. {0}</target>
+        <note>
+      {StrBegin="MSB4194: "}UE: This message is shown when one of the override tasks file (*.overridetasks) located alongside the MSBuild binaries cannot
+      be opened/parsed. "{0}" contains a message explaining why. The filename itself is not part of the message but is provided
+      separately to loggers.
+      LOCALIZATION: "{0}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskNotRootedPath">
+        <source>The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</source>
+        <target state="new">The override tasks path "{0}" must not be a relative path and must exist on disk. Default tasks will not be overridden.</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTaskProblemWithPath">
+        <source>A problem occurred loading the override tasks path "{0}". {1}</source>
+        <target state="new">A problem occurred loading the override tasks path "{0}". {1}</target>
+        <note>
+        UE: This message is shown when the override tasks path in the registry or passed to the toolset is not a full path.
+    </note>
+      </trans-unit>
+      <trans-unit id="OverrideTasksFileLoadFailureWarning">
+        <source>MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</source>
+        <target state="new">MSB4196: The "{0}" files could not be successfully loaded from their expected location "{1}". Default tasks will not be overridden. {2}</target>
+        <note>
+      {StrBegin="MSB4196: "}UE: This message is shown when the override tasks files that are located alongside the MSBuild binaries cannot be
+      found, either because they don't exist, or because of lack of permissions. "{2}" contains a message explaining why.
+      LOCALIZATION: "{2}" is a message from some FX method and is already localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TasksPropertyBagError">
+        <source>MSB4195: There was an error gathering properties for tasks file evaluation. {0}</source>
+        <target state="new">MSB4195: There was an error gathering properties for tasks file evaluation. {0}</target>
+        <note>
+      {StrBegin="MSB4195: "}UE: This message is shown when the gathering of properties for the evaluation of override and defaults tasks has an exception. "{0"} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="DefaultToolsVersionNotFound">
+        <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
+        <target state="new">MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</target>
+        <note>{StrBegin="MSB4133: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateImport">
+        <source>MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</source>
+        <target state="new">MSB4011: "{0}" cannot be imported again. It was already imported at "{1}". This is most likely a build authoring error. This subsequent import will be ignored. {2}</target>
+        <note>{StrBegin="MSB4011: "}</note>
+      </trans-unit>
+      <trans-unit id="UsedUninitializedProperty">
+        <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
+        <target state="new">MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</target>
+        <note>{StrBegin="MSB4211: "}</note>
+      </trans-unit>
+      <trans-unit id="SelfImport">
+        <source>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</source>
+        <target state="new">MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</target>
+        <note>{StrBegin="MSB4210: "}</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectExtensions">
+        <source>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</source>
+        <target state="new">MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</target>
+        <note>{StrBegin="MSB4079: "}</note>
+      </trans-unit>
+      <trans-unit id="EmbeddedItemVectorCannotBeItemized">
+        <source>MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</source>
+        <target state="new">MSB4012: The expression "{0}" cannot be used in this context. Item lists cannot be concatenated with other strings where an item list is expected. Use a semicolon to separate multiple item lists.</target>
+        <note>{StrBegin="MSB4012: "}UE: This message is shown when the user does not properly specify an item list when an item list is expected
+    e.g. "badprefix@(foo)badsuffix" instead of "prefix; @(foo); suffix"</note>
+      </trans-unit>
+      <trans-unit id="EndOfInputTokenName">
+        <source>end of input</source>
+        <target state="new">end of input</target>
+        <note>This is the name of the "EndOfInput" token. It is displayed in quotes as the
+    unexpected char or token when the end of a conditional was unexpectedly reached.</note>
+      </trans-unit>
+      <trans-unit id="ErrorConvertedIntoWarning">
+        <source>The previous error was converted to a warning because the task was called with ContinueOnError=true.</source>
+        <target state="new">The previous error was converted to a warning because the task was called with ContinueOnError=true.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCount">
+        <source>{0} Error(s)</source>
+        <target state="new">{0} Error(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorCreatingToolset">
+        <source>MSB4159: Error creating the toolset "{0}". {1}</source>
+        <target state="new">MSB4159: Error creating the toolset "{0}". {1}</target>
+        <note>{StrBegin="MSB4159: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
+        <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
+        <target state="new">MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</target>
+        <note>{StrBegin="MSB4146: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningMessageNotSupported">
+        <source>The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</source>
+        <target state="new">The &lt;{0}&gt; tag is no longer supported as a child of the &lt;Project&gt; element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the &lt;Project&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExecutingTaskInTaskHost">
+        <source>Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</source>
+        <target state="new">Launching task "{0}" from assembly "{1}" in an external task host with a runtime of "{2}" and a process architecture of "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ExpressionDoesNotEvaluateToBoolean">
+        <source>MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</source>
+        <target state="new">MSB4100: Expected "{0}" to evaluate to a boolean instead of "{1}", in condition "{2}".</target>
+        <note>{StrBegin="MSB4100: "}</note>
+      </trans-unit>
+      <trans-unit id="FailedToRetrieveTaskOutputs">
+        <source>MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</source>
+        <target state="new">MSB4028: The "{0}" task's outputs could not be retrieved from the "{1}" parameter. {2}</target>
+        <note>{StrBegin="MSB4028: "}</note>
+      </trans-unit>
+      <trans-unit id="FatalBuildError">
+        <source>MSB4014: The build stopped unexpectedly because of an internal failure.</source>
+        <target state="new">MSB4014: The build stopped unexpectedly because of an internal failure.</target>
+        <note>{StrBegin="MSB4014: "}UE: This message is shown when an unhandled exception terminates the build. The cause is most likely a programming
+    error in the build engine.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorDuringLoggerShutdown">
+        <source>MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</source>
+        <target state="new">MSB4015: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during shutdown.</target>
+        <note>{StrBegin="MSB4015: "}UE: This message is used for a special exception that is thrown when a logger fails while shutting down (most likely
+    because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a special
+    exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileInitializingLogger">
+        <source>MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</source>
+        <target state="new">MSB4016: The build stopped unexpectedly because the "{0}" logger failed unexpectedly during initialization.</target>
+        <note>{StrBegin="MSB4016: "}UE: This message is used for a special exception that is thrown when a logger fails while initializing itself (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalErrorWhileLogging">
+        <source>MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</source>
+        <target state="new">MSB4017: The build stopped unexpectedly because of an unexpected logger failure.</target>
+        <note>{StrBegin="MSB4017: "}UE: This message is used for a special exception that is thrown when a logger fails while logging an event (most
+    likely because of a programming error in the logger). When a logger dies, we cannot proceed with the build, and we throw a
+    special exception to abort the build.</note>
+      </trans-unit>
+      <trans-unit id="FatalTaskError">
+        <source>MSB4018: The "{0}" task failed unexpectedly.</source>
+        <target state="new">MSB4018: The "{0}" task failed unexpectedly.</target>
+        <note>{StrBegin="MSB4018: "}UE: This message is shown when a task terminates because of an unhandled exception. The cause is most likely a
+    programming error in the task; however, it is also possible that the unhandled exception originated in the engine, and was
+    surfaced through the task when the task called into the engine.</note>
+      </trans-unit>
+      <trans-unit id="FailedToReceiveTaskThreadStatus">
+        <source>MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</source>
+        <target state="new">MSB4187: Failed to receive a response from the task thread in the timeout period "{0}" ms. Shutting down.</target>
+        <note>{StrBegin="MSB4187: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedCondition">
+        <source>MSB4088: Condition "{0}" is improperly constructed.</source>
+        <target state="new">MSB4088: Condition "{0}" is improperly constructed.</target>
+        <note>{StrBegin="MSB4088: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedEqualsInCondition">
+        <source>MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</source>
+        <target state="new">MSB4105: Found an unexpected character '{2}' at position {1} in condition "{0}". Did you intend to use "=="?</target>
+        <note>{StrBegin="MSB4105: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListCloseParenthesisInCondition">
+        <source>MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4106: Expected an item list at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4106: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
+        <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
+        <target state="new">MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</target>
+        <note>{StrBegin="MSB4107: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedItemListQuoteInCondition">
+        <source>MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</source>
+        <target state="new">MSB4108: Expected an item list at position {1} in condition "{0}". Did you forget to close a quote inside the item list expression?</target>
+        <note>{StrBegin="MSB4108: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyCloseParenthesisInCondition">
+        <source>MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</source>
+        <target state="new">MSB4109: Expected a property at position {1} in condition "{0}". Did you forget the closing parenthesis?</target>
+        <note>{StrBegin="MSB4109: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
+        <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
+        <target state="new">MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</target>
+        <note>{StrBegin="MSB4110: "}</note>
+      </trans-unit>
+      <trans-unit id="IllFormedQuotedStringInCondition">
+        <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
+        <target state="new">MSB4101: Expected a closing quote after position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4101: "}</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectNotFound">
+        <source>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</source>
+        <target state="new">MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</target>
+        <note>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
+        <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
+        <target state="new">MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</target>
+        <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="IncorrectNumberOfFunctionArguments">
+        <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
+        <target state="new">MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</target>
+        <note>{StrBegin="MSB4089: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValue">
+        <source>MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</source>
+        <target state="new">MSB4020: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid.</target>
+        <note>{StrBegin="MSB4020: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+    attributes e.g. &lt;Import Project=""&gt; -- the value of Project should not be an empty string.</note>
+      </trans-unit>
+      <trans-unit id="InvalidAttributeValueWithException">
+        <source>MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</source>
+        <target state="new">MSB4102: The value "{0}" of the "{1}" attribute in element &lt;{2}&gt; is invalid. {3}</target>
+        <note>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
+        attributes. At the end of the message we show the exception text we got trying to use the value.</note>
+      </trans-unit>
+      <trans-unit id="InvalidContinueOnErrorAttribute">
+        <source>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</source>
+        <target state="new">MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</target>
+        <note>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="InvalidEvaluatedAttributeValue">
+        <source>MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</source>
+        <target state="new">MSB4022: The result "{0}" of evaluating the value "{1}" of the "{2}" attribute in element &lt;{3}&gt; is not valid.</target>
+        <note>{StrBegin="MSB4022: "}UE: This message is shown when the engine is checking the correctness of the value (after evaluating embedded
+    properties/items) assigned to an XML attribute of an XML element in the project file.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileLoggerFile">
+        <source>MSB4104: Failed to write to log file "{0}". {1}</source>
+        <target state="new">MSB4104: Failed to write to log file "{0}". {1}</target>
+        <note>{StrBegin="MSB4104: "}UE: This is shown when the File Logger can't create or write to the file it was instructed to log to.</note>
+      </trans-unit>
+      <trans-unit id="InvalidImportedProjectFile">
+        <source>MSB4024: The imported project file "{0}" could not be loaded. {1}</source>
+        <target state="new">MSB4024: The imported project file "{0}" could not be loaded. {1}</target>
+        <note>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
+    filename is not part of the message because it is provided separately to loggers.
+    LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyNameInToolset">
+        <source>MSB4147: The property "{0}" at "{1}" is invalid. {2}</source>
+        <target state="new">MSB4147: The property "{0}" at "{1}" is invalid. {2}</target>
+        <note>{StrBegin="MSB4147: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidProperty">
+        <source>MSB4177: Invalid property. {0}</source>
+        <target state="new">MSB4177: Invalid property. {0}</target>
+        <note>{StrBegin="MSB4177: "}
+      UE: {0} is a localized message indicating what the problem was.</note>
+      </trans-unit>
+      <trans-unit id="InvalidRegistryPropertyExpression">
+        <source>MSB4143: The registry expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4143: The registry expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4143: "}
+      UE: This message is shown when the user attempts to provide an expression like "$(Registry:HKEY_LOCAL_MACHINE\Software\Vendor\Tools@TaskLocation)"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpression">
+        <source>MSB4184: The expression "{0}" cannot be evaluated. {1}</source>
+        <target state="new">MSB4184: The expression "{0}" cannot be evaluated. {1}</target>
+        <note>{StrBegin="MSB4184: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "$(SomeProperty.ToLower())" or "@(Foo-&gt;Bar())"
+      LOCALIZATION: "{0}" is the expression that was bad. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedQuote">
+        <source>The quotes were mismatched.</source>
+        <target state="new">The quotes were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedParenthesis">
+        <source>The parentheses were mismatched.</source>
+        <target state="new">The parentheses were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionPropertyExpressionDetailMismatchedSquareBrackets">
+        <source>The square brackets were mismatched.</source>
+        <target state="new">The square brackets were mismatched.</target>
+        <note>This is a potential suffix to "InvalidFunctionPropertyExpression" so it has no error code.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionMethodUnavailable">
+        <source>MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</source>
+        <target state="new">MSB4185: The function "{0}" on type "{1}" is not available for execution as an MSBuild property function.</target>
+        <note>
+      {StrBegin="MSB4185: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the static function name, "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionTypeUnavailable">
+        <source>MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</source>
+        <target state="new">MSB4212: Invalid static method invocation syntax: "{0}". The type "{1}" is either not available for execution in an MSBuild property function or could not be found.</target>
+        <note>
+      {StrBegin="MSB4212: "}
+      UE: This message is shown when the user attempts to provide an expression like "$([System.DateTime]::Now)", but the expression has not been enabled
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is the .NET Framework type name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidFunctionStaticMethodSyntax">
+        <source>MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </source>
+        <target state="new">MSB4186: Invalid static method invocation syntax: "{0}". {1} Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). </target>
+        <note>{StrBegin="MSB4186: "}
+      UE: This message is shown when the user attempts to call a static method on a type, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function expression which is in error. "{1}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionExpression">
+        <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
+        <target state="new">MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</target>
+        <note>
+      {StrBegin="MSB4198: "}
+      Double quotes as the expression will typically have single quotes in it.
+      UE: This message is shown when the user attempts to provide an expression like "@(SomeItem-&gt;DirectoryName())"
+      LOCALIZATION: "{0}" is the expression that was bad, "{1}" is the item or file that was being worked on. "{2}" is a message from an FX exception that describes why the expression is bad.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidItemFunctionSyntax">
+        <source>MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</source>
+        <target state="new">MSB4199: Invalid transformation syntax "{0}". An item function was not found with that name and {1} parameters.</target>
+        <note>
+      {StrBegin="MSB4199: "}
+      UE: This message is shown when the user attempts to call a transformation on an item, but has used the incorrect syntax
+      LOCALIZATION: "{0}" is the function which is in error
+    </note>
+      </trans-unit>
+      <trans-unit id="UnknownItemFunction">
+        <source>MSB4200: Unknown item transformation function "{0}".</source>
+        <target state="new">MSB4200: Unknown item transformation function "{0}".</target>
+        <note>
+      {StrBegin="MSB4200: "}
+      UE: This message is shown when the user attempts to provide an expression like @(Item-&gt;SomeTransform()), but SomeTransform is unknown
+      LOCALIZATION: "{0}" is the function name
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskAttributeError">
+        <source>MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</source>
+        <target state="new">MSB4026: The "{0}={1}" parameter for the "{2}" task is invalid.</target>
+        <note>{StrBegin="MSB4026: "}UE: This message is displayed when a task has an invalid parameter that cannot be initialized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskItemsInTaskOutputs">
+        <source>MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</source>
+        <target state="new">MSB4027: The "{0}" task generated invalid items from the "{1}" output parameter. {2}</target>
+        <note>{StrBegin="MSB4027: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskOutputSpecification">
+        <source>MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</source>
+        <target state="new">MSB4029: The "{0}" task has an invalid output specification. The "TaskParameter" attribute is required, and either the "ItemName" or "PropertyName" attribute must be specified (but not both).</target>
+        <note>{StrBegin="MSB4029: "}LOCALIZATION: "TaskParameter", "ItemName" and "PropertyName" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskParameterValueError">
+        <source>MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</source>
+        <target state="new">MSB4030: "{0}" is an invalid value for the "{1}" parameter of the "{3}" task. The "{1}" parameter is of type "{2}".</target>
+        <note>{StrBegin="MSB4030: "}UE: This error is shown when a type mis-match occurs between the value assigned to task parameter in the project file
+    and the type of the .NET property that corresponds to the task parameter. For example, if an int task parameter called "Count"
+    is assigned the value "x", this error would be displayed: &lt;MyTask Count="x" /&gt;</note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsetValueInConfigFileValue">
+        <source>MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</source>
+        <target state="new">MSB4137: Invalid value specified in the configuration file at "{0}". Property name or tools version name is an empty string.</target>
+        <note>{StrBegin="MSB4137: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDefinitionGroupNotLegalInsideTarget">
+        <source>MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</source>
+        <target state="new">MSB4163: &lt;ItemDefinitionGroup&gt; is not allowed inside a target.</target>
+        <note>{StrBegin="MSB4163: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
+        <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
+        <target state="new">MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</target>
+        <note>{StrBegin="MSB4096: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemListNotAllowedInThisConditional">
+        <source>MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4099: A reference to an item list at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4099: "}</note>
+      </trans-unit>
+      <trans-unit id="CustomMetadataNotAllowedInThisConditional">
+        <source>MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4191: The reference to custom metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4191: "}</note>
+      </trans-unit>
+      <trans-unit id="BuiltInMetadataNotAllowedInThisConditional">
+        <source>MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</source>
+        <target state="new">MSB4190: The reference to the built-in metadata "{2}" at position {1} is not allowed in this condition "{0}".</target>
+        <note>{StrBegin="MSB4190: "}</note>
+      </trans-unit>
+      <trans-unit id="ItemSpecModifierCannotBeCustomMetadata">
+        <source>MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</source>
+        <target state="new">MSB4033: "{0}" is a reserved item metadata, and cannot be redefined as a custom metadata on the item.</target>
+        <note>{StrBegin="MSB4033: "}</note>
+      </trans-unit>
+      <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
+        <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
+        <target state="new">An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</target>
+        <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
+    only the engine is allowed to create and throw this exception.
+    LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ItemListHeader">
+        <source>Initial Items:</source>
+        <target state="new">Initial Items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="EnvironmentHeader">
+        <source>Environment at start of build:</source>
+        <target state="new">Environment at start of build:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MetadataDefinitionCannotContainItemVectorExpression">
+        <source>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</source>
+        <target state="new">MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</target>
+        <note>{StrBegin="MSB4164: "}</note>
+      </trans-unit>
+      <trans-unit id="MissingRequiredAttribute">
+        <source>MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</source>
+        <target state="new">MSB4035: The required attribute "{0}" is empty or missing from the element &lt;{1}&gt;.</target>
+        <note>{StrBegin="MSB4035: "}UE: This message is shown when a user leaves off a required attribute from a project element
+    e.g. &lt;UsingTask AssemblyName="foo"&gt; -- this is missing the "TaskName" attribute.</note>
+      </trans-unit>
+      <trans-unit id="MissingTaskError">
+        <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
+        <target state="new">MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</target>
+        <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathIsNotSpecified">
+        <source>MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</source>
+        <target state="new">MSB4141: MSBuildToolsPath is not specified for the ToolsVersion "{0}" defined at "{1}", or the value specified evaluates to the empty string.</target>
+        <note>{StrBegin="MSB4141: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuildToolsPathNotSupportedInSubToolsets">
+        <source>MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</source>
+        <target state="new">MSB4222: ToolsVersion "{0}", defined at "{1}", contains sub-toolset "{2}" which sets MSBuildBinPath or MSBuildToolsPath. This is not supported in sub-toolsets.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameToolset">
+        <source>MSB4144: Multiple definitions were found for the toolset "{0}". </source>
+        <target state="new">MSB4144: Multiple definitions were found for the toolset "{0}". </target>
+        <note>{StrBegin="MSB4144: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameExtensionsPathOS">
+        <source>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</source>
+        <target state="new">MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</target>
+        <note>{StrBegin="MSB4225: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleDefinitionsForSameProperty">
+        <source>MSB4145: Multiple definitions were found for the property "{0}".</source>
+        <target state="new">MSB4145: Multiple definitions were found for the property "{0}".</target>
+        <note>{StrBegin="MSB4145: "}</note>
+      </trans-unit>
+      <trans-unit id="MultipleOtherwise">
+        <source>MSB4082: Choose has more than one &lt;Otherwise&gt; element.</source>
+        <target state="new">MSB4082: Choose has more than one &lt;Otherwise&gt; element.</target>
+        <note>{StrBegin="MSB4082: "}</note>
+      </trans-unit>
+      <trans-unit id="NodeMustBeLastUnderElement">
+        <source>MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</source>
+        <target state="new">MSB4038: The element &lt;{0}&gt; must be last under element &lt;{1}&gt;. Found element &lt;{2}&gt; instead.</target>
+        <note>{StrBegin="MSB4038: "}</note>
+      </trans-unit>
+      <trans-unit id="NonStringDataInRegistry">
+        <source>MSB4138: Non-string data was specified at the registry location "{0}".</source>
+        <target state="new">MSB4138: Non-string data was specified at the registry location "{0}".</target>
+        <note>{StrBegin="MSB4138: "}</note>
+      </trans-unit>
+      <trans-unit id="NoRootProjectElement">
+        <source>MSB4039: No "{0}" element was found in the project file.</source>
+        <target state="new">MSB4039: No "{0}" element was found in the project file.</target>
+        <note>{StrBegin="MSB4039: "}</note>
+      </trans-unit>
+      <trans-unit id="NoTargetSpecified">
+        <source>MSB4040: There is no target in the project.</source>
+        <target state="new">MSB4040: There is no target in the project.</target>
+        <note>{StrBegin="MSB4040: "}</note>
+      </trans-unit>
+      <trans-unit id="NullLoggerNotAllowed">
+        <source>A null entry was found in the collection of loggers.</source>
+        <target state="new">A null entry was found in the collection of loggers.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxNodeCount">
+        <source>MaxNodeCount may only be assigned a value greater than zero.</source>
+        <target state="new">MaxNodeCount may only be assigned a value greater than zero.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OverridingTarget">
+        <source>Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</source>
+        <target state="new">Overriding target "{0}" in project "{1}" with target "{2}" from project "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceLine">
+        <source>{0} ms  {1} {2} calls</source>
+        <target state="new">{0} ms  {1} {2} calls</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PerformanceReentrancyNote">
+        <source>(* = timing was not recorded because of reentrancy)</source>
+        <target state="new">(* = timing was not recorded because of reentrancy)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFileNotFound">
+        <source>The project file "{0}" was not found.</source>
+        <target state="new">The project file "{0}" was not found.</target>
+        <note>UE: This message is shown when the user calls into the OM to build a project that doesn't exist on disk.</note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedFailure">
+        <source>Done building project "{0}" -- FAILED.</source>
+        <target state="new">Done building project "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedSuccess">
+        <source>Done building project "{0}".</source>
+        <target state="new">Done building project "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProc">
+        <source>Done Building Project "{0}" ({1} target(s)).</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProc">
+        <source>Done Building Project "{0}" (default targets).</source>
+        <target state="new">Done Building Project "{0}" (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithTargetNamesMultiProcFailed">
+        <source>Done Building Project "{0}" ({1} target(s)) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" ({1} target(s)) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectFinishedPrefixWithDefaultTargetsMultiProcFailed">
+        <source>Done Building Project "{0}" (default targets) -- FAILED.</source>
+        <target state="new">Done Building Project "{0}" (default targets) -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
+        <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
+        <target state="new">MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</target>
+        <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
+      LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProjectPerformanceSummary">
+        <source>Project Performance Summary:</source>
+        <target state="new">Project Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithTargetNames">
+        <source>Project "{0}" is building "{1}" ({2} target(s)):</source>
+        <target state="new">Project "{0}" is building "{1}" ({2} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForNestedProjectWithDefaultTargets">
+        <source>Project "{0}" is building "{1}" (default targets):</source>
+        <target state="new">Project "{0}" is building "{1}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithTargetNames">
+        <source>Project "{0}" ({1} target(s)):</source>
+        <target state="new">Project "{0}" ({1} target(s)):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedPrefixForTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" (default targets):</source>
+        <target state="new">Project "{0}" (default targets):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectTaskNameEmpty">
+        <source>Task name cannot be empty.</source>
+        <target state="new">Task name cannot be empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeeded">
+        <source>MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4075: The project file "{0}" must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4075: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB4192: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB4192: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="PropertyListHeader">
+        <source>Initial Properties:</source>
+        <target state="new">Initial Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyNameInRegistryHasZeroLength">
+        <source>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</source>
+        <target state="new">MSB4148: The name of a property stored under the registry key "{0}" has zero length.</target>
+        <note>{StrBegin="MSB4148: "}</note>
+      </trans-unit>
+      <trans-unit id="QualifiedMetadataInTransformNotAllowed">
+        <source>MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</source>
+        <target state="new">MSB4043: The item metadata reference "{0}" is invalid because it is qualified with an item name. Item metadata referenced in transforms do not need to be qualified, because the item name is automatically deduced from the items being transformed. Change "{0}" to "%({1})".</target>
+        <note>{StrBegin="MSB4043: "}UE: This message is shown when the user does something like this: @(foo-&gt;'%(foo.metadata)'). There is no need to specify
+    "foo.metadata", because "foo" is automatically deduced. In corollary, "bar.metadata" is not allowed either, where "bar" is a different
+    item list type.</note>
+      </trans-unit>
+      <trans-unit id="RegistryReadError">
+        <source>MSB4135: Error reading the toolset information from the registry location "{0}". {1}</source>
+        <target state="new">MSB4135: Error reading the toolset information from the registry location "{0}". {1}</target>
+        <note>{StrBegin="MSB4135: "}</note>
+      </trans-unit>
+      <trans-unit id="RequiredPropertyNotSetError">
+        <source>MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</source>
+        <target state="new">MSB4044: The "{0}" task was not given a value for the required parameter "{1}".</target>
+        <note>{StrBegin="MSB4044: "}UE: This message is shown when a task parameter designated as "required" is not set in the project file.</note>
+      </trans-unit>
+      <trans-unit id="SecurityProjectBuildDisabled">
+        <source>MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</source>
+        <target state="new">MSB4112: The targets in this project have been disabled by the host and therefore cannot be built at this time. This may have been done for security reasons. To enable the targets, the host must set Project.BuildEnabled to "true".</target>
+        <note>{StrBegin="MSB4112: "}</note>
+      </trans-unit>
+      <trans-unit id="SetAccessorNotAvailableOnTaskParameter">
+        <source>MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</source>
+        <target state="new">MSB4093: The "{0}" parameter of the "{1}" task cannot be written to because it does not have a "set" accessor.</target>
+        <note>{StrBegin="MSB4093: "}UE: This error is shown when a project tries to assign a value to a task parameter that does not have a "set"
+    accessor on the corresponding .NET property on the task class.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputs">
+        <source>Skipping target "{0}" because it has no inputs.</source>
+        <target state="new">Skipping target "{0}" because it has no inputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoInputsDetail">
+        <source>Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its inputs, the input specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputs">
+        <source>Skipping target "{0}" because it has no outputs.</source>
+        <target state="new">Skipping target "{0}" because it has no outputs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseNoOutputsDetail">
+        <source>Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</source>
+        <target state="new">Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetBecauseOutputsUpToDate">
+        <source>Skipping target "{0}" because all output files are up-to-date with respect to the input files.</source>
+        <target state="new">Skipping target "{0}" because all output files are up-to-date with respect to the input files.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateInputs">
+        <source>Input files: {0}</source>
+        <target state="new">Input files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="SkipTargetUpToDateOutputs">
+        <source>Output files: {0}</source>
+        <target state="new">Output files: {0}</target>
+        <note>{0} is a semicolon-separated list of filenames.</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.TargetingHigherFrameworksDefaultsTo40">
+        <source>{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</source>
+        <target state="new">{0}: Defaulting .NET Framework v{1} to the .NET Framework v4.0 version of aspnet_compiler.exe. To change the version of the tool used, please set the "ToolPath" parameter with the correct path to the tool.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerNotDotNET">
+        <source>MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</source>
+        <target state="new">MSB4203: {0}: Invalid TargetFrameworkMoniker {1}. The AspNetCompiler task only supports targeting the .NET Framework.</target>
+        <note>{StrBegin="MSB4203: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.20NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
+        <source>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</source>
+        <target state="new">MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</target>
+        <note>{StrBegin="MSB4204: "}</note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedExplicitToolsVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator because the tools version was set to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OldWrapperGeneratedOldSolutionVersion">
+        <source>Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</source>
+        <target state="new">Using the MSBuild v3.5 solution wrapper generator with a tools version of {0} because the solution file format was version {1} and no tools version was supplied.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SolutionBuildingSolutionConfiguration">
+        <source>Building solution configuration "{0}".</source>
+        <target state="new">Building solution configuration "{0}".</target>
+        <note>UE: This is not an error, so doesn't need an error code.</note>
+      </trans-unit>
+      <trans-unit id="SolutionCircularDependencyError">
+        <source>MSB4160: A circular dependency involving project "{0}" has been detected.</source>
+        <target state="new">MSB4160: A circular dependency involving project "{0}" has been detected.</target>
+        <note>{StrBegin="MSB4160: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionInvalidSolutionConfiguration">
+        <source>MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</source>
+        <target state="new">MSB4126: The specified solution configuration "{0}" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration.</target>
+        <note>{StrBegin="MSB4126: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseErrorReadingProject">
+        <source>MSB4046: Error reading project file "{0}": {1}</source>
+        <target state="new">MSB4046: Error reading project file "{0}": {1}</target>
+        <note>{StrBegin="MSB4046: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseInvalidProjectFileName">
+        <source>MSB4125: The project file name "{0}" is invalid. {1}</source>
+        <target state="new">MSB4125: The project file name "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB4125: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseProjectDepNotFoundError">
+        <source>MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</source>
+        <target state="new">MSB4051: Project {0} is referencing a project with GUID {1}, but a project with this GUID was not found in the .SLN file.</target>
+        <note>{StrBegin="MSB4051: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUnknownProjectType">
+        <source>MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</source>
+        <target state="new">MSB4078: The project file "{0}" is not supported by MSBuild and cannot be built.</target>
+        <note>{StrBegin="MSB4078: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionParseUpgradeNeeded">
+        <source>MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</source>
+        <target state="new">MSB4054: The solution file must be opened in the Visual Studio IDE and converted to the latest version before it can be built by MSBuild.</target>
+        <note>{StrBegin="MSB4054: "}UE: The solution filename is provided separately to loggers.</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectConfigurationMissing">
+        <source>MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</source>
+        <target state="new">MSB4121: The project configuration for project "{0}" was not specified in the solution file for the solution configuration "{1}".</target>
+        <note>{StrBegin="MSB4121: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionProjectSkippedForBuilding">
+        <source>The project "{0}" is not selected for building in solution configuration "{1}".</source>
+        <target state="new">The project "{0}" is not selected for building in solution configuration "{1}".</target>
+        <note>
+      UE: This is not an error, so doesn't need an error code.
+    </note>
+      </trans-unit>
+      <trans-unit id="SolutionScanProjectDependenciesFailed">
+        <source>MSB4122: Scanning project dependencies for project "{0}" failed. {1}</source>
+        <target state="new">MSB4122: Scanning project dependencies for project "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB4122: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionToolsVersionDoesNotSupportProjectToolsVersion">
+        <source>MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</source>
+        <target state="new">MSB4149: The tools version "{0}" of the solution does not support building projects with a different tools version.</target>
+        <note>{StrBegin="MSB4149: "}</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoClean">
+        <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Clean" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Clean".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectNoPublish">
+        <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
+        <target state="new">Web projects do not support the "Publish" target.  Continuing with remaining projects ...</target>
+        <note>UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do not localize "Publish".</note>
+      </trans-unit>
+      <trans-unit id="SolutionVenusProjectSkipped">
+        <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
+        <target state="new">Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</target>
+        <note>
+    UE: This is not an error, so doesn't need an error code.
+    LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
+    </note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteFailure">
+        <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built unsuccessfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetAlreadyCompleteSuccess">
+        <source>Target "{0}" skipped. Previously built successfully.</source>
+        <target state="new">Target "{0}" skipped. Previously built successfully.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetConditionHasInvalidMetadataReference">
+        <source>MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</source>
+        <target state="new">MSB4116: The condition "{1}" on the "{0}" target has a reference to item metadata. References to item metadata are not allowed in target conditions unless they are part of an item transform.</target>
+        <note>{StrBegin="MSB4116: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExist">
+        <source>MSB4057: The target "{0}" does not exist in the project.</source>
+        <target state="new">MSB4057: The target "{0}" does not exist in the project.</target>
+        <note>{StrBegin="MSB4057: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistBeforeTargetMessage">
+        <source>The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in a BeforeTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetDoesNotExistAfterTargetMessage">
+        <source>The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</source>
+        <target state="new">The target "{0}" listed in an AfterTargets attribute at "{1}" does not exist in the project, and will be ignored.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedFailure">
+        <source>Done building target "{0}" in project "{1}" -- FAILED.</source>
+        <target state="new">Done building target "{0}" in project "{1}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetFinishedSuccess">
+        <source>Done building target "{0}" in project "{1}".</source>
+        <target state="new">Done building target "{0}" in project "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetMessageWithId">
+        <source>{0}: (TargetId:{1})</source>
+        <target state="new">{0}: (TargetId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItemsHeader">
+        <source>Target output items:</source>
+        <target state="new">Target output items:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetOutputItem">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetInputsSpecifiedWithoutOutputs">
+        <source>MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</source>
+        <target state="new">MSB4058: The "{0}" target is missing its output specification. If a target declares inputs, it must also declare outputs.</target>
+        <note>{StrBegin="MSB4058: "}</note>
+      </trans-unit>
+      <trans-unit id="TargetPerformanceSummary">
+        <source>Target Performance Summary:</source>
+        <target state="new">Target Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetSkippedFalseCondition">
+        <source>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectEntry">
+        <source>Target "{0}" in file "{1}" from project "{2}" (entry point):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectDepends">
+        <source>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectBefore">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run before target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFileProjectAfter">
+        <source>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStarted">
+        <source>Target "{0}" in project "{1}":</source>
+        <target state="new">Target "{0}" in project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectEntry">
+        <source>Target "{0}" in project "{1}" (entry point):</source>
+        <target state="new">Target "{0}" in project "{1}" (entry point):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectDepends">
+        <source>Target "{0}" in project "{1}" (target "{2}" depends on it):</source>
+        <target state="new">Target "{0}" in project "{1}" (target "{2}" depends on it):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectBefore">
+        <source>Target "{0}" in project "{1}" (designated to run before target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run before target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedProjectAfter">
+        <source>Target "{0}" in project "{1}" (designated to run after target "{2}"):</source>
+        <target state="new">Target "{0}" in project "{1}" (designated to run after target "{2}"):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefix">
+        <source>Target {0}:</source>
+        <target state="new">Target {0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFile">
+        <source>Target "{0}" in file "{1}":</source>
+        <target state="new">Target "{0}" in file "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedPrefixInProject">
+        <source>Target {0} from project "{1}":</source>
+        <target state="new">Target {0} from project "{1}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TargetStartedFromFileInProject">
+        <source>Target "{0}" in file "{1}" from project "{2}":</source>
+        <target state="new">Target "{0}" in file "{1}" from project "{2}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupIncludeLogMessagePrefix">
+        <source>Added Item(s): </source>
+        <target state="new">Added Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemGroupRemoveLogMessage">
+        <source>Removed Item(s): </source>
+        <target state="new">Removed Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyGroupLogMessage">
+        <source>Set Property: {0}={1}</source>
+        <target state="new">Set Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputItemParameterMessagePrefix">
+        <source>Output Item(s): </source>
+        <target state="new">Output Item(s): </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OutputPropertyLogMessage">
+        <source>Output Property: {0}={1}</source>
+        <target state="new">Output Property: {0}={1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskContinuedDueToContinueOnError">
+        <source>Build continuing because "{0}" on the task "{1}" is set to "{2}".</source>
+        <target state="new">Build continuing because "{0}" on the task "{1}" is set to "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskDeclarationOrUsageError">
+        <source>MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</source>
+        <target state="new">MSB4060: The "{0}" task has been declared or used incorrectly, or failed during construction. Check the spelling of the task name and the assembly name.</target>
+        <note>{StrBegin="MSB4060: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskExistsButHasMismatchedIdentityError">
+        <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
+        <target state="new">MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedFailure">
+        <source>Done executing task "{0}" -- FAILED.</source>
+        <target state="new">Done executing task "{0}" -- FAILED.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFinishedSuccess">
+        <source>Done executing task "{0}".</source>
+        <target state="new">Done executing task "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskMessageWithId">
+        <source>{0} (TaskId:{1})</source>
+        <target state="new">{0} (TaskId:{1})</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskFound">
+        <source>Using "{0}" task from assembly "{1}".</source>
+        <target state="new">Using "{0}" task from assembly "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskFoundFromFactory">
+        <source>Using "{0}" task from the task factory "{1}".</source>
+        <target state="new">Using "{0}" task from the task factory "{1}".</target>
+        <note>UE: This informational message helps users determine which assemblies their tasks were loaded from.</note>
+      </trans-unit>
+      <trans-unit id="TaskNeedsSTA">
+        <source>Task "{0}" will be run in a single-threaded apartment thread.</source>
+        <target state="new">Task "{0}" will be run in a single-threaded apartment thread.</target>
+        <note>UE: This informational message helps users determine if their tasks are run in the STA or MTA.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureError">
+        <source>MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</source>
+        <target state="new">MSB4061: The "{0}" task could not be instantiated from "{1}". {2}</target>
+        <note>{StrBegin="MSB4061: "}LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskInstantiationFailureErrorInvalidCast">
+        <source>MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4127: The "{0}" task could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4127: "}UE: This message is a specialized version of the TaskInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="LoggerInstantiationFailureErrorInvalidCast">
+        <source>MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4180: The "{0}" logger could not be instantiated from the assembly "{1}". Please verify the logger assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>
+      {StrBegin="MSB4180: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBxxxx: " should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstanceCreationError">
+        <source>MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</source>
+        <target state="new">MSB4179: The task factory instance for the "{0}" task could not be instantiated from the task factory "{1}". {2}</target>
+        <note>{StrBegin="MSB4179: "}
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception.</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryInstantiationFailureErrorInvalidCast">
+        <source>MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</source>
+        <target state="new">MSB4176: The "{0}" task factory could not be instantiated from the assembly "{1}". Please verify the task assembly has been built using the same version of the Microsoft.Build.Framework assembly as the one installed on your computer and that your host application is not missing a binding redirect for Microsoft.Build.Framework. {2}</target>
+        <note>{StrBegin="MSB4176: "}UE: This message is a specialized version of the TaskFactoryInstantiationFailureError message and can probably reuse some of its docs.
+      LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryWillIgnoreTaskFactoryParameters">
+        <source>MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</source>
+        <target state="new">MSB4219: The TaskFactory "{0}" does not implement ITaskFactory2. The attributes "{1}" and/or "{2}" on the UsingTask declaration for task "{3}" will be be ignored.</target>
+        <note>{StrBegin="MSB4219: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailure">
+        <source>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</source>
+        <target state="new">MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</target>
+        <note>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
+    invalid task declaration, disk error, etc. "{2}" contains a message explaining what happened.
+    LOCALIZATION: "{2}" is a message from the CLR loader and is already localized. Also, &lt;UsingTask&gt; should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TaskLoadFailureInvalidTaskHostFactoryParameter">
+        <source>MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</source>
+        <target state="new">MSB4215: The "{0}" task could not be loaded. "{1}" is an invalid value for the task host parameter "{2}". Valid values are:  "{3}", "{4}", "{5}", and "{6}"; not specifying a value is also valid.</target>
+        <note>{StrBegin="MSB4215: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidTaskHostFactoryParameter">
+        <source>"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</source>
+        <target state="new">"{0}" is an invalid value for the task host parameter "{1}". Valid values are: "{2}", "{3}", "{4}", and "{5}"; not specifying a value is also valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostAcquireFailed">
+        <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
+        <target state="new">MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</target>
+        <note>{StrBegin="MSB4216: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunch">
+        <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
+        <target state="new">MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</target>
+        <note>{StrBegin="MSB4221: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
+        <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
+        <target state="new">A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskHostExitedPrematurely">
+        <source>MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</source>
+        <target state="new">MSB4217: Task host node exited prematurely. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt. {0}</target>
+        <note>{StrBegin="MSB4217: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParametersError">
+        <source>MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</source>
+        <target state="new">MSB4063: The "{0}" task could not be initialized with its input parameters. {1}</target>
+        <note>{StrBegin="MSB4063: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskParameterPrefix">
+        <source>Task Parameter:</source>
+        <target state="new">Task Parameter:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskPerformanceSummary">
+        <source>Task Performance Summary:</source>
+        <target state="new">Task Performance Summary:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskSkippedFalseCondition">
+        <source>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</source>
+        <target state="new">Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TaskStarted">
+        <source>Task "{0}"</source>
+        <target state="new">Task "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TimeElapsed">
+        <source>Time Elapsed {0}</source>
+        <target state="new">Time Elapsed {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ToolsVersionInEffectForBuild">
+        <source>Building with tools version "{0}".</source>
+        <target state="new">Building with tools version "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UsingDifferentToolsVersionFromProjectFile">
+        <source>Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</source>
+        <target state="new">Project file contains ToolsVersion="{0}". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="{1}". For more information, please see http://go.microsoft.com/fwlink/?LinkId=293424.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DeferredMessages">
+        <source>Deferred Messages</source>
+        <target state="new">Deferred Messages</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnexpectedCharacterInCondition">
+        <source>MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</source>
+        <target state="new">MSB4090: Found an unexpected character '{2}' at position {1} in condition "{0}".</target>
+        <note>{StrBegin="MSB4090: "}</note>
+      </trans-unit>
+      <trans-unit id="UndefinedFunctionCall">
+        <source>MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</source>
+        <target state="new">MSB4091: Found a call to an undefined function "{1}" in condition "{0}".</target>
+        <note>{StrBegin="MSB4091: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskAttribute">
+        <source>MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</source>
+        <target state="new">MSB4064: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a settable public instance property.</target>
+        <note>{StrBegin="MSB4064: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTaskOutputAttribute">
+        <source>MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</source>
+        <target state="new">MSB4131: The "{0}" parameter is not supported by the "{1}" task. Verify the parameter exists on the task, and it is a gettable public instance property.</target>
+        <note>{StrBegin="MSB4131: "}</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedTokenInCondition">
+        <source>MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</source>
+        <target state="new">MSB4092: An unexpected token "{1}" was found at character position {2} in condition "{0}".</target>
+        <note>{StrBegin="MSB4092: "}</note>
+      </trans-unit>
+      <trans-unit id="UnmarkedOutputTaskParameter">
+        <source>MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</source>
+        <target state="new">MSB4065: The "{0}" parameter is not marked for output by the "{1}" task.</target>
+        <note>{StrBegin="MSB4065: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedAttribute">
+        <source>MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4066: The attribute "{0}" in element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4066: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedChildElement">
+        <source>MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</source>
+        <target state="new">MSB4067: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is unrecognized.</target>
+        <note>{StrBegin="MSB4067: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidChildElementDueToDuplication">
+        <source>MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</source>
+        <target state="new">MSB4173: The element &lt;{0}&gt; beneath element &lt;{1}&gt; is invalid because a child element with that name already exists</target>
+        <note>{StrBegin="MSB4173: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedParentElement">
+        <source>MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</source>
+        <target state="new">MSB4189: &lt;{1}&gt; is not a valid child of the &lt;{0}&gt; element.</target>
+        <note>{StrBegin="MSB4189: "}</note>
+      </trans-unit>
+      <trans-unit id="UnrecognizedElement">
+        <source>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</source>
+        <target state="new">MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</target>
+        <note>{StrBegin="MSB4068: "}</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedTaskParameterTypeError">
+        <source>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</source>
+        <target state="new">MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</target>
+        <note>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UsingTaskAssemblySpecification">
+        <source>MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</source>
+        <target state="new">MSB4072: A &lt;{0}&gt; element must contain either the "{1}" attribute or the "{2}" attribute (but not both).</target>
+        <note>{StrBegin="MSB4072: "}</note>
+      </trans-unit>
+      <trans-unit id="WarningCount">
+        <source>{0} Warning(s)</source>
+        <target state="new">{0} Warning(s)</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WhenNotAllowedAfterOtherwise">
+        <source>MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</source>
+        <target state="new">MSB4084: A &lt;When&gt; element may not follow an &lt;Otherwise&gt; element in a &lt;Choose&gt;.</target>
+        <note>{StrBegin="MSB4084: "}</note>
+      </trans-unit>
+      <trans-unit id="MustCallInitializeBeforeApplyParameter">
+        <source>MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</source>
+        <target state="new">MSB4150: Must initialize the console logger using the initialize method before using ApplyParameter</target>
+        <note>{StrBegin="MSB4150: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidHostObjectOnOutOfProcProject">
+        <source>MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</source>
+        <target state="new">MSB4206: A non-null host object cannot be specified for a project which has an affinity set to out-of-process.</target>
+        <note>{StrBegin="MSB4206: "}</note>
+      </trans-unit>
+      <trans-unit id="InvalidAffinityForProjectWithHostObject">
+        <source>MSB4207: Only an in-process affinity may be specified for projects which have registered host objects.</source>
+        <target state="new">MSB4208: Only an in-process affinity may be specified for projects which have registered host objects.</target>
+        <note>{StrBegin="MSB4207: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectInstanceConflictsWithAffinity">
+        <source>MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</source>
+        <target state="new">MSB4209: The specified project instance conflicts with the affinity specified in the HostServices.</target>
+        <note>{StrBegin="MSB4209: "}</note>
+      </trans-unit>
+      <trans-unit id="AffinityConflict">
+        <source>MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</source>
+        <target state="new">MSB4213: The specified request affinity {0} conflicts with a previous affinity {1} specified for this project.</target>
+        <note>{StrBegin="MSB4213: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCreateNode">
+        <source>MSB4223: A node of the required type {0} could not be created.</source>
+        <target state="new">MSB4223: A node of the required type {0} could not be created.</target>
+        <note>{StrBegin="MSB4223: "}</note>
+      </trans-unit>
+      <trans-unit id="KeepAndRemoveMetadataMutuallyExclusive">
+        <source>MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</source>
+        <target state="new">MSB4224: KeepMetadata and RemoveMetadata are mutually exclusive.</target>
+        <note>{StrBegin="MSB4224: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithTargetNames">
+        <source>"{0}" ({1} target) ({2}) -&gt;</source>
+        <target state="new">"{0}" ({1} target) ({2}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStackWithDefaultTargets">
+        <source>"{0}" (default target) ({1}) -&gt;</source>
+        <target state="new">"{0}" (default target) ({1}) -&gt;</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildEventContext">
+        <source>{0} {1,5}</source>
+        <target state="new">{0} {1,5}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithTargetNames">
+        <source>Project "{0}" on node {1} ({2} target(s)).</source>
+        <target state="new">Project "{0}" on node {1} ({2} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedTopLevelProjectWithDefaultTargets">
+        <source>Project "{0}" on node {1} (default targets).</source>
+        <target state="new">Project "{0}" on node {1} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} ({5} target(s)).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectStartedWithDefaultTargetsMultiProc">
+        <source>Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</source>
+        <target state="new">Project "{0}" ({1}) is building "{2}" ({3}) on node {4} (default targets).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWarningInTarget">
+        <source>({0} target) -&gt; </source>
+        <target state="new">({0} target) -&gt; </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="PropertyOutputOverridden">
+        <source>The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</source>
+        <target state="new">The property "{0}" with value "{1}" is being overridden by another batch. The property is now: "{2}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="logfilePathNullOrEmpty">
+        <source>The log file path cannot be null or empty.</source>
+        <target state="new">The log file path cannot be null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DefaultTargets">
+        <source>[default]</source>
+        <target state="new">[default]</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CouldNotFindFactory">
+        <source>MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</source>
+        <target state="new">MSB4174: The task factory "{0}" could not be found in the assembly "{1}".</target>
+        <note>{StrBegin="MSB4174: "}</note>
+      </trans-unit>
+      <trans-unit id="TaskFactoryLoadFailure">
+        <source>MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</source>
+        <target state="new">MSB4175: The task factory "{0}" could not be loaded from the assembly "{1}". {2}</target>
+        <note>{StrBegin="MSB4175: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancel">
+        <source>MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</source>
+        <target state="new">MSB4201: The cancel operation was unable to complete because the currently executing task is not responding.</target>
+        <note>{StrBegin="MSB4201: "}</note>
+      </trans-unit>
+      <trans-unit id="UnableToCancelTask">
+        <source>MSB4220: Waiting for the currently executing task "{0}" to cancel.</source>
+        <target state="new">MSB4220: Waiting for the currently executing task "{0}" to cancel.</target>
+        <note>{StrBegin="MSB4220: "}</note>
+      </trans-unit>
+      <trans-unit id="MainThreadInUse">
+        <source>MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</source>
+        <target state="new">MSB4202: The request to build submission {0} cannot proceed because submission {1} is already using the main thread.</target>
+        <note>{StrBegin="MSB4202: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectAlreadyBuilding">
+        <source>The request to build this submission cannot proceed because a project with the same configuration is already building.</source>
+        <target state="new">The request to build this submission cannot proceed because a project with the same configuration is already building.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskFactory">
+        <source>Initializing task factory "{0}" from assembly "{1}".</source>
+        <target state="new">Initializing task factory "{0}" from assembly "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InitializingTaskHostFactory">
+        <source>Initializing task host factory for task "{0}" from assembly "{1}"</source>
+        <target state="new">Initializing task host factory for task "{0}" from assembly "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CantWriteBuildPlan">
+        <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
+        <target state="new">The build plan could not be written.  Check that the build process has permissions to write to {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CacheFileInaccessible">
+        <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
+        <target state="new">The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</target>
+        <note>
+      LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
+    </note>
+      </trans-unit>
+      <trans-unit id="CantReadBuildPlan">
+        <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
+        <target state="new">The build plan could not be read.  Check that the build process has permissions to read {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildPlanCorrupt">
+        <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
+        <target state="new">The build plan at {0} appears to be corrupt and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DetailedSummaryHeader">
+        <source>
+Detailed Build Summary
+======================
+    </source>
+        <target state="new">
+Detailed Build Summary
+======================
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyHeader">
+        <source>
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Build Hierarchy (IDs represent configurations) =====================================================
+Id                  : Exclusive Time   Total Time   Path (Targets)
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="BuildHierarchyEntry">
+        <source>{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </source>
+        <target state="new">{0}{1,-3}{2}: {3:0.000}s           {4:0.000}s       {5} ({6}) </target>
+        <note>Fields 3 and 4 represent seconds, and the 's' following them should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationHeader">
+        <source>
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</source>
+        <target state="new">
+============================== Node Utilization (IDs represent configurations) ====================================================
+Timestamp:            {0} Duration   Cumulative
+-----------------------------------------------------------------------------------------------------------------------------------</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationEntry">
+        <source>{0} {1:0.000}s     {2:0.000}s {3}</source>
+        <target state="new">{0} {1:0.000}s     {2:0.000}s {3}</target>
+        <note>Fields 1 and 2 represents seconds, and the 's' following it should reflect the localized abbreviation for seconds.</note>
+      </trans-unit>
+      <trans-unit id="NodeUtilizationSummary">
+        <source>-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</source>
+        <target state="new">-----------------------------------------------------------------------------------------------------------------------------------
+Utilization:          {0} Average Utilization: {1:###.0}</target>
+        <note>Spacing is important.  Preserve the number of characters between the start of each word.</note>
+      </trans-unit>
+      <trans-unit id="OM_NotSupportedConvertingCollectionValueToBacking">
+        <source>This collection cannot convert from the specified value to the backing value.</source>
+        <target state="new">This collection cannot convert from the specified value to the backing value.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotCreateReservedProperty">
+        <source>The "{0}" property name is reserved.</source>
+        <target state="new">The "{0}" property name is reserved.</target>
+        <note>UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile) through the object model</note>
+      </trans-unit>
+      <trans-unit id="OM_EitherAttributeButNotBoth">
+        <source>The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</source>
+        <target state="new">The &lt;{0}&gt; element must have either the "{1}" attribute or the "{2}" attribute but not both.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveOutsideTargets">
+        <source>The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "Remove" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepMetadataOutsideTargets">
+        <source>The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoRemoveMetadataOutsideTargets">
+        <source>The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "RemoveMetadata" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoKeepDuplicatesOutsideTargets">
+        <source>The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</source>
+        <target state="new">The "KeepDuplicates" attribute is not permitted on an item outside of a &lt;Target&gt;.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotGetSetCondition">
+        <source>Elements of this type do not have a condition.</source>
+        <target state="new">Elements of this type do not have a condition.</target>
+        <note>For example, it is not legal for a &lt;ProjectExtensions&gt; element to have a condition attribute.</note>
+      </trans-unit>
+      <trans-unit id="OM_NodeAlreadyParented">
+        <source>The node already has a parent. Remove it from its parent before moving it.</source>
+        <target state="new">The node already has a parent. Remove it from its parent before moving it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NodeNotAlreadyParentedByThis">
+        <source>The node is not parented by this object so it cannot be removed from it.</source>
+        <target state="new">The node is not parented by this object so it cannot be removed from it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReferenceDoesNotHaveThisParent">
+        <source>The reference node is not a child of this node.</source>
+        <target state="new">The reference node is not a child of this node.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_SelfAncestor">
+        <source>Cannot make a node or an ancestor of that node a child of itself.</source>
+        <target state="new">Cannot make a node or an ancestor of that node a child of itself.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustBeSameProject">
+        <source>Cannot create a relationship between nodes that were created from different projects.</source>
+        <target state="new">Cannot create a relationship between nodes that were created from different projects.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ParentNotParented">
+        <source>The parent node is not itself parented.</source>
+        <target state="new">The parent node is not itself parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotAcceptParent">
+        <source>This parent is not a valid parent for the item.</source>
+        <target state="new">This parent is not a valid parent for the item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ItemsOutsideTargetMustHaveIncludeNoRemove">
+        <source>An item not parented under a Target must have a value for Include and no value for Remove.</source>
+        <target state="new">An item not parented under a Target must have a value for Include and no value for Remove.</target>
+        <note>LOCALIZATION: Please do not localize "Target", "Include", and "Remove".</note>
+      </trans-unit>
+      <trans-unit id="OM_NameInvalid">
+        <source>The name "{0}" contains an invalid character "{1}".</source>
+        <target state="new">The name "{0}" contains an invalid character "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_NoOtherwiseBeforeWhenOrOtherwise">
+        <source>An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</source>
+        <target state="new">An &lt;Otherwise&gt; element cannot be located before a &lt;When&gt; or &lt;Otherwise&gt; element.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetFileNameBeforeSave">
+        <source>Project has not been given a path to save to.</source>
+        <target state="new">Project has not been given a path to save to.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MustSetRecordDuplicateInputs">
+        <source>Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</source>
+        <target state="new">Project was not loaded with the ProjectLoadSettings.RecordDuplicateImports flag.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotSaveFileLoadedAsReadOnly">
+        <source>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</source>
+        <target state="new">Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_IncorrectObjectAssociation">
+        <source>The "{0}" object specified does not belong to the correct "{1}" object.</source>
+        <target state="new">The "{0}" object specified does not belong to the correct "{1}" object.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ReservedName">
+        <source>The "{0}" name is reserved, and cannot be used.</source>
+        <target state="new">The "{0}" name is reserved, and cannot be used.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_GlobalProperty">
+        <source>The "{0}" property is a global property, and cannot be modified.</source>
+        <target state="new">The "{0}" property is a global property, and cannot be modified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_MatchingProjectAlreadyInCollection">
+        <source>An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</source>
+        <target state="new">An equivalent project (a project with the same global properties and tools version) is already present in the project collection, with the path "{0}". To load an equivalent into this project collection, unload this project first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectWasNotLoaded">
+        <source>The project provided was not loaded in the collection.</source>
+        <target state="new">The project provided was not loaded in the collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotModifyEvaluatedObjectInImportedFile">
+        <source>Cannot modify an evaluated object originating in an imported file "{0}".</source>
+        <target state="new">Cannot modify an evaluated object originating in an imported file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_CannotRemoveMetadataOriginatingFromItemDefinition">
+        <source>Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</source>
+        <target state="new">Cannot remove the metadata named "{0}" as it originates from an item definition, rather than being directly defined on this item.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectIsNoLongerActive">
+        <source>The project cannot be used as it is no longer loaded into a project collection.</source>
+        <target state="new">The project cannot be used as it is no longer loaded into a project collection.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ObjectIsNoLongerActive">
+        <source>The operation is not allowed because currently this object is not parented.</source>
+        <target state="new">The operation is not allowed because currently this object is not parented.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectXmlCannotBeUnloadedDueToLoadedProjects">
+        <source>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</source>
+        <target state="new">The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_ProjectInstanceImmutable">
+        <source>Instance object was created as immutable.</source>
+        <target state="new">Instance object was created as immutable.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="OM_BuildSubmissionsMultipleProjectCollections">
+        <source>All build submissions in a build must use project instances originating from the same project collection.</source>
+        <target state="new">All build submissions in a build must use project instances originating from the same project collection.</target>
+        <note>This occurs if a client tries to add two BuildSubmissions to a build, each involving a ProjectInstance originating in different ProjectCollection. This is not allowed.</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>
+      {StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+      and they have not specified the SkipNonexistentProjects parameter, or it is set to false.
+    </note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.cs.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.cs.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.de.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.de.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.es.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.es.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.fr.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.fr.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.it.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.it.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.ja.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.ja.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.ko.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.ko.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.pl.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.pl.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.pt.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.pt.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.ru.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.ru.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.tr.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.tr.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeCommandLine/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/XMakeCommandLine/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,0 +1,1185 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
+    <body>
+      <group id="MSBUILD/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AmbiguousProjectError">
+        <source>MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1011: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ConfigurationFailurePrefixNoErrorCode">
+        <source>MSBUILD : Configuration error {0}: {1}</source>
+        <target state="new">MSBUILD : Configuration error {0}: {1}</target>
+        <note>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
+      There's no error code because one was included in the error message.
+      LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="CannotAutoDisableAutoResponseFile">
+        <source>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</source>
+        <target state="new">MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</target>
+        <note>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightMessage">
+        <source>Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</source>
+        <target state="new">Microsoft (R) Build Engine version {0}
+Copyright (C) Microsoft Corporation. All rights reserved.
+</target>
+        <note>LOCALIZATION: {0} contains the DLL version number</note>
+      </trans-unit>
+      <trans-unit id="DuplicateProjectSwitchError">
+        <source>MSBUILD : error MSB1008: Only one project can be specified.</source>
+        <target state="new">MSBUILD : error MSB1008: Only one project can be specified.</target>
+        <note>{StrBegin="MSBUILD : error MSB1008: "}UE: This happens if the user does something like "msbuild.exe myapp.proj myapp2.proj". This is not allowed.
+    MSBuild.exe will only build a single project. The help topic may link to an article about how to author an MSBuild project
+    that itself launches MSBuild on a number of other projects.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FatalError">
+        <source>MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</source>
+        <target state="new">MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.</target>
+        <note>{StrBegin="MSBUILD : error MSB1025: "}UE: This message is shown when the application has to terminate either because of a bug in the code, or because some
+      FX/CLR method threw an unexpected exception.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_1_Syntax">
+        <source>Syntax:              MSBuild.exe [options] [project file]
+</source>
+        <target state="new">Syntax:              MSBuild.exe [options] [project file]
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_2_Description">
+        <source>Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</source>
+        <target state="new">Description:         Builds the specified targets in the project file. If
+                     a project file is not specified, MSBuild searches the
+                     current working directory for a file that has a file
+                     extension that ends in "proj" and uses that file.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_3_SwitchesHeader">
+        <source>Switches:
+</source>
+        <target state="new">Switches:
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_4_HelpSwitch">
+        <source>  /help              Display this usage message. (Short form: /? or /h)
+</source>
+        <target state="new">  /help              Display this usage message. (Short form: /? or /h)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_5_NoLogoSwitch">
+        <source>  /nologo            Do not display the startup banner and copyright message.
+</source>
+        <target state="new">  /nologo            Do not display the startup banner and copyright message.
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_6_VersionSwitch">
+        <source>  /version           Display version information only. (Short form: /ver)
+</source>
+        <target state="new">  /version           Display version information only. (Short form: /ver)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_7_ResponseFile">
+        <source>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</source>
+        <target state="new">  @&lt;file&gt;            Insert command-line settings from a text file. To specify
+                     multiple response files, specify each response file
+                     separately.
+                     
+                     Any response files named "msbuild.rsp" are automatically 
+                     consumed from the following locations: 
+                     (1) the directory of msbuild.exe
+                     (2) the directory of the first project or solution built
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_8_NoAutoResponseSwitch">
+        <source>  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</source>
+        <target state="new">  /noautoresponse    Do not auto-include any MSBuild.rsp files. (Short form:
+                     /noautorsp)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_9_TargetSwitch">
+        <source>  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</source>
+        <target state="new">  /target:&lt;targets&gt;  Build these targets in this project. Use a semicolon or a
+                     comma to separate multiple targets, or specify each
+                     target separately. (Short form: /t)
+                     Example:
+                       /target:Resources;Compile
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_10_PropertySwitch">
+        <source>  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</source>
+        <target state="new">  /property:&lt;n&gt;=&lt;v&gt;  Set or override these project-level properties. &lt;n&gt; is
+                     the property name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties, or
+                     specify each property separately. (Short form: /p)
+                     Example:
+                       /property:WarningLevel=2;OutDir=bin\Debug\
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_11_LoggerSwitch">
+        <source>  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</source>
+        <target state="new">  /logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
+                     multiple loggers, specify each logger separately.
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_12_VerbositySwitch">
+        <source>  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</source>
+        <target state="new">  /verbosity:&lt;level&gt; Display this amount of information in the event log.
+                     The available verbosity levels are: q[uiet], m[inimal],
+                     n[ormal], d[etailed], and diag[nostic]. (Short form: /v)
+                     Example:
+                       /verbosity:quiet
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_13_ConsoleLoggerParametersSwitch">
+        <source>  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</source>
+        <target state="new">  /consoleloggerparameters:&lt;parameters&gt;
+                     Parameters to console logger. (Short form: /clp)
+                     The available parameters are:
+                        PerformanceSummary--Show time spent in tasks, targets
+                            and projects.
+                        Summary--Show error and warning summary at the end.
+                        NoSummary--Don't show error and warning summary at the
+                            end.
+                        ErrorsOnly--Show only errors.
+                        WarningsOnly--Show only warnings.
+                        NoItemAndPropertyList--Don't show list of items and
+                            properties at the start of each project build.    
+                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                        ShowTimestamp--Display the Timestamp as a prefix to any
+                            message.                                           
+                        ShowEventId--Show eventId for started events, finished 
+                            events, and messages
+                        ForceNoAlign--Does not align the text to the size of
+                            the console buffer
+                        DisableConsoleColor--Use the default console colors
+                            for all logging messages.
+                        DisableMPLogging-- Disable the multiprocessor
+                            logging style of output when running in 
+                            non-multiprocessor mode.
+                        EnableMPLogging--Enable the multiprocessor logging
+                            style even when running in non-multiprocessor
+                            mode. This logging style is on by default. 
+                        ForceConsoleColor--Use ANSI console colors even if
+                            console does not support it
+                        Verbosity--overrides the /verbosity setting for this
+                            logger.
+                     Example:
+                        /consoleloggerparameters:PerformanceSummary;NoSummary;
+                                                 Verbosity=minimal
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_14_NoConsoleLoggerSwitch">
+        <source>  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</source>
+        <target state="new">  /noconsolelogger   Disable the default console logger and do not log events
+                     to the console. (Short form: /noconlog)
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_15_ValidateSwitch">
+        <source>  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</source>
+        <target state="new">  /validate          Validate the project against the default schema. (Short
+                     form: /val)
+
+  /validate:&lt;schema&gt; Validate the project against the specified schema. (Short
+                     form: /val)
+                     Example:
+                       /validate:MyExtendedBuildSchema.xsd
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_17_MaximumCPUSwitch">
+        <source>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </source>
+        <target state="new">  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+                     build with. If the switch is not used, the default
+                     value used is 1. If the switch is used without a value
+                     MSBuild will use up to the number of processors on the 
+                     computer. (Short form: /m[:n])
+      </target>
+        <note>
+          LOCALIZATION: "maxcpucount" should not be localized.
+          LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+      </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_16_Examples">
+        <source>Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </source>
+        <target state="new">Examples:
+
+        MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
+        MSBuild MyApp.csproj /t:Clean 
+                             /p:Configuration=Debug;TargetFrameworkVersion=v3.5
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpPrompt">
+        <source>For switch syntax, type "MSBuild /help"</source>
+        <target state="new">For switch syntax, type "MSBuild /help"</target>
+        <note>UE: this message is shown when the user makes a syntax error on the command-line for a switch.
+    LOCALIZATION: "MSBuild /help" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_18_DistributedLoggerSwitch">
+        <source>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</source>
+        <target state="new">  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+                     Use this logger to log events from MSBuild, attaching a
+                     different logger instance to each node. To specify
+                     multiple loggers, specify each logger separately. 
+                     (Short form /dl)
+                     The &lt;logger&gt; syntax is:
+                       [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
+                     The &lt;logger class&gt; syntax is:
+                       [&lt;partial or full namespace&gt;.]&lt;logger class name&gt;
+                     The &lt;logger assembly&gt; syntax is:
+                       {&lt;assembly name&gt;[,&lt;strong name&gt;] | &lt;assembly file&gt;}
+                     The &lt;logger parameters&gt; are optional, and are passed
+                     to the logger exactly as you typed them. (Short form: /l)
+                     Examples:
+                       /dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
+                       /dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+</target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_19_IgnoreProjectExtensionsSwitch">
+        <source>  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </source>
+        <target state="new">  /ignoreprojectextensions:&lt;extensions&gt;
+                     List of extensions to ignore when determining which 
+                     project file to build. Use a semicolon or a comma 
+                     to separate multiple extensions.
+                     (Short form: /ignore)
+                     Example:
+                       /ignoreprojectextensions:.sln
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_23_ToolsVersionSwitch">
+        <source>  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </source>
+        <target state="new">  /toolsversion:&lt;version&gt;
+                     The version of the MSBuild Toolset (tasks, targets, etc.)
+                     to use during build. This version will override the 
+                     versions specified by individual projects. (Short form: 
+                     /tv)
+                     Example:
+                       /toolsversion:3.5
+   </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_20_FileLoggerSwitch">
+        <source>  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </source>
+        <target state="new">  /fileLogger[n]     Logs the build output to a file. By default
+                     the file is in the current directory and named 
+                     "msbuild[n].log". Events from all nodes are combined into
+                     a single log. The location of the file and other
+                     parameters for the fileLogger can be specified through 
+                     the addition of the "/fileLoggerParameters[n]" switch.
+                     "n" if present can be a digit from 1-9, allowing up to 
+                     10 file loggers to be attached. (Short form: /fl[n])
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_21_DistributedFileLoggerSwitch">
+        <source>  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </source>
+        <target state="new">  /distributedFileLogger                                                       
+                     Logs the build output to multiple log files, one log file
+                     per MSBuild node. The initial location for these files is
+                     the current directory. By default the files are called 
+                     "MSBuild&lt;nodeid&gt;.log". The location of the files and
+                     other parameters for the fileLogger can be specified 
+                     with the addition of the "/fileLoggerParameters" switch.
+
+                     If a log file name is set through the fileLoggerParameters
+                     switch the distributed logger will use the fileName as a 
+                     template and append the node id to this fileName to 
+                     create a log file for each node.
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_22_FileLoggerParametersSwitch">
+        <source>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </source>
+        <target state="new">  /fileloggerparameters[n]:&lt;parameters&gt;                                
+                     Provides any extra parameters for file loggers.
+                     The presence of this switch implies the 
+                     corresponding /filelogger[n] switch.
+                     "n" if present can be a digit from 1-9.
+                     /fileloggerparameters is also used by any distributed
+                     file logger, see description of /distributedFileLogger.
+                     (Short form: /flp[n])
+                     The same parameters listed for the console logger are
+                     available. Some additional available parameters are:
+                        LogFile--path to the log file into which the
+                            build log will be written.
+                        Append--determines if the build log will be appended
+                            to or overwrite the log file. Setting the
+                            switch appends the build log to the log file;
+                            Not setting the switch overwrites the 
+                            contents of an existing log file. 
+                            The default is not to append to the log file.
+                        Encoding--specifies the encoding for the file, 
+                            for example, UTF-8, Unicode, or ASCII
+                     Default verbosity is Detailed.
+                     Examples:
+                       /fileLoggerParameters:LogFile=MyLog.log;Append;
+                                           Verbosity=diagnostic;Encoding=UTF-8
+
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
+                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp2:errorsonly;logfile=msbuild.err
+    </target>
+        <note>
+      LOCALIZATION: The following should not be localized:
+      1) "MSBuild", "MSBuild.exe" and "MSBuild.rsp"
+      2) the string "proj" that describes the extension we look for
+      3) all switch names and their short forms e.g. /property, or /p
+      4) all verbosity levels and their short forms e.g. quiet, or q
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_24_NodeReuse">
+        <source>  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </source>
+        <target state="new">  /nodeReuse:&lt;parameters&gt;
+                     Enables or Disables the reuse of MSBuild nodes.
+                     The parameters are:
+                     True --Nodes will remain after the build completes
+                            and will be reused by subsequent builds (default)
+                     False--Nodes will not remain after the build completes
+                     (Short form: /nr)
+                     Example:
+                       /nr:true
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_25_PreprocessSwitch">
+        <source>  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </source>
+        <target state="new">  /preprocess[:file] 
+                     Creates a single, aggregated project file by
+                     inlining all the files that would be imported during a
+                     build, with their boundaries marked. This can be
+                     useful for figuring out what files are being imported
+                     and from where, and what they will contribute to
+                     the build. By default the output is written to
+                     the console window. If the path to an output file 
+                     is provided that will be used instead.
+                     (Short form: /pp)
+                     Example:
+                       /pp:out.txt
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_26_DetailedSummarySwitch">
+        <source>  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </source>
+        <target state="new">  /detailedsummary 
+                     Shows detailed information at the end of the build
+                     about the configurations built and how they were
+                     scheduled to nodes. 
+                     (Short form: /ds)
+    </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_27_DebuggerSwitch">
+        <source>  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </source>
+        <target state="new">  /debug
+                     Causes a debugger prompt to appear immediately so that 
+                     Visual Studio can be attached for you to debug the 
+                     MSBuild XML and any tasks and loggers it uses.
+   </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidConfigurationFile">
+        <source>MSBUILD : Configuration error MSB1043: The application could not start. {0}</source>
+        <target state="new">MSBUILD : Configuration error MSB1043: The application could not start. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : Configuration error MSB1043: "}
+      UE: This error is shown when the msbuild.exe.config file had invalid content.
+      LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidLoggerError">
+        <source>MSBUILD : error MSB1019: Logger switch was not correctly formed.</source>
+        <target state="new">MSBUILD : error MSB1019: Logger switch was not correctly formed.</target>
+        <note>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user does any of the following:
+      msbuild.exe /logger:;"logger parameters"                    (missing logger class and assembly)
+      msbuild.exe /logger:loggerclass,                            (missing logger assembly)
+      msbuild.exe /logger:loggerclass,;"logger parameters"        (missing logger assembly)
+      The correct way to specify a logger is to give both the logger class and logger assembly, or just the logger assembly (logger
+      parameters are optional).
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValue">
+        <source>MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1030: Maximum CPU count is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1030: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an invalid CPU value. For example, /m:foo instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxCPUCountValueOutsideRange">
+        <source>MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</source>
+        <target state="new">MSBUILD : error MSB1032: Maximum CPU count is not valid. Value must be an integer greater than zero and no more than 1024.</target>
+        <note>{StrBegin="MSBUILD : error MSB1032: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /m:0 instead of /m:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValue">
+        <source>MSBUILD : error MSB1033: Node number is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1033: Node number is not valid. {0}.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1033: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:foo instead of /nodemode:2.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeNumberValueIsNegative">
+        <source>MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</source>
+        <target state="new">MSBUILD : error MSB1034: Node number is not valid. Value must be an integer greater than zero.</target>
+        <note>{StrBegin="MSBUILD : error MSB1034: "}
+        UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+        This error is shown when a user specifies a CPU value that is zero or less. For example, /nodemode:0 instead of /nodemode:2.
+        LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="InvalidPropertyError">
+        <source>MSBUILD : error MSB1006: Property is not valid.</source>
+        <target state="new">MSBUILD : error MSB1006: Property is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1006: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown if the user does any of the following:
+      msbuild.exe /property:foo              (missing property value)
+      msbuild.exe /property:=4               (missing property name)
+      The user must pass in an actual property name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidSchemaFile">
+        <source>MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</source>
+        <target state="new">MSBUILD : MSB1046: The schema "{0}" is not valid. {1}</target>
+        <note>{StrBegin="MSBUILD : MSB1046: "}UE: This message is shown when the schema file provided for the validation of a project is itself not valid.
+    LOCALIZATION: "{0}" is the schema file path. "{1}" is a message from an FX exception that describes why the schema file is bad.</note>
+      </trans-unit>
+      <trans-unit id="InvalidSwitchIndicator">
+        <source>Switch: {0}</source>
+        <target state="new">Switch: {0}</target>
+        <note>
+      UE: This is attached to error messages caused by an invalid switch. This message indicates what the invalid arg was.
+      For example, if an unknown switch is passed to MSBuild.exe, the error message will look like this:
+      MSBUILD : error MSB1001: Unknown switch.
+      Switch: /bogus
+      LOCALIZATION: {0} contains the invalid switch text.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidToolsVersionError">
+        <source>MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1040: ToolsVersion is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1040: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown toolversion, eg /toolsversion:99
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidVerbosityError">
+        <source>MSBUILD : error MSB1018: Verbosity level is not valid.</source>
+        <target state="new">MSBUILD : error MSB1018: Verbosity level is not valid.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1018: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an unknown verbosity level e.g. "msbuild /verbosity:foo". The only valid verbosities
+      (and their short forms) are: q[uiet], m[inimal], n[ormal], d[etailed], diag[nostic].
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="LoggerFatalError">
+        <source>MSBUILD : error MSB1028: The logger failed unexpectedly.</source>
+        <target state="new">MSBUILD : error MSB1028: The logger failed unexpectedly.</target>
+        <note>{StrBegin="MSBUILD : error MSB1028: "}
+      UE: This error is shown when a logger specified with the /logger switch throws an exception while being
+      initialized. This message is followed by the exception text including the stack trace.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixNoErrorCode">
+        <source>MSBUILD : Logger error {0}: {1}</source>
+        <target state="new">MSBUILD : Logger error {0}: {1}</target>
+        <note>UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+      For example, the logger is indicating that it could not create its output file.
+      There's no error code because one was supplied by the logger.
+      LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="LoggerFailurePrefixWithErrorCode">
+        <source>MSBUILD : Logger error MSB1029: {0}</source>
+        <target state="new">MSBUILD : Logger error MSB1029: {0}</target>
+        <note>{SubString="Logger", "{0}"}{StrBegin="MSBUILD : "}
+        UE: This prefixes the error message emitted by a logger, when a logger fails in a controlled way using a LoggerException.
+        For example, the logger is indicating that it could not create its output file.
+        This is like LoggerFailurePrefixNoErrorCode, but the logger didn't supply its own error code, so we have to provide one.
+        LOCALIZATION: The word "Logger" should be localized, the words "MSBuild" and "error" should NOT be localized.
+      </note>
+      </trans-unit>
+      <trans-unit id="MissingLoggerError">
+        <source>MSBUILD : error MSB1007: Specify a logger.</source>
+        <target state="new">MSBUILD : error MSB1007: Specify a logger.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1007: "}UE: This happens if the user does something like "msbuild.exe /logger". The user must pass in an actual logger class
+      following the switch, as in "msbuild.exe /logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingMaxCPUCountError">
+        <source>MSBUILD : error MSB1031: Specify the maximum number of CPUs.</source>
+        <target state="new">MSBUILD : error MSB1031: Specify the maximum number of CPUs.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1031: "}UE: This happens if the user does something like "msbuild.exe /m". The user must pass in an actual number like /m:4.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingProjectError">
+        <source>MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</source>
+        <target state="new">MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1003: "}UE: The user must either specify a project or solution file to build, or there must be a project file in the current directory
+      with a file extension ending in "proj" (e.g., foo.csproj), or a solution file ending in "sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingPropertyError">
+        <source>MSBUILD : error MSB1005: Specify a property and its value.</source>
+        <target state="new">MSBUILD : error MSB1005: Specify a property and its value.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1005: "}UE: This happens if the user does something like "msbuild.exe /property". The user must pass in an actual property
+      name and value following the switch, as in "msbuild.exe /property:Configuration=Debug".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingResponseFileError">
+        <source>MSBUILD : error MSB1012: Specify a response file.</source>
+        <target state="new">MSBUILD : error MSB1012: Specify a response file.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1012: "}UE: This error would occur if the user did something like "msbuild.exe @ foo.proj". The at-sign must be followed by a
+      response file.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingTargetError">
+        <source>MSBUILD : error MSB1004: Specify the name of the target.</source>
+        <target state="new">MSBUILD : error MSB1004: Specify the name of the target.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1004: "}UE: This happens if the user does something like "msbuild.exe /target". The user must pass in an actual target name
+      following the switch, as in "msbuild.exe /target:blah".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingToolsVersionError">
+        <source>MSBUILD : error MSB1039: Specify the version of the toolset.</source>
+        <target state="new">MSBUILD : error MSB1039: Specify the version of the toolset.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1039: "}
+      UE: This happens if the user does something like "msbuild.exe /ToolsVersion". The user must pass in an actual toolsversion
+      name following the switch, as in "msbuild.exe /ToolsVersion:3.5".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingVerbosityError">
+        <source>MSBUILD : error MSB1016: Specify the verbosity level.</source>
+        <target state="new">MSBUILD : error MSB1016: Specify the verbosity level.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1016: "}UE: This happens if the user does something like "msbuild.exe /verbosity". The user must pass in a verbosity level
+      after the switch e.g. "msbuild.exe /verbosity:detailed".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MultipleSchemasError">
+        <source>MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</source>
+        <target state="new">MSBUILD : error MSB1024: Only one schema can be specified for validation of the project.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild /validate:foo.xsd /validate:bar.xsd. We only allow one schema to be specified.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="PickedUpSwitchesFromAutoResponse">
+        <source>Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</source>
+        <target state="new">Some command line switches were read from the auto-response file "{0}". To disable this file, use the "/noautoresponse" switch.</target>
+        <note>
+      UE: This message appears in high verbosity modes when we used some
+      switches from the auto-response file msbuild.rsp: otherwise the user may be unaware
+      where the switches are coming from.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectNotFoundError">
+        <source>MSBUILD : error MSB1009: Project file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1009: Project file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1009: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="PossiblyOmittedMaxCPUSwitch">
+        <source>Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</source>
+        <target state="new">Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectSchemaErrorHalt">
+        <source>MSBUILD : MSB1045: Stopping because of syntax errors in project file.</source>
+        <target state="new">MSBUILD : MSB1045: Stopping because of syntax errors in project file.</target>
+        <note>{StrBegin="MSBUILD : MSB1045: "}</note>
+      </trans-unit>
+      <trans-unit id="ReadResponseFileError">
+        <source>MSBUILD : error MSB1023: Cannot read the response file. {0}</source>
+        <target state="new">MSBUILD : error MSB1023: Cannot read the response file. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1023: "}UE: This error is shown when the response file cannot be read off disk.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a localized message explaining
+    why the response file could not be read -- this message comes from the CLR/FX.</note>
+      </trans-unit>
+      <trans-unit id="RepeatedResponseFileError">
+        <source>MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</source>
+        <target state="new">MSBUILD : error MSB1013: The response file was specified twice. A response file can be specified only once. Any files named "msbuild.rsp" in the directory of MSBuild.exe or in the directory of the first project or solution built (which if no project or solution is specified is the current working directory) were automatically used as response files.</target>
+        <note>{StrBegin="MSBUILD : error MSB1013: "}UE: Response files are just text files that contain a bunch of command-line switches to be passed to MSBuild.exe. The
+    purpose is so you don't have to type the same switches over and over again ... you can just pass in the response file instead.
+    Response files can include the @ switch in order to further include other response files. In order to prevent a circular
+    reference here, we disallow the same response file from being included twice. This error message would be followed by the
+    exact @ switch that resulted in the duplicate response file.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ResponseFileNotFoundError">
+        <source>MSBUILD : error MSB1022: Response file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1022: Response file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1022: "}UE: This message would show if the user did something like "msbuild @bogus.rsp" where bogus.rsp doesn't exist. This
+    message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaFileLocation">
+        <source>Validating project using schema file "{0}".</source>
+        <target state="new">Validating project using schema file "{0}".</target>
+        <note>LOCALIZATION: "{0}" is the location of the schema file.</note>
+      </trans-unit>
+      <trans-unit id="SchemaValidationError">
+        <source>MSBUILD : MSB1044: Project is not valid. {0}</source>
+        <target state="new">MSBUILD : MSB1044: Project is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : MSB1044: "}UE: This error is shown when the user asks his project to be validated against a schema (/val switch for
+    MSBuild.exe), and the project has errors. "{0}" contains a message explaining the problem.
+    LOCALIZATION: "{0}" is a message from the System.XML schema validator and is already localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundError">
+        <source>MSBUILD : error MSB1026: Schema file does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is shown when the user specifies a schema file using the /validate:&lt;schema&gt; switch, and the file
+    does not exist on disk. This message does not need in-line parameters because the exception takes care of displaying the
+    invalid arg.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SchemaNotFoundErrorWithFile">
+        <source>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</source>
+        <target state="new">MSBUILD : error MSB1026: Schema file '{0}' does not exist.</target>
+        <note>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnexpectedParametersError">
+        <source>MSBUILD : error MSB1002: This switch does not take any parameters.</source>
+        <target state="new">MSBUILD : error MSB1002: This switch does not take any parameters.</target>
+        <note>{StrBegin="MSBUILD : error MSB1002: "}UE: For example, if somebody types "msbuild.exe /nologo:1", they would get this error because the /nologo switch
+    should not be followed by any parameters ... it stands alone.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnknownSwitchError">
+        <source>MSBUILD : error MSB1001: Unknown switch.</source>
+        <target state="new">MSBUILD : error MSB1001: Unknown switch.</target>
+        <note>{StrBegin="MSBUILD : error MSB1001: "}UE: This occurs when the user passes in an unrecognized switch on the MSBuild.exe command-line.
+    LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedOS">
+        <source>MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</source>
+        <target state="new">MSBUILD : error MSB1015: MSBuild does not run on this version of the operating system. It is only supported on Windows 2000, Windows XP, and later versions.</target>
+        <note>{StrBegin="MSBUILD : error MSB1015: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Using35Engine">
+        <source>Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</source>
+        <target state="new">Forcing load of Microsoft.Build.Engine because MSBUILDOLDOM=1...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingIgnoreProjectExtensionsError">
+        <source>MSBUILD : error MSB1035: Specify the project extensions to ignore.</source>
+        <target state="new">MSBUILD : error MSB1035: Specify the project extensions to ignore.</target>
+        <note>{StrBegin="MSBUILD : error MSB1035: "}
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidExtensionToIgnore">
+        <source>MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</source>
+        <target state="new">MSBUILD : error MSB1036: There is an invalid extension in the /ignoreprojectextensions list. Extensions must start with a period ".", have one or more characters after the period and not contain any invalid path characters or wildcards.</target>
+        <note>{StrBegin="MSBUILD : error MSB1036: "}LOCALIZATION: The error prefix "MSBUILD : error MSBxxxx:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MissingConsoleLoggerParameterError">
+        <source>MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1037: Specify one or more parameters for the console logger if using the /consoleLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1037: "}
+      UE: This happens if the user does something like "msbuild.exe /consoleLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /consoleLoggerParameters:ErrorSummary".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingFileLoggerParameterError">
+        <source>MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</source>
+        <target state="new">MSBUILD : error MSB1038: Specify one or more parameters for the file logger if using the /fileLoggerParameters switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1038: "}
+      UE: This happens if the user does something like "msbuild.exe /fileLoggerParameters:". The user must pass in one or more parameters
+      after the switch e.g. "msbuild.exe /fileLoggerParameters:logfile=c:\temp\logfile".
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="MissingNodeReuseParameterError">
+        <source>MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</source>
+        <target state="new">MSBUILD : error MSB1041: Specify one or more parameters for node reuse if using the /nodereuse switch</target>
+        <note>{StrBegin="MSBUILD : error MSB1041: "}
+      UE: This happens if the user does something like "msbuild.exe /nodereuse:" without a true or false
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+     </note>
+      </trans-unit>
+      <trans-unit id="InvalidNodeReuseValue">
+        <source>MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</source>
+        <target state="new">MSBUILD : error MSB1042: Node reuse value is not valid. {0}.</target>
+        <note>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivilant to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </note>
+      </trans-unit>
+      <trans-unit id="AbortingBuild">
+        <source>Attempting to cancel the build...</source>
+        <target state="new">Attempting to cancel the build...</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidPreprocessPath">
+        <source>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1047: "}</note>
+      </trans-unit>
+      <trans-unit id="LoggerCreationError">
+        <source>MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</source>
+        <target state="new">MSBUILD : error MSB1021: Cannot create an instance of the logger. {0}</target>
+        <note>{StrBegin="MSBUILD : error MSB1021: "}
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.</note>
+      </trans-unit>
+      <trans-unit id="LoggerNotFoundError">
+        <source>MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</source>
+        <target state="new">MSBUILD : error MSB1020: The logger was not found. Check the following: 1.) The logger name specified is the same as the name of the logger class. 2.) The logger class is "public" and implements the Microsoft.Build.Framework.ILogger interface. 3.) The path to the logger assembly is correct, or the logger can be loaded using only the assembly name provided.</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1020: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies an logger that does not exist e.g. "msbuild /logger:FooLoggerClass,FooAssembly". The
+      logger class must exist in the given assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="ProjectUpgradeNeededToVcxProj">
+        <source>MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</source>
+        <target state="new">MSBUILD : error MSB4192: The project file "{0}" is in the ".vcproj" or ".dsp" file format, which MSBuild cannot build directly. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or, for ".vcproj", use MSBuild to build the solution file containing the project instead.</target>
+        <note>{StrBegin="MSBUILD : error MSB4192: "} LOC: ".vcproj" and ".dsp" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="NeedJustMyCode">
+        <source>If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</source>
+        <target state="new">If MSBuild debugging does not work correctly, please verify that the "Just My Code" feature is enabled in Visual Studio, and that you have selected the managed debugger.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DebuggingSolutionFiles">
+        <source>MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</source>
+        <target state="new">MSBUILD : error MSB1048: Solution files cannot be debugged directly. Run MSBuild first with an environment variable MSBUILDEMITSOLUTION=1 to create a corresponding ".sln.metaproj" file. Then debug that.</target>
+        <note>{StrBegin="MSBUILD : error MSB1048: "} LOC: ".SLN" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="BuildStarted">
+        <source>Build started.</source>
+        <target state="new">Build started.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FileLocation">
+        <source>{0} ({1},{2})</source>
+        <target state="new">{0} ({1},{2})</target>
+        <note>A file location to be embedded in a string.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.cs.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.cs.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.de.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.de.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.es.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.es.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.fr.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.fr.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.it.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.it.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.ja.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.ja.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.ko.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.ko.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.pl.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.pl.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.pt.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.pt.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.ru.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.ru.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.tr.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.tr.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/XMakeTasks/ManifestUtil/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/MANIFESTUTIL/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="ComImporter.LocalServerNotSupported">
+        <source>Out of process servers are not supported</source>
+        <target state="new">Out of process servers are not supported</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.MissingValue">
+        <source>Registry key '{0}' is missing value '{1}'.</source>
+        <target state="new">Registry key '{0}' is missing value '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.NoRegisteredClasses">
+        <source>No registered classes were detected for this component.</source>
+        <target state="new">No registered classes were detected for this component.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ProtectedFile">
+        <source>Components under system file protection should not be isolated.</source>
+        <target state="new">Components under system file protection should not be isolated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.TypeLibraryLoadFailure">
+        <source>Could not load type library.</source>
+        <target state="new">Could not load type library.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.SubKeyNotImported">
+        <source>Registry key '{0}' was not imported.</source>
+        <target state="new">Registry key '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ComImporter.ValueNotImported">
+        <source>Registry value '{0}' was not imported.</source>
+        <target state="new">Registry value '{0}' was not imported.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SignTargetNotFound">
+        <source>The file to be signed {0} could not be found.</source>
+        <target state="new">The file to be signed {0} could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolFail">
+        <source>Failed to sign {0}. {1}</source>
+        <target state="new">Failed to sign {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolWarning">
+        <source>Warning while signing {0}. {1}</source>
+        <target state="new">Warning while signing {0}. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.SigntoolNotFound">
+        <source>SignTool.exe was not found at path {0}.</source>
+        <target state="new">SignTool.exe was not found at path {0}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.TimestampUrlNotFound">
+        <source>Timestamp URL server name or address could not be resolved.</source>
+        <target state="new">Timestamp URL server name or address could not be resolved.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SecurityUtil.OnlyRSACertsAreAllowed">
+        <source>Only certificates using RSA encryption are valid for signing ClickOnce manifests.</source>
+        <target state="new">Only certificates using RSA encryption are valid for signing ClickOnce manifests.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="TrustInfo.RequestedExecutionLevelComment">
+        <source>
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </source>
+        <target state="new">
+          UAC Manifest Options
+          If you want to change the Windows User Account Control level replace the 
+          requestedExecutionLevel node with one of the following.
+
+        &lt;requestedExecutionLevel  level="asInvoker" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="requireAdministrator" uiAccess="false" /&gt;
+        &lt;requestedExecutionLevel  level="highestAvailable" uiAccess="false" /&gt;
+
+         If you want to utilize File and Registry Virtualization for backward 
+         compatibility then delete the requestedExecutionLevel node.
+    </target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.cs.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.cs.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.de.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.de.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.es.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.es.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.fr.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.fr.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.it.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.it.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.ja.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.ja.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.ko.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.ko.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.pl.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.pl.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.pt.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.pt.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.ru.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.ru.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.tr.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.tr.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/XMakeTasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/XMakeTasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,0 +1,2967 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
+    <body>
+      <group id="MICROSOFT.BUILD.TASKS/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="AppConfig.BindingRedirectMissingOldVersion">
+        <source>BindingRedirect is missing required field 'oldVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'oldVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.BindingRedirectMissingNewVersion">
+        <source>BindingRedirect is missing required field 'newVersion'.</source>
+        <target state="new">BindingRedirect is missing required field 'newVersion'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidAssemblyIdentityFields">
+        <source>Some attributes of the assemblyIdentity element are incorrect.</source>
+        <target state="new">Some attributes of the assemblyIdentity element are incorrect.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidOldVersionAttribute">
+        <source>There was a problem parsing the oldVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the oldVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppConfig.InvalidNewVersionAttribute">
+        <source>There was a problem parsing the newVersion attribute. {0}</source>
+        <target state="new">There was a problem parsing the newVersion attribute. {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.IllegalMappingString">
+        <source>The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</source>
+        <target state="new">The platform mapping "{0}" in the platform mapping list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "foo=bar;foo2=bar2".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION:
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="AssignProjectConfiguration.ProjectConfigurationResolutionSuccess">
+        <source>Project reference "{0}" has been assigned the "{1}" configuration.</source>
+        <target state="new">Project reference "{0}" has been assigned the "{1}" configuration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.CannotCombineMetabaseAndVirtualPathOrPhysicalPath">
+        <source>MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</source>
+        <target state="new">MSB3461: The MetabasePath parameter cannot be combined with VirtualPath or PhysicalPath.</target>
+        <note>{StrBegin="MSB3461: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingMetabasePathAndVirtualPath">
+        <source>MSB3462: Either MetabasePath or VirtualPath must be specified.</source>
+        <target state="new">MSB3462: Either MetabasePath or VirtualPath must be specified.</target>
+        <note>{StrBegin="MSB3462: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForUpdatableApplication">
+        <source>MSB3463: The TargetPath parameter must be specified if the application is updatable.</source>
+        <target state="new">MSB3463: The TargetPath parameter must be specified if the application is updatable.</target>
+        <note>{StrBegin="MSB3463: "}</note>
+      </trans-unit>
+      <trans-unit id="AspNetCompiler.MissingTargetPathForOverwrittenApplication">
+        <source>MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</source>
+        <target state="new">MSB3464: The TargetPath parameter must be specified if the target directory needs to be overwritten.</target>
+        <note>{StrBegin="MSB3464: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.CannotExtractCulture">
+        <source>MSB3001: Cannot extract culture information from file name "{0}". {1}</source>
+        <target state="new">MSB3001: Cannot extract culture information from file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3001: "}</note>
+      </trans-unit>
+      <trans-unit id="AssignCulture.Comment">
+        <source>Culture of "{0}" was assigned to file "{1}".</source>
+        <target state="new">Culture of "{0}" was assigned to file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AxImp.NoInputFileSpecified">
+        <source>MSB3656: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3656: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3656: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3646: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3646: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3646: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3647: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3647: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.InvalidKeyFileSpecified">
+        <source>MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</source>
+        <target state="new">MSB3649: The KeyFile path '{0}' is invalid. KeyFile must point to an existing file.</target>
+        <note>{StrBegin="MSB3649: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3650: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3651: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3651: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3651: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3652: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3652: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3652: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.ToolNameMustBeSet">
+        <source>MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</source>
+        <target state="new">MSB3653: AxTlbBaseTask is not an executable task. If deriving from it, please ensure the ToolName property was set.</target>
+        <note>{StrBegin="MSB3653: "}</note>
+      </trans-unit>
+      <trans-unit id="AxTlbBaseTask.StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</source>
+        <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
+        <note>{StrBegin="MSB3654: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalArguments">
+        <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
+        <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
+        <note>{StrBegin="MSB3881: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.FatalNoResponse">
+        <source>MSB3882: Fatal Error: No response from server.</source>
+        <target state="new">MSB3882: Fatal Error: No response from server.</target>
+        <note>{StrBegin="MSB3882: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnexpectedException">
+        <source>MSB3883: Unexpected exception: </source>
+        <target state="new">MSB3883: Unexpected exception: </target>
+        <note>{StrBegin="MSB3883: "}</note>
+      </trans-unit>
+      <trans-unit id="Compiler.UnableToFindRuleSet">
+        <source>MSB3884: Could not find rule set file "{0}".</source>
+        <target state="new">MSB3884: Could not find rule set file "{0}".</target>
+        <note>{StrBegin="MSB3884: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.DestinationIsDirectory">
+        <source>MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3024: Could not copy the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3024: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.DidNotCopyBecauseOfFileMatch">
+        <source>Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not copy from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.Error">
+        <source>MSB3021: Unable to copy file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3021: Unable to copy file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3021: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExactlyOneTypeOfDestination">
+        <source>MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</source>
+        <target state="new">MSB3022: Both "{0}" and "{1}" were specified as input parameters in the project file. Please choose one or the other.</target>
+        <note>{StrBegin="MSB3022: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.FileComment">
+        <source>Copying file from "{0}" to "{1}".</source>
+        <target state="new">Copying file from "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.HardLinkComment">
+        <source>Creating hard link to copy "{0}" to "{1}".</source>
+        <target state="new">Creating hard link to copy "{0}" to "{1}".</target>
+        <note>LOCALIZATION: {0} and {1} are paths.</note>
+      </trans-unit>
+      <trans-unit id="Copy.RetryingAsFileCopy">
+        <source>Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</source>
+        <target state="new">Could not use a hard link to copy "{0}" to "{1}". Copying the file instead. {2}</target>
+        <note>LOCALIZATION: {0} and {1} are paths. {2} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.NeedsDestination">
+        <source>MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3023: No destination specified for Copy. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3023: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.RemovingReadOnlyAttribute">
+        <source>Removing read-only attribute from "{0}".</source>
+        <target state="new">Removing read-only attribute from "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceIsDirectory">
+        <source>MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</source>
+        <target state="new">MSB3025: The source file "{0}" is actually a directory.  The "Copy" task does not support copying directories.</target>
+        <note>{StrBegin="MSB3025: "}</note>
+      </trans-unit>
+      <trans-unit id="Copy.Retrying">
+        <source>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</source>
+        <target state="new">MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4}</target>
+        <note>{StrBegin="MSB3026: "} LOCALIZATION: {0} and {1} are paths. {2} and {3} are numbers. {4} is an optional localized message.</note>
+      </trans-unit>
+      <trans-unit id="Copy.ExceededRetries">
+        <source>MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</source>
+        <target state="new">MSB3027: Could not copy "{0}" to "{1}". Exceeded retry count of {2}. Failed.</target>
+        <note>{StrBegin="MSB3027: "} LOCALIZATION: {0} and {1} are paths. {2} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryCount">
+        <source>MSB3028: {0} is an invalid retry count. Value must not be negative.</source>
+        <target state="new">MSB3028: {0} is an invalid retry count. Value must not be negative.</target>
+        <note>{StrBegin="MSB3028: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.InvalidRetryDelay">
+        <source>MSB3029: {0} is an invalid retry delay. Value must not be negative.</source>
+        <target state="new">MSB3029: {0} is an invalid retry delay. Value must not be negative.</target>
+        <note>{StrBegin="MSB3029: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="Copy.SourceFileNotFound">
+        <source>MSB3030: Could not copy the file "{0}" because it was not found.</source>
+        <target state="new">MSB3030: Could not copy the file "{0}" because it was not found.</target>
+        <note>{StrBegin="MSB3030: "} LOCALIZATION: {0} is a number.</note>
+      </trans-unit>
+      <trans-unit id="CreateItem.AdditionalMetadataError">
+        <source>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</source>
+        <target state="new">MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</target>
+        <note>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.AssignedName">
+        <source>Resource file '{0}' gets manifest resource name '{1}'.</source>
+        <target state="new">Resource file '{0}' gets manifest resource name '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DefinitionFoundWithinConditionalDirective">
+        <source>MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</source>
+        <target state="new">MSB3042: A namespace or class definition was found within a conditional compilation directive in the file "{0}".  This may lead to an incorrect choice for the manifest resource name for resource "{1}".</target>
+        <note>{StrBegin="MSB3042: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUpon">
+        <source>Resource file '{0}' depends on '{1}'.</source>
+        <target state="new">Resource file '{0}' depends on '{1}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.DependsUponNothing">
+        <source>Resource file '{0}' doesn't depend on any other file.</source>
+        <target state="new">Resource file '{0}' doesn't depend on any other file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.Error">
+        <source>MSB3041: Unable to create a manifest resource name for "{0}". {1}</source>
+        <target state="new">MSB3041: Unable to create a manifest resource name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3041: "}</note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.NoRootNamespace">
+        <source>Root namespace is empty.</source>
+        <target state="new">Root namespace is empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CreateManifestResourceName.RootNamespace">
+        <source>Root namespace is '{0}'.</source>
+        <target state="new">Root namespace is '{0}'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Csc.AssemblyAliasContainsIllegalCharacters">
+        <source>MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</source>
+        <target state="new">MSB3053: The assembly alias "{1}" on reference "{0}" contains illegal characters.</target>
+        <note>{StrBegin="MSB3053: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameter">
+        <source>MSB3051: The parameter to the compiler is invalid.  {0}</source>
+        <target state="new">MSB3051: The parameter to the compiler is invalid.  {0}</target>
+        <note>{StrBegin="MSB3051: "}</note>
+      </trans-unit>
+      <trans-unit id="Csc.InvalidParameterWarning">
+        <source>MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</source>
+        <target state="new">MSB3052: The parameter to the compiler is invalid, '{0}{1}' will be ignored.</target>
+        <note>{StrBegin="MSB3052: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.DeletingFile">
+        <source>Deleting file "{0}".</source>
+        <target state="new">Deleting file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Delete.Error">
+        <source>MSB3061: Unable to delete file "{0}". {1}</source>
+        <target state="new">MSB3061: Unable to delete file "{0}". {1}</target>
+        <note>{StrBegin="MSB3061: "}</note>
+      </trans-unit>
+      <trans-unit id="Delete.SkippingNonexistentFile">
+        <source>File "{0}" doesn't exist. Skipping.</source>
+        <target state="new">File "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.AllDriveLettersMappedError">
+        <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
+        <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
+        <note>{StrBegin="MSB3071: "}LOCALIZATION: "Exec", "A:", and "Z:" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailed">
+        <source>MSB3073: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3073: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3073: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedAccessDenied">
+        <source>MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3075: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3075: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.CommandFailedNoErrorCode">
+        <source>The command "{0}" exited with code {1}.</source>
+        <target state="new">The command "{0}" exited with code {1}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidRegex">
+        <source>MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</source>
+        <target state="new">MSB3076: The regular expression "{0}" that was supplied is invalid. {1}</target>
+        <note>{StrBegin="MSB3076: "}</note>
+      </trans-unit>
+      <trans-unit id="Exec.MissingCommandError">
+        <source>MSB3072: The "Exec" task needs a command to execute.</source>
+        <target state="new">MSB3072: The "Exec" task needs a command to execute.</target>
+        <note>{StrBegin="MSB3072: "}LOCALIZATION: "Exec" should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Exec.InvalidWorkingDirectory">
+        <source>The working directory "{0}" does not exist.</source>
+        <target state="new">The working directory "{0}" does not exist.</target>
+        <note>No error code because an error will be prefixed.</note>
+      </trans-unit>
+      <trans-unit id="FindInList.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindInList.InvalidPath">
+        <source>"{0}" is not a valid file name. {1}</source>
+        <target state="new">"{0}" is not a valid file name. {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.ComparisonPath">
+        <source>Comparison path is "{0}".</source>
+        <target state="new">Comparison path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="FindUnderPath.InvalidParameter">
+        <source>MSB3541: {0} has invalid value "{1}". {2}</source>
+        <target state="new">MSB3541: {0} has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3541: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotDeleteStateFile">
+        <source>MSB3102: Could not delete state file "{0}". {1}</source>
+        <target state="new">MSB3102: Could not delete state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3102: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotLocateAssembly">
+        <source>Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</source>
+        <target state="new">Could not locate the assembly "{0}". Check to make sure the assembly exists on disk.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFile">
+        <source>MSB3088: Could not read state file "{0}". {1}</source>
+        <target state="new">MSB3088: Could not read state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3088: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotReadStateFileMessage">
+        <source>Could not read state file "{0}". {1}</source>
+        <target state="new">Could not read state file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotSetHostObjectParameter">
+        <source>MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</source>
+        <target state="new">MSB3081: A problem occurred while trying to set the "{0}" parameter for the IDE's in-process compiler. {1}</target>
+        <note>{StrBegin="MSB3081: "}</note>
+      </trans-unit>
+      <trans-unit id="General.CouldNotWriteStateFile">
+        <source>MSB3101: Could not write state file "{0}". {1}</source>
+        <target state="new">MSB3101: Could not write state file "{0}". {1}</target>
+        <note>{StrBegin="MSB3101: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupported">
+        <source>MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</source>
+        <target state="new">MSB3105: The item "{0}" was specified more than once in the "{1}" parameter.  Duplicate items are not supported by the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3105: "}</note>
+      </trans-unit>
+      <trans-unit id="General.DuplicateItemsNotSupportedWithMetadata">
+        <source>MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</source>
+        <target state="new">MSB3083: The item "{0}" was specified more than once in the "{1}" parameter and both items had the same value "{2}" for the "{3}" metadata.  Duplicate items are not supported by the "{1}" parameter unless they have different values for the "{3}" metadata.</target>
+        <note>{StrBegin="MSB3083: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ErrorExecutingTask">
+        <source>MSB3108: Error executing the {0} task. {1}</source>
+        <target state="new">MSB3108: Error executing the {0} task. {1}</target>
+        <note>{StrBegin="MSB3108: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileGotDirectory">
+        <source>Expected a file but got directory "{0}".</source>
+        <target state="new">Expected a file but got directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ExpectedFileMissing">
+        <source>Expected file "{0}" does not exist.</source>
+        <target state="new">Expected file "{0}" does not exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.FrameworksFileNotFound">
+        <source>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</source>
+        <target state="new">MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</target>
+        <note>{StrBegin="MSB3082: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncorrectHostObject">
+        <source>MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</source>
+        <target state="new">MSB3087: An incompatible host object was passed into the "{0}" task.  The host object for this task must implement the "{1}" interface.</target>
+        <note>{StrBegin="MSB3087: "}</note>
+      </trans-unit>
+      <trans-unit id="General.IncompatibleStateFileType">
+        <source>The format of this state file is not valid.</source>
+        <target state="new">The format of this state file is not valid.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAttributeMetadata">
+        <source>Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</source>
+        <target state="new">Item "{0}" has attribute "{1}" with value "{2}" that could not be converted to "{3}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidArgument">
+        <source>MSB3095: Invalid argument. {0}</source>
+        <target state="new">MSB3095: Invalid argument. {0}</target>
+        <note>{StrBegin="MSB3095: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssembly">
+        <source>MSB3097: File "{0}" is not a valid assembly.</source>
+        <target state="new">MSB3097: File "{0}" is not a valid assembly.</target>
+        <note>{StrBegin="MSB3097: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidValue">
+        <source>MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</source>
+        <target state="new">MSB3098: "{1}" task received an invalid value for the "{0}" parameter.</target>
+        <note>{StrBegin="MSB3098: "}</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidAssemblyName">
+        <source>MSB3099: Invalid assembly name "{0}". {1}</source>
+        <target state="new">MSB3099: Invalid assembly name "{0}". {1}</target>
+        <note>{StrBegin="MSB3099: "}UE: This message is shown when RegisterAssembly or UnregisterAssembly is passed an assembly with an invalid filename. "{0}" is the name of the file, and "{1}" is a message explaining the problem. LOCALIZATION: "{1}" is a localized message.</note>
+      </trans-unit>
+      <trans-unit id="General.InvalidPropertyError">
+        <source>MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</source>
+        <target state="new">MSB3100: Syntax for "{0}" parameter is not valid ({1}). Correct syntax is {0}="&lt;name&gt;=&lt;value&gt;".</target>
+        <note>{StrBegin="MSB3100: "}This error is shown if the user does any of the following:
+    Properties="foo"              (missing property value)
+    Properties="=4"               (missing property name)
+    The user must pass in an actual property name and value, as in Properties="Configuration=Debug".</note>
+      </trans-unit>
+      <trans-unit id="General.GlobalProperties">
+        <source>Global Properties:</source>
+        <target state="new">Global Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.UndefineProperties">
+        <source>Removing Properties:</source>
+        <target state="new">Removing Properties:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.OverridingProperties">
+        <source>Overriding Global Properties for project "{0}" with:</source>
+        <target state="new">Overriding Global Properties for project "{0}" with:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.AdditionalProperties">
+        <source>Additional Properties for project "{0}":</source>
+        <target state="new">Additional Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.ProjectUndefineProperties">
+        <source>Removing Properties for project "{0}":</source>
+        <target state="new">Removing Properties for project "{0}":</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.InvalidResxFile">
+        <source>MSB3103: Invalid Resx file. {0}</source>
+        <target state="new">MSB3103: Invalid Resx file. {0}</target>
+        <note>{StrBegin="MSB3103: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MalformedAssemblyName">
+        <source>MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</source>
+        <target state="new">MSB3106: Assembly strong name "{0}" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).</target>
+        <note>{StrBegin="MSB3106: "}</note>
+      </trans-unit>
+      <trans-unit id="General.MissingOrUnknownProjectReferenceAttribute">
+        <source>MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</source>
+        <target state="new">MSB3107: The specified project reference metadata for the reference "{0}" is missing or has an invalid value: {1}</target>
+        <note>{StrBegin="MSB3107: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ParameterUnsupportedOnHostCompiler">
+        <source>The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</source>
+        <target state="new">The IDE's in-process compiler does not support the specified values for the "{0}" parameter.  Therefore, this task will fallback to using the command-line compiler.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFound">
+        <source>MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</source>
+        <target state="new">MSB3091: Task failed because "{0}" was not found, or the correct Microsoft Windows SDK is not installed. The task is looking for "{0}" in the "bin" subdirectory beneath the location specified in the {1} value of the registry key {2}. You may be able to solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.  4) Pass the correct location into the "ToolPath" parameter of the task.</target>
+        <note>{StrBegin="MSB3091: "}</note>
+      </trans-unit>
+      <trans-unit id="General.PlatformSDKFileNotFoundSdkToolsPath">
+        <source>MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</source>
+        <target state="new">MSB3084: Task attempted to find "{0}" in two locations. 1) Under the "{1}" processor specific directory which is generated based on SdkToolsPath 2) The x86 specific directory under "{2}" which is specified by the SDKToolsPath property. You may be able to solve the problem by doing one of the following:  1) Set the "SDKToolsPath" property to the location of the Microsoft Windows SDK.</target>
+        <note>{StrBegin="MSB3084: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathNotSpecifiedOrToolDoesNotExist">
+        <source>Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</source>
+        <target state="new">Task attempted to find "{0}" using the SdkToolsPath value "{1}". Make sure the SdkToolsPath is set to the correct value and the tool exists in the correct processor specific location below it.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathToolDoesNotExist">
+        <source>MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</source>
+        <target state="new">MSB3086: Task could not find "{0}" using the SdkToolsPath "{1}" or the registry key "{2}". Make sure the SdkToolsPath is set and the tool exists in the correct processor specific location under the SdkToolsPath and that the Microsoft Windows SDK is installed</target>
+        <note>{StrBegin="MSB3086: "}</note>
+      </trans-unit>
+      <trans-unit id="General.SdkToolsPathError">
+        <source>MSB3666: The SDK tool "{0}" could not be found. {1}</source>
+        <target state="new">MSB3666: The SDK tool "{0}" could not be found. {1}</target>
+        <note>{StrBegin="MSB3666: "} The {1} will be the exception message</note>
+      </trans-unit>
+      <trans-unit id="General.ReferenceDoesNotExist">
+        <source>MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</source>
+        <target state="new">MSB3104: The referenced assembly "{0}" was not found. If this assembly is produced by another one of your projects, please make sure to build that project before building this one.</target>
+        <note>{StrBegin="MSB3104: "}</note>
+      </trans-unit>
+      <trans-unit id="General.ToolCommandFailed">
+        <source>MSB3093: The command exited with code {0}.</source>
+        <target state="new">MSB3093: The command exited with code {0}.</target>
+        <note>{StrBegin="MSB3093: "}</note>
+      </trans-unit>
+      <trans-unit id="General.TwoVectorsMustHaveSameLength">
+        <source>MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</source>
+        <target state="new">MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items.</target>
+        <note>{StrBegin="MSB3094: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingConfigurationNode">
+        <source>MSB3831: The application configuration file must have root configuration element.</source>
+        <target state="new">MSB3831: The application configuration file must have root configuration element.</target>
+        <note>{StrBegin="MSB3831: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedVersionNumber">
+        <source>MSB3832: The version number "{0}" is invalid.</source>
+        <target state="new">MSB3832: The version number "{0}" is invalid.</target>
+        <note>{StrBegin="MSB3832: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MalformedAssemblyName">
+        <source>MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</source>
+        <target state="new">MSB3833: The assembly name "{0}" contained in the suggested binding redirect is invalid.</target>
+        <note>{StrBegin="MSB3833: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.NoSuggestedRedirects">
+        <source>No suggested binding redirects from ResolveAssemblyReferences.</source>
+        <target state="new">No suggested binding redirects from ResolveAssemblyReferences.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.MissingNode">
+        <source>MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</source>
+        <target state="new">MSB3835: The "{0}" node is missing from the "{1}" node. Skipping.</target>
+        <note>{StrBegin="MSB3835: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.OverlappingBindingRedirect">
+        <source>MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</source>
+        <target state="new">MSB3836: The explicit binding redirect on "{0}" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "{1}".</target>
+        <note>{StrBegin="MSB3836: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBindingRedirects.ProcessingSuggestedRedirect">
+        <source>Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</source>
+        <target state="new">Processing suggested binding redirect on "{0}" with MaxVersion "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CircularDependency">
+        <source>MSB3161: A circular dependency was detected between the following built packages: {0}.</source>
+        <target state="new">MSB3161: A circular dependency was detected between the following built packages: {0}.</target>
+        <note>{StrBegin="MSB3161: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyError">
+        <source>MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</source>
+        <target state="new">MSB3142: An error occurred trying to copy '{0}' to '{1}': {2}</target>
+        <note>{StrBegin="MSB3142: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.CopyPackageError">
+        <source>MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</source>
+        <target state="new">MSB3143: An error occurred trying to copy '{0}' for item '{1}': {2}</target>
+        <note>{StrBegin="MSB3143: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DependencyNotFound">
+        <source>MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</source>
+        <target state="new">MSB3162: The '{0}' item selected requires '{1}'. Select the missing prerequisite in the Prerequisites Dialog Box or create a bootstrapper package for the missing prerequisite.</target>
+        <note>{StrBegin="MSB3162: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DifferingPublicKeys">
+        <source>MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</source>
+        <target state="new">MSB3165: The value of the '{0}' attribute in '{1}' does not match that of file '{2}'.</target>
+        <note>{StrBegin="MSB3165: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.DuplicateItems">
+        <source>MSB3168: Duplicate item '{0}' will be ignored.</source>
+        <target state="new">MSB3168: Duplicate item '{0}' will be ignored.</target>
+        <note>{StrBegin="MSB3168: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.General">
+        <source>MSB3169: An error occurred generating a bootstrapper: {0}</source>
+        <target state="new">MSB3169: An error occurred generating a bootstrapper: {0}</target>
+        <note>{StrBegin="MSB3169: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.IncludedProductIncluded">
+        <source>MSB3151: Item '{0}' already includes '{1}'.</source>
+        <target state="new">MSB3151: Item '{0}' already includes '{1}'.</target>
+        <note>{StrBegin="MSB3151: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidComponentsLocation">
+        <source>MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</source>
+        <target state="new">MSB3163: Build input parameter 'ComponentsLocation={0}' is not valid. The value must be one of 'HomeSite', 'Relative', or 'Absolute'. Defaulting to 'HomeSite'.</target>
+        <note>{StrBegin="MSB3163: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidInput">
+        <source>MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</source>
+        <target state="new">MSB3144: Not enough data was provided to generate a bootstrapper. Please provide a value for at least one of the parameters: 'ApplicationFile' or 'BootstrapperItems'.</target>
+        <note>{StrBegin="MSB3144: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.InvalidUrl">
+        <source>MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</source>
+        <target state="new">MSB3145: Build input parameter '{0}={1}' is not a web url or UNC share.</target>
+        <note>{StrBegin="MSB3145: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependency">
+        <source>MSB3146: Item '{0}' is required by '{1}', but was not included.</source>
+        <target state="new">MSB3146: Item '{0}' is required by '{1}', but was not included.</target>
+        <note>{StrBegin="MSB3146: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingDependencyMultiple">
+        <source>MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</source>
+        <target state="new">MSB3696: One of the following items '{0}' is required by '{1}', but none were included.</target>
+        <note>{StrBegin="MSB3696: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingSetupBin">
+        <source>MSB3147: Could not find required file '{0}' in '{1}'.</source>
+        <target state="new">MSB3147: Could not find required file '{0}' in '{1}'.</target>
+        <note>{StrBegin="MSB3147: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MissingVerificationInformation">
+        <source>MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</source>
+        <target state="new">MSB3141: No 'PublicKey' or 'Hash' attribute specified for file '{0}' in item '{1}'.</target>
+        <note>{StrBegin="MSB3141: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.MultipleDependeciesNotFound">
+        <source>MSB3170: Item '{0}' could not find any of dependent items '{1}'.</source>
+        <target state="new">MSB3170: Item '{0}' could not find any of dependent items '{1}'.</target>
+        <note>{StrBegin="MSB3170: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoOutputPath">
+        <source>MSB3148: No output path specified in build settings.</source>
+        <target state="new">MSB3148: No output path specified in build settings.</target>
+        <note>{StrBegin="MSB3148: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoResources">
+        <source>MSB3149: No resources available for building a bootstrapper.</source>
+        <target state="new">MSB3149: No resources available for building a bootstrapper.</target>
+        <note>{StrBegin="MSB3149: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.NoStringsForCulture">
+        <source>MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</source>
+        <target state="new">MSB3150: No string resources available for building a bootstrapper with culture '{0}'.</target>
+        <note>{StrBegin="MSB3150: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageFileNotFound">
+        <source>MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</source>
+        <target state="new">MSB3152: To enable 'Download prerequisites from the same location as my application' in the Prerequisites dialog box, you must download file '{0}' for item '{1}' to your local machine. For more information, see http://go.microsoft.com/fwlink/?LinkId=616018.</target>
+        <note>{StrBegin="MSB3152: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageResourceFileNotFound">
+        <source>MSB3166: Could not find required file '{0}' for item '{1}'.</source>
+        <target state="new">MSB3166: Could not find required file '{0}' for item '{1}'.</target>
+        <note>{StrBegin="MSB3166: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageHomeSiteMissing">
+        <source>MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</source>
+        <target state="new">MSB3164: No 'HomeSite' attribute has been provided for '{0}', so the package will be published to the same location as the bootstrapper.</target>
+        <note>{StrBegin="MSB3164: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.PackageValidation">
+        <source>MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3153: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3153: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductCultureNotFound">
+        <source>MSB3154: Could not find string resources for item '{0}'.</source>
+        <target state="new">MSB3154: Could not find string resources for item '{0}'.</target>
+        <note>{StrBegin="MSB3154: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductNotFound">
+        <source>MSB3155: Item '{0}' could not be located in '{1}'.</source>
+        <target state="new">MSB3155: Item '{0}' could not be located in '{1}'.</target>
+        <note>{StrBegin="MSB3155: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ProductValidation">
+        <source>MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</source>
+        <target state="new">MSB3156: Xml validation did not pass for item '{0}' located at '{1}'.</target>
+        <note>{StrBegin="MSB3156: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingProductCulture">
+        <source>MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</source>
+        <target state="new">MSB3157: Could not match culture '{0}' for item '{1}'. Using culture '{2}' instead.</target>
+        <note>{StrBegin="MSB3157: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.UsingResourcesCulture">
+        <source>MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</source>
+        <target state="new">MSB3158: Could not find resources for culture '{0}'. Using culture '{1}' instead.</target>
+        <note>{StrBegin="MSB3158: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationError">
+        <source>MSB3159: Xml Validation error in file '{0}': {1}</source>
+        <target state="new">MSB3159: Xml Validation error in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3159: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateBootstrapper.ValidationWarning">
+        <source>MSB3160: Xml Validation warning in file '{0}': {1}</source>
+        <target state="new">MSB3160: Xml Validation warning in file '{0}': {1}</target>
+        <note>{StrBegin="MSB3160: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AllowPartiallyTrustedCallers">
+        <source>MSB3177: Reference '{0}' does not allow partially trusted callers.</source>
+        <target state="new">MSB3177: Reference '{0}' does not allow partially trusted callers.</target>
+        <note>{StrBegin="MSB3177: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.AssemblyAsFile">
+        <source>MSB3178: Assembly '{0}' is incorrectly specified as a file.</source>
+        <target state="new">MSB3178: Assembly '{0}' is incorrectly specified as a file.</target>
+        <note>{StrBegin="MSB3178: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ComImport">
+        <source>MSB3179: Problem isolating COM reference '{0}': {1}</source>
+        <target state="new">MSB3179: Problem isolating COM reference '{0}': {1}</target>
+        <note>{StrBegin="MSB3179: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ConfigBindingRedirectsWithPartialTrust">
+        <source>MSB3111: Use of app.config binding redirects requires full trust.</source>
+        <target state="new">MSB3111: Use of app.config binding redirects requires full trust.</target>
+        <note>{StrBegin="MSB3111: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateAssemblyIdentity">
+        <source>MSB3112: Two or more assemblies have the same identity '{0}'.</source>
+        <target state="new">MSB3112: Two or more assemblies have the same identity '{0}'.</target>
+        <note>{StrBegin="MSB3112: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateComDefinition">
+        <source>MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</source>
+        <target state="new">MSB3180: COM component '{1}' is defined in both '{3}' and '{4}', {0}="{2}".</target>
+        <note>{StrBegin="MSB3180: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.DuplicateTargetPath">
+        <source>MSB3181: Two or more files have the same target path '{0}'.</source>
+        <target state="new">MSB3181: Two or more files have the same target path '{0}'.</target>
+        <note>{StrBegin="MSB3181: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationDefaultIconNotInstalled">
+        <source>MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</source>
+        <target state="new">MSB3127: The default icon {0} could not be found in the current file references or is not part of the required download group. The default icon file name is case sensitive so the file name referenced in the application manifest must exactly match the icon's file name.</target>
+        <note>{StrBegin="MSB3127: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionMissingLeadDot">
+        <source>MSB3119: File association extensions must start with a period character (.).</source>
+        <target state="new">MSB3119: File association extensions must start with a period character (.).</target>
+        <note>{StrBegin="MSB3119: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationExtensionTooLong">
+        <source>MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</source>
+        <target state="new">MSB3120: File association extension '{0}' exceeds the maximum allowed length of {1}.</target>
+        <note>{StrBegin="MSB3120: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationMissingAttribute">
+        <source>MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</source>
+        <target state="new">MSB3121: The file association element in the application manifest is missing one or more of the following required attributes: extension, description, progid, or default icon.</target>
+        <note>{StrBegin="MSB3121: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsApplicationNotFullTrust">
+        <source>MSB3122: Use of file associations requires full trust.</source>
+        <target state="new">MSB3122: Use of file associations requires full trust.</target>
+        <note>{StrBegin="MSB3122: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsCountExceedsMaximum">
+        <source>MSB3123: The number of file associations exceeds the limit of {0}.</source>
+        <target state="new">MSB3123: The number of file associations exceeds the limit of {0}.</target>
+        <note>{StrBegin="MSB3123: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsDuplicateExtensions">
+        <source>MSB3124: A file association has already been created for extension '{0}'.</source>
+        <target state="new">MSB3124: A file association has already been created for extension '{0}'.</target>
+        <note>{StrBegin="MSB3124: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNoEntryPoint">
+        <source>MSB3125: The application is using file associations but has no EntryPoint build parameter.</source>
+        <target state="new">MSB3125: The application is using file associations but has no EntryPoint build parameter.</target>
+        <note>{StrBegin="MSB3125: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.FileAssociationsNotInstalled">
+        <source>MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</source>
+        <target state="new">MSB3126: The application is using file associations but is not marked for installation. File associations cannot be used for applications that are not installed such as applications hosted in a web browser.</target>
+        <note>{StrBegin="MSB3126: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.General">
+        <source>MSB3171: Problem generating manifest. {0}</source>
+        <target state="new">MSB3171: Problem generating manifest. {0}</target>
+        <note>{StrBegin="MSB3171: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.GreaterMinimumRequiredVersion">
+        <source>MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</source>
+        <target state="new">MSB3176: Specified minimum required version is greater than the current publish version. Please specify a version less than or equal to the current publish version.</target>
+        <note>{StrBegin="MSB3176: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserInvalidFrameworkVersion">
+        <source>MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</source>
+        <target state="new">MSB3117: Application is set to host in browser but the TargetFrameworkVersion is set to v2.0.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.HostInBrowserNotOnlineOnly">
+        <source>MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</source>
+        <target state="new">MSB3116: Application is marked to host in browser but is also marked for online and offline use. Please change your application to online only.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.IdentityFileNameMismatch">
+        <source>MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</source>
+        <target state="new">MSB3110: Assembly '{0}' has mismatched identity '{1}', expected file name: '{2}'.</target>
+        <note>{StrBegin="MSB3110: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidEntryPoint">
+        <source>MSB3115: File '{0}' is not a valid entry point.</source>
+        <target state="new">MSB3115: File '{0}' is not a valid entry point.</target>
+        <note>{StrBegin="MSB3115: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidInputManifest">
+        <source>MSB3184: Input manifest is invalid.</source>
+        <target state="new">MSB3184: Input manifest is invalid.</target>
+        <note>{StrBegin="MSB3184: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ExcludedPermissionsNotSupported">
+        <source>MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3133: The ExcludePermissions property is deprecated. The permission set requested by the application has been set to the permissions defined in Internet or Local Intranet zone. To continue using a custom Permission Set, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3133: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.KnownTargetZoneCannotHaveAdditionalPermissionType">
+        <source>MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</source>
+        <target state="new">MSB3134: The permission set requested by the application exceeded the permissions allowed by the Internet or Intranet zones. Select Full Trust or to continue using partial trust, define your custom permission set in the Security Page of the Project Designer.</target>
+        <note>{StrBegin="MSB3134: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoPermissionSetForTargetZone">
+        <source>MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</source>
+        <target state="new">MSB3135: The PermissionSet for the target zone has not been defined for the following version of the .NET Framework: {0}.</target>
+        <note>{StrBegin="MSB3135: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidItemValue">
+        <source>MSB3175: Invalid value for '{0}' of item '{1}'.</source>
+        <target state="new">MSB3175: Invalid value for '{0}' of item '{1}'.</target>
+        <note>{StrBegin="MSB3175: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidValue">
+        <source>MSB3174: Invalid value for '{0}'.</source>
+        <target state="new">MSB3174: Invalid value for '{0}'.</target>
+        <note>{StrBegin="MSB3174: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidDeploymentProvider">
+        <source>MSB3189: The update location for this application is a local path.</source>
+        <target state="new">MSB3189: The update location for this application is a local path.</target>
+        <note>{StrBegin="MSB3189: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoEntryPoint">
+        <source>MSB3185: EntryPoint not specified for manifest.</source>
+        <target state="new">MSB3185: EntryPoint not specified for manifest.</target>
+        <note>{StrBegin="MSB3185: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.NoIdentity">
+        <source>MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</source>
+        <target state="new">MSB3186: Unable to infer an assembly identity for generated manifest from task input parameters.</target>
+        <note>{StrBegin="MSB3186: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PlatformMismatch">
+        <source>MSB3187: Referenced assembly '{0}' targets a different processor than the application.</source>
+        <target state="new">MSB3187: Referenced assembly '{0}' targets a different processor than the application.</target>
+        <note>{StrBegin="MSB3187: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.PrerequisiteNotSigned">
+        <source>MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</source>
+        <target state="new">MSB3188: Assembly '{0}' must be strong signed in order to be marked as a prerequisite.</target>
+        <note>{StrBegin="MSB3188: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ReadInputManifestFailed">
+        <source>MSB3172: Unable to read manifest '{0}'. {1}</source>
+        <target state="new">MSB3172: Unable to read manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3172: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadOnlyMode">
+        <source>MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</source>
+        <target state="new">MSB3114: Could not find file '{0}' referenced by assembly '{1}'.</target>
+        <note>{StrBegin="MSB3114: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ResolveFailedInReadWriteMode">
+        <source>MSB3113: Could not find file '{0}'.</source>
+        <target state="new">MSB3113: Could not find file '{0}'.</target>
+        <note>{StrBegin="MSB3113: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.ManifestsSignedHashExcluded">
+        <source>MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</source>
+        <target state="new">MSB3128: The ClickOnce manifests cannot be signed because they contain one or more references that are not hashed.</target>
+        <note>{StrBegin="MSB3128: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.TargetPathTooLong">
+        <source>MSB3182: File name '{0}' exceeds {1} characters.</source>
+        <target state="new">MSB3182: File name '{0}' exceeds {1} characters.</target>
+        <note>{StrBegin="MSB3182: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.UnmanagedCodePermission">
+        <source>MSB3183: Reference '{0}' is an interop assembly requiring full trust.</source>
+        <target state="new">MSB3183: Reference '{0}' is an interop assembly requiring full trust.</target>
+        <note>{StrBegin="MSB3183: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.WriteOutputManifestFailed">
+        <source>MSB3173: Unable to write manifest '{0}'. {1}</source>
+        <target state="new">MSB3173: Unable to write manifest '{0}'. {1}</target>
+        <note>{StrBegin="MSB3173: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateManifest.InvalidRequestedExecutionLevel">
+        <source>MSB3190: ClickOnce does not support the request execution level '{0}'.</source>
+        <target state="new">MSB3190: ClickOnce does not support the request execution level '{0}'.</target>
+        <note>{StrBegin="MSB3190: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ResourceNotFound">
+        <source>MSB3552: Resource file "{0}" cannot be found.</source>
+        <target state="new">MSB3552: Resource file "{0}" cannot be found.</target>
+        <note>{StrBegin="MSB3552: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidFilename">
+        <source>MSB3553: Resource file "{0}" has an invalid name. {1}</source>
+        <target state="new">MSB3553: Resource file "{0}" has an invalid name. {1}</target>
+        <note>{StrBegin="MSB3553: "}Appears if the input file name is so invalid we can't change the file extension on it.</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteOutput">
+        <source>MSB3554: Cannot write to the output file "{0}". {1}</source>
+        <target state="new">MSB3554: Cannot write to the output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3554: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CorruptOutput">
+        <source>MSB3555: Output file "{0}" is possibly corrupt.</source>
+        <target state="new">MSB3555: Output file "{0}" is possibly corrupt.</target>
+        <note>{StrBegin="MSB3555: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.OnlyStringsSupported">
+        <source>MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</source>
+        <target state="new">MSB3556: Only strings can be written to a .txt file, resource "{0}" is type {1}.</target>
+        <note>{StrBegin="MSB3556: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ErrorFromCodeDom">
+        <source>MSB3557: Error(s) generating strongly typed resources for file "{0}".</source>
+        <target state="new">MSB3557: Error(s) generating strongly typed resources for file "{0}".</target>
+        <note>{StrBegin="MSB3557: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnknownFileExtension">
+        <source>MSB3558: Unsupported file extension "{0}" on file "{1}".</source>
+        <target state="new">MSB3558: Unsupported file extension "{0}" on file "{1}".</target>
+        <note>{StrBegin="MSB3558: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRCodeDomProviderFailed">
+        <source>MSB3559: The code DOM provider for the "{0}" language failed. {1}</source>
+        <target state="new">MSB3559: The code DOM provider for the "{0}" language failed. {1}</target>
+        <note>{StrBegin="MSB3559: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DeleteCorruptOutputFailed">
+        <source>MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</source>
+        <target state="new">MSB3560: Could not delete the possibly corrupt output file "{0}". {1}</target>
+        <note>{StrBegin="MSB3560: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ObsoleteStringsTag">
+        <source>MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</source>
+        <target state="new">MSB3562: The "[strings]" tag is no longer necessary in text resources; please remove it.</target>
+        <note>{StrBegin="MSB3562: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnexpectedInfBracket">
+        <source>MSB3563: Unsupported square bracket keyword, "{0}".</source>
+        <target state="new">MSB3563: Unsupported square bracket keyword, "{0}".</target>
+        <note>{StrBegin="MSB3563: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoEqualsInLine">
+        <source>MSB3564: Resource line without an equals sign, "{0}".</source>
+        <target state="new">MSB3564: Resource line without an equals sign, "{0}".</target>
+        <note>{StrBegin="MSB3564: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoNameInLine">
+        <source>MSB3565: Resource line without a name.</source>
+        <target state="new">MSB3565: Resource line without a name.</target>
+        <note>{StrBegin="MSB3565: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidEscape">
+        <source>MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</source>
+        <target state="new">MSB3566: Unsupported or invalid escape character in resource "{0}", char '{1}'.</target>
+        <note>{StrBegin="MSB3566: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CodeDomError">
+        <source>MSB3567: Could not generate property on class "{0}".</source>
+        <target state="new">MSB3567: Could not generate property on class "{0}".</target>
+        <note>{StrBegin="MSB3567: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CouldNotLoadType">
+        <source>Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</source>
+        <target state="new">Could not load type {0} which is used in the .RESX file.  Ensure that the necessary references have been added to your project.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateResourceName">
+        <source>MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</source>
+        <target state="new">MSB3568: Duplicate resource name "{0}" is not allowed, ignored.</target>
+        <note>{StrBegin="MSB3568: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.InvalidHexEscapeValue">
+        <source>MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</source>
+        <target state="new">MSB3569: Invalid hex value after '\u' in resource "{0}", value '{1}'.</target>
+        <note>{StrBegin="MSB3569: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteSTRFile">
+        <source>MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</source>
+        <target state="new">MSB3570: Cannot write to the Strongly Typed Resource class file "{0}". {1}</target>
+        <note>{StrBegin="MSB3570: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3572: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3572: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3573: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3573: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MessageTunnel">
+        <source>{0}</source>
+        <target state="new">{0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ProcessingFile">
+        <source>Processing resource file "{0}" into "{1}".</source>
+        <target state="new">Processing resource file "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExtractingResWFiles">
+        <source>Extracting .ResW files from assembly "{0}" into "{1}".</source>
+        <target state="new">Extracting .ResW files from assembly "{0}" into "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SkippingExtractingFromNonSupportedFramework">
+        <source>Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</source>
+        <target state="new">Skipping extracting .ResW files from assembly "{0}" because it declares non-supported framework "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ReadResourceMessage">
+        <source>Processing {0} resources from file "{1}".</source>
+        <target state="new">Processing {0} resources from file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingSTR">
+        <source>Creating strongly typed resources class "{0}".</source>
+        <target state="new">Creating strongly typed resources class "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoSources">
+        <source>No resources specified in "Sources". Skipping resource generation.</source>
+        <target state="new">No resources specified in "Sources". Skipping resource generation.</target>
+        <note>
+            LOCALIZATION: Please don't localize "Sources" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NothingOutOfDate">
+        <source>No resources are out of date with respect to their source files. Skipping resource generation.</source>
+        <target state="new">No resources are out of date with respect to their source files. Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.AdditionalInputNewerThanTLog">
+        <source>Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</source>
+        <target state="new">Additional input "{0}" has been updated since the last build.  Forcing regeneration of all resources.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue">
+        <source>Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</source>
+        <target state="new">Creating a separate AppDomain because "NeverLockTypeAssemblies" evaluated to 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfErrorDeserializingLineNumber">
+        <source>Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</source>
+        <target state="new">Creating a separate AppDomain because while parsing "{0}" the serialized type "{1}" on line {2} could not be loaded. {3}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfException">
+        <source>Creating a separate AppDomain because of error parsing "{0}". {1}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfExceptionLineNumber">
+        <source>Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</source>
+        <target state="new">Creating a separate AppDomain because of error parsing "{0}" on line {1}. {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfMimeType">
+        <source>Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" representing a serialized type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SeparateAppDomainBecauseOfType">
+        <source>Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</source>
+        <target state="new">Creating a separate AppDomain because of resource "{0}" of type "{1}" in "{2}" on line {3}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.BadImageFormat">
+        <source>MSB3574: Did not recognize "{0}" as a managed assembly.</source>
+        <target state="new">MSB3574: Did not recognize "{0}" as a managed assembly.</target>
+        <note>{StrBegin="MSB3574: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotWriteAssembly">
+        <source>MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</source>
+        <target state="new">MSB3575: GenerateResource cannot write assemblies, only read from them. Cannot create assembly "{0}".</target>
+        <note>{StrBegin="MSB3575: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CreatingCultureInfoFailed">
+        <source>MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</source>
+        <target state="new">MSB3576: Creating the CultureInfo failed for assembly "{2}". Note the set of cultures supported is Operating System-dependent, and the Operating System has removed some cultures from time to time (ie, some Serbian cultures are split up in Windows 7).  The culture may be a user-defined custom culture that we can't currently load on this machine.  Exception info: {0}: {1}</target>
+        <note>{StrBegin="MSB3576: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.DuplicateOutputFilenames">
+        <source>MSB3577: Two output file names resolved to the same output path: "{0}"</source>
+        <target state="new">MSB3577: Two output file names resolved to the same output path: "{0}"</target>
+        <note>{StrBegin="MSB3577: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NeutralityOfCultureNotPreserved">
+        <source>MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</source>
+        <target state="new">MSB3578: This assembly contains neutral resources corresponding to the culture "{0}". These resources will not be considered neutral in the output format as we are unable to preserve this information. The resources will continue to correspond to "{0}" in the output format.</target>
+        <note>{StrBegin="MSB3578: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.NoResourcesFileInAssembly">
+        <source>MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</source>
+        <target state="new">MSB3579: Couldn't find the linked resources file "{0}" listed in the assembly manifest.</target>
+        <note>{StrBegin="MSB3579: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteOrMalformedAssembly">
+        <source>MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</source>
+        <target state="new">MSB3580: The assembly in file "{0}" has an assembly culture, indicating it is a satellite assembly for culture "{1}".  But satellite assembly simple names must end in ".resources", while this one's simple name is "{2}".  This is either a main assembly with the culture incorrectly set, or a satellite assembly with an incorrect simple name.</target>
+        <note>{StrBegin="MSB3580: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsCode">
+        <source>MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</source>
+        <target state="new">MSB3811: The assembly "{0}" says it is a satellite assembly, but it contains code. Main assemblies shouldn't specify the assembly culture in their manifest, and satellites should not contain code.  This is almost certainly an error in your build process.</target>
+        <note>{StrBegin="MSB3811: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.SatelliteAssemblyContainsNoResourcesFile">
+        <source>MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</source>
+        <target state="new">MSB3812: This assembly claims to be a satellite assembly, but doesn't contain any properly named .resources files as manifest resources. The name of the files should end in {0}.resources.  There is probably a build-related problem with this assembly.</target>
+        <note>{StrBegin="MSB3812: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.UnrecognizedUltimateResourceFallbackLocation">
+        <source>MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</source>
+        <target state="new">MSB3813: Invalid or unrecognized UltimateResourceFallbackLocation value in the NeutralResourcesLanguageAttribute for assembly "{1}". Location: "{0}"</target>
+        <note>{StrBegin="MSB3813: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltMainAssembly">
+        <source>MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</source>
+        <target state="new">MSB3814: Main assembly "{1}" was built improperly. The manifest resource "{0}" ends in .en-US.resources, when it should end in .resources. Either rename it to something like foo.resources (and consider using the NeutralResourcesLanguageAttribute on the main assembly), or move it to a US English satellite assembly.</target>
+        <note>{StrBegin="MSB3814: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ImproperlyBuiltSatelliteAssembly">
+        <source>MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</source>
+        <target state="new">MSB3815: Satellite assembly "{2}" was built improperly. The manifest resource "{0}" will not be found by the ResourceManager.  It must end in "{1}".</target>
+        <note>{StrBegin="MSB3815: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.CannotLoadAssemblyLoadFromFailed">
+        <source>MSB3816: Loading assembly "{0}" failed. {1}</source>
+        <target state="new">MSB3816: Loading assembly "{0}" failed. {1}</target>
+        <note>{StrBegin="MSB3816: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MainAssemblyMissingNeutralResourcesLanguage">
+        <source>MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</source>
+        <target state="new">MSB3817: The assembly "{0}" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).</target>
+        <note>{StrBegin="MSB3817: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.ExecuteAsToolAndExtractResWNotSupported">
+        <source>MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</source>
+        <target state="new">MSB3818: The GenerateResource task doesn't currently support simultaneously running as an external tool and extracting ResW files from assemblies.</target>
+        <note>{StrBegin="MSB3818: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.MissingFile">
+        <source>MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</source>
+        <target state="new">MSB3819: Cannot find assembly "{0}", which may contain managed resources that need to be included in this app package.  Please ensure that this assembly exists.</target>
+        <note>{StrBegin="MSB3819: "}</note>
+      </trans-unit>
+      <trans-unit id="GenerateResource.PathTooLong">
+        <source>MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</source>
+        <target state="new">MSB3820: The path needed to store build-related temporary files is too long.  Try your project in a shorter directory, or rename some of your resources.  The full path was "{0}".</target>
+        <note>{StrBegin="MSB3820: "}</note>
+      </trans-unit>
+      <trans-unit id="GetAssemblyIdentity.CouldNotGetAssemblyName">
+        <source>MSB3441: Cannot get assembly name for "{0}". {1}</source>
+        <target state="new">MSB3441: Cannot get assembly name for "{0}". {1}</target>
+        <note>{StrBegin="MSB3441: "}</note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.CouldNotFindSDK">
+        <source>Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</source>
+        <target state="new">Could not locate the expected version of the Microsoft Windows SDK. Looked for a location specified in the "{0}" value of the registry key "{1}". If your build process does not need the SDK then this can be ignored. Otherwise you can solve the problem by doing one of the following:  1) Install the Microsoft Windows SDK.  2) Install Visual Studio 2010.  3) Manually set the above registry key to the correct location.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetFrameworkSdkPath.FoundSDK">
+        <source>Found the Microsoft Windows SDK installed at "{0}".</source>
+        <target state="new">Found the Microsoft Windows SDK installed at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Comment">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MakeDir.Error">
+        <source>MSB3191: Unable to create directory "{0}". {1}</source>
+        <target state="new">MSB3191: Unable to create directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3191: "}</note>
+      </trans-unit>
+      <trans-unit id="Message.InvalidImportance">
+        <source>MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</source>
+        <target state="new">MSB3511: "{0}" is an invalid value for the "Importance" parameter. Valid values are: High, Normal and Low.</target>
+        <note>{StrBegin="MSB3511: "}UE: This message is shown when a user specifies a value for the importance attribute of Message which is not valid.
+            The importance enumeration is: High, Normal and Low.  Specifying any other importance will result in this message being shown
+            LOCALIZATION: "Importance" should not be localized.
+            High should not be localized.
+            Normal should not be localized.
+            Low should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="Move.CreatesDirectory">
+        <source>Creating directory "{0}".</source>
+        <target state="new">Creating directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.DestinationIsDirectory">
+        <source>MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</source>
+        <target state="new">MSB3676: Could not move the file "{0}" to the destination file "{1}", because the destination is a folder instead of a file. To move the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles.</target>
+        <note>{StrBegin="MSB3676: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.Error">
+        <source>MSB3677: Unable to move file "{0}" to "{1}". {2}</source>
+        <target state="new">MSB3677: Unable to move file "{0}" to "{1}". {2}</target>
+        <note>{StrBegin="MSB3677: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.ExactlyOneTypeOfDestination">
+        <source>MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</source>
+        <target state="new">MSB3678: Both "{0}" and "{1}" were specified as input parameters in the project file. Only one must be provided.</target>
+        <note>{StrBegin="MSB3678: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.FileComment">
+        <source>Moving file from "{0}" to "{1}".</source>
+        <target state="new">Moving file from "{0}" to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Move.NeedsDestination">
+        <source>MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</source>
+        <target state="new">MSB3679: No destination specified for Move. Please supply either "{0}" or "{1}".</target>
+        <note>{StrBegin="MSB3679: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceDoesNotExist">
+        <source>MSB3680: The source file "{0}" does not exist.</source>
+        <target state="new">MSB3680: The source file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3680: "}</note>
+      </trans-unit>
+      <trans-unit id="Move.SourceIsDirectory">
+        <source>MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</source>
+        <target state="new">MSB3681: The source file "{0}" is a directory. The "Move" task does not support moving directories.</target>
+        <note>{StrBegin="MSB3681: "}</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.CannotRebaseOutputItemPath">
+        <source>MSB3203: The output path "{0}" cannot be rebased. {1}</source>
+        <target state="new">MSB3203: The output path "{0}" cannot be rebased. {1}</target>
+        <note>{StrBegin="MSB3203: "}UE: This message is shown when the user asks the "MSBuild" task to rebase the paths of its output items relative to the project from where the "MSBuild" task is called (as opposed to the project(s) on which the "MSBuild" task is called), and one of the output item paths is invalid. LOCALIZATION: "{1}" is a localized message from a CLR/FX exception explaining the problem.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFound">
+        <source>MSB3202: The project file "{0}" was not found.</source>
+        <target state="new">MSB3202: The project file "{0}" was not found.</target>
+        <note>{StrBegin="MSB3202: "}UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter.
+             and they have not specified the SkipNonexistentProjects parameter, or it is set to false.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
+        <source>Skipping project "{0}" because it was not found.</source>
+        <target state="new">Skipping project "{0}" because it was not found.</target>
+        <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
+        <source>MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</source>
+        <target state="new">MSB3204: The project file "{0}" is in the ".vcproj" file format, which MSBuild no longer supports. Please convert the project by opening it in the Visual Studio IDE or running the conversion tool, or use MSBuild 3.5 or earlier to build it.</target>
+        <note>{StrBegin="MSB3204: "} LOC: ".vcproj" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.InvalidSkipNonexistentProjectValue">
+        <source>MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</source>
+        <target state="new">MSB3205: SkipNonexistentProject can only accept values of "True", "False" and "Build".</target>
+        <note>{StrBegin="MSB3205: "} LOC: "SkipNonexistentProject", "True", "False" and "Build" should not be localized</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingProjects">
+        <source>The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining projects because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.SkippingRemainingTargets">
+        <source>The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</source>
+        <target state="new">The MSBuild task is skipping the remaining targets because the StopOnFirstFailure parameter was set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild" or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NotBuildingInParallel">
+        <source>Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</source>
+        <target state="new">Overriding the BuildingInParallel property by setting it to false. This is due to the system being run in single process mode with StopOnFirstFailure set to true.</target>
+        <note>LOCALIZATION:  Do not localize the words "MSBuild", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="MSBuild.NoStopOnFirstFailure">
+        <source>StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</source>
+        <target state="new">StopOnFirstFailure will have no effect when the following conditions are all present: 1) The system is running in multiple process mode 2) The BuildInParallel property is true. 3) The RunEachTargetSeparately property is false.</target>
+        <note>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</note>
+      </trans-unit>
+      <trans-unit id="ReadLinesFromFile.ErrorOrWarning">
+        <source>MSB3501: Could not read lines from file "{0}". {1}</source>
+        <target state="new">MSB3501: Could not read lines from file "{0}". {1}</target>
+        <note>{StrBegin="MSB3501: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.AssemblyNotRegisteredForComInterop">
+        <source>MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</source>
+        <target state="new">MSB3211: The assembly '{0}' is not registered for COM Interop. Please register it with regasm.exe /tlb.</target>
+        <note>{StrBegin="MSB3211: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantExportTypeLib">
+        <source>MSB3212: The assembly "{0}" could not be converted to a type library. {1}</source>
+        <target state="new">MSB3212: The assembly "{0}" could not be converted to a type library. {1}</target>
+        <note>{StrBegin="MSB3212: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterAssembly">
+        <source>MSB3217: Cannot register assembly "{0}". {1}</source>
+        <target state="new">MSB3217: Cannot register assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3217: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.CantRegisterTypeLib">
+        <source>MSB3213: Cannot register type library "{0}". {1}</source>
+        <target state="new">MSB3213: Cannot register type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3213: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.NoValidTypes">
+        <source>MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</source>
+        <target state="new">MSB3214: "{0}" does not contain any types that can be registered for COM Interop.</target>
+        <note>{StrBegin="MSB3214: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisterAsmFileDoesNotExist">
+        <source>MSB3215: Cannot register assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3215: Cannot register assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3215: "}</note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringAssembly">
+        <source>Registering assembly "{0}" for COM Interop.</source>
+        <target state="new">Registering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.RegisteringTypeLib">
+        <source>Exporting and registering type library "{0}".</source>
+        <target state="new">Exporting and registering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.TypeLibUpToDate">
+        <source>Type library "{0}" is up to date, skipping regeneration.</source>
+        <target state="new">Type library "{0}" is up to date, skipping regeneration.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RegisterAssembly.UnauthorizedAccess">
+        <source>MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3216: Cannot register assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3216: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Error">
+        <source>MSB3231: Unable to remove directory "{0}". {1}</source>
+        <target state="new">MSB3231: Unable to remove directory "{0}". {1}</target>
+        <note>{StrBegin="MSB3231: "}</note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.Removing">
+        <source>Removing directory "{0}".</source>
+        <target state="new">Removing directory "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="RemoveDir.SkippingNonexistentDirectory">
+        <source>Directory "{0}" doesn't exist. Skipping.</source>
+        <target state="new">Directory "{0}" doesn't exist. Skipping.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.NoInputFiles">
+        <source>No resources specified in "InputFiles". Skipping resource generation.</source>
+        <target state="new">No resources specified in "InputFiles". Skipping resource generation.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResGen.SdkOrToolPathNotSpecifiedOrInvalid">
+        <source>MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</source>
+        <target state="new">MSB3451: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</target>
+        <note>{StrBegin="MSB3451: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRClassNamespaceOrFilenameWithoutLanguage">
+        <source>MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</source>
+        <target state="new">MSB3452: StronglyTypedClassName, StronglyTypedNamespace, and/or StronglyTypedFileName parameters were passed in, but no StronglyTypedLanguage. If you want to create a strongly typed resource class, please specify a language. Otherwise remove all class, file name, and namespace parameters.</target>
+        <note>{StrBegin="MSB3452: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.STRLanguageButNotExactlyOneSourceFile">
+        <source>MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</source>
+        <target state="new">MSB3453: The language for a strongly typed resource class was specified, but more than one source file was passed in. Please pass in only one source file at a time if you want to generate strongly typed resource classes.</target>
+        <note>{StrBegin="MSB3453: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.TrackerNotFound">
+        <source>MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</source>
+        <target state="new">MSB3454: Tracker.exe is required to correctly incrementally generate resources in some circumstances, such as when building on a 64-bit OS using 32-bit MSBuild. This build requires Tracker.exe, but it could not be found.  The task is looking for Tracker.exe beneath the {0} value of the registry key {1}.  To solve the problem, either: 1) Install the Microsoft Windows SDK v7.0A or later. 2) Install Microsoft Visual Studio 2010. 3) Manually set the above registry key to the correct location. Alternatively, you can turn off incremental resource generation by setting the "TrackFileAccess" property to "false".</target>
+        <note>{StrBegin="MSB3454: "}</note>
+      </trans-unit>
+      <trans-unit id="ResGen.CommandTooLong">
+        <source>MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</source>
+        <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
+        <note>{StrBegin="MSB3455: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
+        <source>AssemblyFoldersEx location: "{0}"</source>
+        <target state="new">AssemblyFoldersEx location: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchedAssemblyFoldersEx">
+        <source>Considered AssemblyFoldersEx locations.</source>
+        <target state="new">Considered AssemblyFoldersEx locations.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictFound">
+        <source>There was a conflict between "{0}" and "{1}".</source>
+        <target state="new">There was a conflict between "{0}" and "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictHigherVersionChosen">
+        <source>"{0}" was chosen because it had a higher version.</source>
+        <target state="new">"{0}" was chosen because it had a higher version.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictPrimaryChosen">
+        <source>"{0}" was chosen because it was primary and "{1}" was not.</source>
+        <target state="new">"{0}" was chosen because it was primary and "{1}" was not.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictRedirectSuggestion">
+        <source>Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</source>
+        <target state="new">Consider app.config remapping of assembly "{0}" from Version "{1}" [{2}] to Version "{3}" [{4}] to solve conflict and get rid of warning.</target>
+        <note>
+            UE and LOCALIZATION:
+        {1} and {3} are version numbers like 1.0.0.0
+                {2} and {4} are file names correspending to {1} and {3} respectively
+                {0} is an assembly name with no version number like 'D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa'
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
+        <source>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</source>
+        <target state="new">Considered "{0}", but its name "{1}" didn't match.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
+        <source>Considered "{0}", but it didn't exist.</source>
+        <target state="new">Considered "{0}", but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotAFileNameOnDisk">
+        <source>Considered treating "{0}" as a file name, but it didn't exist.</source>
+        <target state="new">Considered treating "{0}" as a file name, but it didn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseNotInGac">
+        <source>Considered "{0}", which was not found in the GAC.</source>
+        <target state="new">Considered "{0}", which was not found in the GAC.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConsideredAndRejectedBecauseTargetDidntHaveFusionName">
+        <source>Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</source>
+        <target state="new">Considered "{0}", which existed but didn't have a valid identity. This may not be an assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetedProcessorArchitectureDoesNotMatch">
+        <source>Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</source>
+        <target state="new">Considered "{0}", which existed but had a processor architecture "{1}" which does not match the targeted processor architecture "{2}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Dependency">
+        <source>Dependency "{0}".</source>
+        <target state="new">Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.EightSpaceIndent">
+        <source>        {0}</source>
+        <target state="new">        {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TenSpaceIndent">
+        <source>          {0}</source>
+        <target state="new">          {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TwelveSpaceIndent">
+        <source>            {0}</source>
+        <target state="new">            {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundRelatedFile">
+        <source>Found related file "{0}".</source>
+        <target state="new">Found related file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundSatelliteFile">
+        <source>Found satellite file "{0}".</source>
+        <target state="new">Found satellite file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundScatterFile">
+        <source>Found embedded scatter file "{0}".</source>
+        <target state="new">Found embedded scatter file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FourSpaceIndent">
+        <source>    {0}</source>
+        <target state="new">    {0}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IgnoringBecauseNonEmptySubtype">
+        <source>Ignoring "{0}" because it has a non-empty subtype "{1}".</source>
+        <target state="new">Ignoring "{0}" because it has a non-empty subtype "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.BadTargetFrameworkFormat">
+        <source>Ignoring invalid Target Framework value "{0}".</source>
+        <target state="new">Ignoring invalid Target Framework value "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictBetweenAppConfigAndAutoUnify">
+        <source>MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</source>
+        <target state="new">MSB3242: Conflict between mutually exclusive parameters. AutoUnify was 'true' and AppConfigFile was set.</target>
+        <note>{StrBegin="MSB3242: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ConflictUnsolvable">
+        <source>MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</source>
+        <target state="new">MSB3243: No way to resolve conflict between "{0}" and "{1}". Choosing "{0}" arbitrarily.</target>
+        <note>{StrBegin="MSB3243: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToFindDependentFiles">
+        <source>MSB3244: Could not find dependent files. {0}</source>
+        <target state="new">MSB3244: Could not find dependent files. {0}</target>
+        <note>{StrBegin="MSB3244: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReference">
+        <source>MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3245: Could not resolve this reference. {0} If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3245: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedWithException">
+        <source>MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</source>
+        <target state="new">MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. {0}</target>
+        <note>{StrBegin="MSB3246: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SuggestedRedirects">
+        <source>MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</source>
+        <target state="new">MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file: {0}</target>
+        <note>{StrBegin="MSB3247: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidParameter">
+        <source>MSB3248: Parameter "{0}" has invalid value "{1}". {2}</source>
+        <target state="new">MSB3248: Parameter "{0}" has invalid value "{1}". {2}</target>
+        <note>{StrBegin="MSB3248: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidAppConfig">
+        <source>MSB3249: Application Configuration file "{0}" is invalid. {1}</source>
+        <target state="new">MSB3249: Application Configuration file "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3249: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblyTablesFile">
+        <source>MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3250: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblyTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3250: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecauseHigherTargetFramework">
+        <source>MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3251: Could not resolve assembly {0}. The target framework required by this assembly ({1}) is higher than the project target framework. If this reference is required by your code, you may get compilation errors.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList">
+        <source>MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3252: The currently targeted framework "{1}" does not include the referenced assembly "{0}". To fix this, either (1) change the targeted framework for this project or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3252: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList">
+        <source>MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</source>
+        <target state="new">MSB3253: The currently targeted framework "{2}" does not include "{1}" which the referenced assembly "{0}" depends on. This caused the referenced assembly to not resolve. To fix this, either (1) change the targeted framework for this project, or (2) remove the referenced assembly from the project.</target>
+        <note>{StrBegin="MSB3253: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile">
+        <source>MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</source>
+        <target state="new">MSB3254: The file "{0}" will be ignored because it cannot be read. This file was either passed in to InstalledAssemblySubsetTables or was found by searching the {1} folder in the TargetFrameworkDirectories. {2}</target>
+        <note>{StrBegin="MSB3254: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubsetsFound">
+        <source>MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</source>
+        <target state="new">MSB3255: Could not find any Target Framework Subset files in the Target Framework Directories or at the locations specified in the InstalledAssemblySubsetTables.</target>
+        <note>{StrBegin="MSB3255: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList">
+        <source>MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </source>
+        <target state="new">MSB3256: No assemblies were read in from the redist lists. A TargetFramework profile exclusion list could not be generated. </target>
+        <note>{StrBegin="MSB3256: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFramework">
+        <source>MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</source>
+        <target state="new">MSB3257: The primary reference "{0}" could not be resolved because it has a higher version "{1}" than exists in the current target framework. The version found in the current target framework is "{2}".</target>
+        <note>{StrBegin="MSB3257: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFramework">
+        <source>MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</source>
+        <target state="new">MSB3258: The primary reference "{0}" could not be resolved because it has an indirect dependency on the .NET Framework assembly "{1}" which has a higher version "{2}" than the version "{3}" in the current target framework.</target>
+        <note>{StrBegin="MSB3258: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.CannotSetProfileAndSubSet">
+        <source>MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </source>
+        <target state="new">MSB3259: Invalid parameter combination. Can only set either subset or profile parameters. Cannot set one or more subset parameters ("TargetFrameworkSubsets", "InstalledAssemblySubsetTables") and one or more profile parameters ("ProfileName", "FullFrameworkFolders", "FullFrameworkAssemblyTables") at the same time. </target>
+        <note>{StrBegin="MSB3259: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoProfilesFound">
+        <source>MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</source>
+        <target state="new">MSB3260: Could not find any target framework profile redist files in the FullFrameworkFolders locations.</target>
+        <note>{StrBegin="MSB3260: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FrameworkDirectoryOnProfiles">
+        <source>MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</source>
+        <target state="new">MSB3261: The FrameworkDirectory metadata must be set on all items passed to the FullFrameworkAssemblyTables parameter. The item "{0}" did not have the metadata set.</target>
+        <note>{StrBegin="MSB3261: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MustSetProfileNameAndFolderLocations">
+        <source>MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</source>
+        <target state="new">MSB3262: When targeting a profile the ProfileName parameter and one of FullFrameworkFolders or FullFrameworkAssemblyTables must be set.</target>
+        <note>{StrBegin="MSB3262: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.InvalidProfileRedistLocation">
+        <source>MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</source>
+        <target state="new">MSB3263: The file "{0}" will be ignored because it cannot be read. This file was either passed in to FullFrameworkAssemblyTables or was found by searching the "{1}" folder in the FullFrameworkFolders. {2}</target>
+        <note>{StrBegin="MSB3263: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceInAnotherFramework">
+        <source>MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</source>
+        <target state="new">MSB3267: The primary reference "{0}", which is a framework assembly, could not be resolved in the currently targeted framework. "{1}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{0}".</target>
+        <note>{StrBegin="MSB3267: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceInAnotherFramework">
+        <source>MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</source>
+        <target state="new">MSB3268: The primary reference "{0}" could not be resolved because it has an indirect dependency on the framework assembly "{1}" which could not be resolved in the currently targeted framework. "{2}". To resolve this problem, either remove the reference "{0}" or retarget your application to a framework version which contains "{1}".</target>
+        <note>{StrBegin="MSB3268: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemDeterminingFrameworkMembership">
+        <source>MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</source>
+        <target state="new">MSB3269: Could not determine if resolved references are part of the targeted framework because of an error. "{0}"</target>
+        <note>{StrBegin="MSB3269: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch">
+        <source>MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3270: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture of the reference "{1}", "{2}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3270: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArchOfImplementation">
+        <source>MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</source>
+        <target state="new">MSB3271: There was a mismatch between the processor architecture of the project being built "{0}" and the processor architecture, "{1}", of the implementation file "{2}" for "{3}". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and implementation file, or choose a winmd file with an implementation file that has a processor architecture which matches the targeted processor architecture of your project.</target>
+        <note>{StrBegin="MSB3271: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemReadingImplementationDll">
+        <source>MSB3272: There was a problem reading the implementation file "{0}". "{1}"</source>
+        <target state="new">MSB3272: There was a problem reading the implementation file "{0}". "{1}"</target>
+        <note>{StrBegin="MSB3272: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader">
+        <source>Invalid PE header found. The implementation file will not used.</source>
+        <target state="new">Invalid PE header found. The implementation file will not used.</target>
+        <note>This message can be used as the {1} in MSB3272</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnknownProcessorArchitecture">
+        <source>MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</source>
+        <target state="new">MSB3273: Unknown processor architecture. The implementation file "{0}" for "{1}" had an ImageFileMachine value of "0x{2}". If you wish to use this implementation file make sure the "ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" property in your project is set to "Warning" or "None".</target>
+        <note>{StrBegin="MSB3273: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</source>
+        <target state="new">MSB3274: The primary reference "{0}" could not be resolved because it was built against the "{1}" framework. This is a higher version than the currently targeted framework "{2}".</target>
+        <note>{StrBegin="MSB3274: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.DependencyReferenceOutsideOfFrameworkUsingAttribute">
+        <source>MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</source>
+        <target state="new">MSB3275: The primary reference "{0}" could not be resolved because it has an indirect dependency on the assembly "{1}" which was built against the "{2}" framework. This is a higher version than the currently targeted framework "{3}".</target>
+        <note>{StrBegin="MSB3275: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects">
+        <source>MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</source>
+        <target state="new">MSB3276: Found conflicts between different versions of the same dependent assembly. Please set the "AutoGenerateBindingRedirects" property to true in the project file. For more information, see http://go.microsoft.com/fwlink/?LinkId=294190.</target>
+        <note>{StrBegin="MSB3276: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FoundConflicts">
+        <source>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</source>
+        <target state="new">MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</target>
+        <note>{StrBegin="MSB3277: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogAttributeFormat">
+        <source>{0} = '{1}'</source>
+        <target state="new">{0} = '{1}'</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.LogTaskPropertyFormat">
+        <source>{0}:</source>
+        <target state="new">{0}:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim">
+        <source>This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</source>
+        <target state="new">This reference is not "CopyLocal" because it conflicted with another reference with the same name and lost the conflict.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ImageRuntimeVersion">
+        <source>The ImageRuntimeVersion for this reference is "{0}".</source>
+        <target state="new">The ImageRuntimeVersion for this reference is "{0}".</target>
+        <note>
+      LOCALIZATION: Please don't localize "ImageRuntimeVersion" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.IsAWinMdFile">
+        <source>This reference is a WinMDFile.</source>
+        <target state="new">This reference is a WinMDFile.</target>
+        <note>
+      LOCALIZATION: Please don't localize "WinMDFile" this is an item meta-data name.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac">
+        <source>This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because the CopyLocalDependenciesWhenParentReferenceInGac property is set to false and all the parent references for this reference are found in the GAC.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name. "CopyLocalDependenciesWhenParentReferenceInGac" is a property name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseEmbedded">
+        <source>This reference is not "CopyLocal" because its types will be embedded into the target assembly.</source>
+        <target state="new">This reference is not "CopyLocal" because its types will be embedded into the target assembly.</target>
+        <note>
+        LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles">
+        <source>This reference is not "CopyLocal" because it's in a Frameworks directory.</source>
+        <target state="new">This reference is not "CopyLocal" because it's in a Frameworks directory.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+   </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode">
+        <source>This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</source>
+        <target state="new">This reference is not "CopyLocal" because at least one source item had "Private" set to "false" and no source items had "Private" set to "true".</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal", "Private", "false", "true".
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecausePrerequisite">
+        <source>This reference is not "CopyLocal" because it's a prerequisite file.</source>
+        <target state="new">This reference is not "CopyLocal" because it's a prerequisite file.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC">
+        <source>This reference is not "CopyLocal" because it's registered in the GAC.</source>
+        <target state="new">This reference is not "CopyLocal" because it's registered in the GAC.</target>
+        <note>
+            LOCALIZATION: Please don't localize "CopyLocal" this is an item meta-data name.
+        </note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimaryReference">
+        <source>Primary reference "{0}".</source>
+        <target state="new">Primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RequiredBy">
+        <source>Required by "{0}".</source>
+        <target state="new">Required by "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ReferenceDependsOn">
+        <source>References which depend on "{0}" [{1}].</source>
+        <target state="new">References which depend on "{0}" [{1}].</target>
+        <note> This will look like references which depend on "A, Version=2.0.0.0 PublicKey=4a4fded9gisujf" [a.dll].</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnResolvedPrimaryItemSpec">
+        <source>Unresolved primary reference with an item include of "{0}".</source>
+        <target state="new">Unresolved primary reference with an item include of "{0}".</target>
+        <note> This messages is for a reference which could not be resolved, however we have its item spec and will display that. {0} will be somethign like  System or A, Version=xxx</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.PrimarySourceItemsForReference">
+        <source>Project file item includes which caused reference "{0}".</source>
+        <target state="new">Project file item includes which caused reference "{0}".</target>
+        <note> This will look like, Project file item includes which caused reference "a.dll".</note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.Resolved">
+        <source>Resolved file path is "{0}".</source>
+        <target state="new">Resolved file path is "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ResolvedFrom">
+        <source>Reference found at search path location "{0}".</source>
+        <target state="new">Reference found at search path location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.SearchPath">
+        <source>For SearchPath "{0}".</source>
+        <target state="new">For SearchPath "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAppConfig">
+        <source>Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</source>
+        <target state="new">Using this version instead of original version "{0}" in "{2}" because of a binding redirect entry in the file "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByAutoUnify">
+        <source>Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because AutoUnify is 'true'.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.RemappedReference">
+        <source>Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</source>
+        <target state="new">Due to a remapping entry in the currently targeted framework redist list, reference "{0}" was remapped to "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnificationByFrameworkRetarget">
+        <source>Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</source>
+        <target state="new">Using this version instead of original version "{0}" in "{1}" because there is a more recent version of this framework file.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedDependency">
+        <source>Unified Dependency "{0}".</source>
+        <target state="new">Unified Dependency "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UnifiedPrimaryReference">
+        <source>Unified primary reference "{0}".</source>
+        <target state="new">Unified primary reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProblemFindingSatelliteAssemblies">
+        <source>Could not find satellite assemblies for reference "{0}". {1}</source>
+        <target state="new">Could not find satellite assemblies for reference "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.UsingExclusionList">
+        <source>A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated. The exclusion list is a list of assemblies not in the profile.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseofFullClientName">
+        <source>A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</source>
+        <target state="new">A TargetFramework profile exclusion list will not be generated. A full client name "{0}" was found in the TargetFrameworkSubsetNames list.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseIgnoreSubsetsAndNoAdditionalOnesProvided">
+        <source>No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework subset exclusion list will be generated. IgnoreDefaultInstalledAssemblySubsetTables is true and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.ProfileExclusionListWillBeGenerated">
+        <source>A TargetFramework profile exclusion list will be generated.</source>
+        <target state="new">A TargetFramework profile exclusion list will be generated.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoExclusionListBecauseNoSubsetsPassedIn">
+        <source>No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</source>
+        <target state="new">No TargetFramework profile exclusion list will be generated. No TargetFrameworkSubsets were provided and no additional profile files were passed in to InstalledAssemblySubsetTables.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkSubsetLogHeader">
+        <source>TargetFramework Profile List Information:</source>
+        <target state="new">TargetFramework Profile List Information:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader">
+        <source>TargetFramework Profile List Paths:</source>
+        <target state="new">TargetFramework Profile List Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkRedistLogHeader">
+        <source>Redist List File Paths:</source>
+        <target state="new">Redist List File Paths:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader">
+        <source>Computed TargetFramework profile exclusion list assembly full names:</source>
+        <target state="new">Computed TargetFramework profile exclusion list assembly full names:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.FormattedAssemblyInfo">
+        <source>Path: "{0}"</source>
+        <target state="new">Path: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.NoSubSetRedistListName">
+        <source>The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</source>
+        <target state="new">The redist list file "{0}" has a null or empty Redist name in the FileList element. Make sure the Redist Name is not null or empty.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TreatingTlbOfActiveXAsNonEmbedded">
+        <source>COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</source>
+        <target state="new">COM Reference '{0}' is the interop assembly for ActiveX control '{1}' but was marked to be linked by the compiler with the /link flag. This COM reference will be treated as a reference and will not be linked.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.AddingMissingTlbReference">
+        <source>Adding a matching tlbimp reference for the aximp reference "{0}".</source>
+        <target state="new">Adding a matching tlbimp reference for the aximp reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.UsingCacheFile">
+        <source>Using cache file at "{0}".</source>
+        <target state="new">Using cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NotUsingCacheFile">
+        <source>Creating new cache file at "{0}".</source>
+        <target state="new">Creating new cache file at "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.BadAssemblyImage">
+        <source>MSB3281: The assembly "{0}" is not a valid assembly file.</source>
+        <target state="new">MSB3281: The assembly "{0}" is not a valid assembly file.</target>
+        <note>{StrBegin="MSB3281: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotAccessTypeLibName">
+        <source>MSB3282: Cannot access type library name for library "{0}". {1}</source>
+        <target state="new">MSB3282: Cannot access type library name for library "{0}". {1}</target>
+        <note>{StrBegin="MSB3282: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
+        <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
+        <target state="new">MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</target>
+        <note>{StrBegin="MSB3283: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">
+        <source>MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3284: Cannot get the file path for type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3284: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotGetTypeLibAttrForTypeLib">
+        <source>MSB3285: Cannot get type library attributes for a dependent type library!</source>
+        <target state="new">MSB3285: Cannot get type library attributes for a dependent type library!</target>
+        <note>{StrBegin="MSB3285: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLib">
+        <source>MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3286: Cannot load type library "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3286: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotLoadTypeLibItemSpec">
+        <source>MSB3287: Cannot load type library for reference "{0}". {1}</source>
+        <target state="new">MSB3287: Cannot load type library for reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3287: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotRetrieveTypeInformation">
+        <source>MSB3302: Cannot retrieve information about a dependent type.</source>
+        <target state="new">MSB3302: Cannot retrieve information about a dependent type.</target>
+        <note>{StrBegin="MSB3302: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyBothKeyFileAndKeyContainer">
+        <source>MSB3300: Cannot specify values for both KeyFile and KeyContainer.</source>
+        <target state="new">MSB3300: Cannot specify values for both KeyFile and KeyContainer.</target>
+        <note>{StrBegin="MSB3300: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.CannotSpecifyDelaySignWithoutEitherKeyFileOrKeyContainer">
+        <source>MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</source>
+        <target state="new">MSB3301: DelaySign parameter is true, but no KeyFile or KeyContainer was specified.</target>
+        <note>{StrBegin="MSB3301: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ConflictingReferences">
+        <source>MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</source>
+        <target state="new">MSB3288: COM reference "{0}" conflicts with reference "{1}" - the project references different type libraries with the same type library names. Ignoring reference "{0}".</target>
+        <note>{StrBegin="MSB3288: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ErrorCreatingWrapperAssembly">
+        <source>MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</source>
+        <target state="new">MSB3290: Failed to create the wrapper assembly for type library "{0}". {1}</target>
+        <note>{StrBegin="MSB3290: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToFindDependentNetAssembly">
+        <source>MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</source>
+        <target state="new">MSB3291: Could not resolve dependent .NET assembly "{0}". Please make sure this assembly is included in the references section of the project file.</target>
+        <note>{StrBegin="MSB3291: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToRemapAdoTypeLib">
+        <source>MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</source>
+        <target state="new">MSB3292: Failed to remap ADO reference version {0}.{1} to version 2.7 - "{2}".</target>
+        <note>{StrBegin="MSB3292: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveComReference">
+        <source>MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</source>
+        <target state="new">MSB3303: Could not resolve COM reference "{0}" version {1}.{2}. {3}</target>
+        <note>{StrBegin="MSB3303: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReference">
+        <source>MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</source>
+        <target state="new">MSB3293: Could not resolve dependent COM reference "{0}" version {1}.{2}.</target>
+        <note>{StrBegin="MSB3293: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToResolveDependentComReferenceByAssemblyName">
+        <source>MSB3294: Could not resolve dependent COM reference "{0}".</source>
+        <target state="new">MSB3294: Could not resolve dependent COM reference "{0}".</target>
+        <note>{StrBegin="MSB3294: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.FailedToScanDependencies">
+        <source>MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</source>
+        <target state="new">MSB3304: Could not determine the dependencies of the COM reference "{0}". {1}</target>
+        <note>{StrBegin="MSB3304: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionWarning">
+        <source>MSB3305: Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">MSB3305: Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note>{StrBegin="MSB3305: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolutionMessage">
+        <source>Processing COM reference "{0}" from path "{1}". {2}</source>
+        <target state="new">Processing COM reference "{0}" from path "{1}". {2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.LoadingDelaySignedAssemblyWithStrongNameVerificationEnabled">
+        <source>MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</source>
+        <target state="new">MSB3295: Failed to load an assembly. Please make sure you have disabled strong name verification for your public key if you want to generate delay signed wrappers. {0}</target>
+        <note>{StrBegin="MSB3295: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.MissingOrUnknownComReferenceAttribute">
+        <source>MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</source>
+        <target state="new">MSB3296: The specified COM reference meta-data for the reference "{1}" is missing or has an invalid value: "{0}".</target>
+        <note>{StrBegin="MSB3296: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.NoComReferencesSpecified">
+        <source>MSB3297: No COM references have been passed into the task, exiting.</source>
+        <target state="new">MSB3297: No COM references have been passed into the task, exiting.</target>
+        <note>{StrBegin="MSB3297: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.RemappingAdoTypeLib">
+        <source>Remapping ADO reference version {0}.{1} to version 2.7.</source>
+        <target state="new">Remapping ADO reference version {0}.{1} to version 2.7.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReference">
+        <source>Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</source>
+        <target state="new">Resolved COM reference dependency "{0}" version {1}.{2}: "{3}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedDependentComReferenceByAssemblyName">
+        <source>Resolved COM reference dependency "{0}": "{1}"</source>
+        <target state="new">Resolved COM reference dependency "{0}": "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvedReference">
+        <source>Resolved COM reference for item "{0}": "{1}".</source>
+        <target state="new">Resolved COM reference for item "{0}": "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.Resolving">
+        <source>Resolving COM reference for item "{0}" with a wrapper "{1}".</source>
+        <target state="new">Resolving COM reference for item "{0}" with a wrapper "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ResolvingDependency">
+        <source>Resolving COM reference dependency "{0}" version {1}.{2}.</source>
+        <target state="new">Resolving COM reference dependency "{0}" version {1}.{2}.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.ScanningDependencies">
+        <source>Determining dependencies of the COM reference "{0}".</source>
+        <target state="new">Determining dependencies of the COM reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInContainer">
+        <source>MSB3298: The key container '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3298: The key container '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3298: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.StrongNameUtils.NoKeyPairInFile">
+        <source>MSB3299: The key file '{0}' does not contain a public/private key pair.</source>
+        <target state="new">MSB3299: The key file '{0}' does not contain a public/private key pair.</target>
+        <note>{StrBegin="MSB3299: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveComReference.TypeLibAttrId">
+        <source>{0} {1}.{2}</source>
+        <target state="new">{0} {1}.{2}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyImportError">
+        <source>MSB3321: Importing key file "{0}" was canceled.</source>
+        <target state="new">MSB3321: Importing key file "{0}" was canceled.</target>
+        <note>{StrBegin="MSB3321: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyMD5SumError">
+        <source>MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</source>
+        <target state="new">MSB3322: Unable to get MD5 checksum for the key file "{0}". {1}</target>
+        <note>{StrBegin="MSB3322: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.MsgBoxTitleImportKeyError">
+        <source>Error importing key</source>
+        <target state="new">Error importing key</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.CertificateNotInStore">
+        <source>MSB3323: Unable to find manifest signing certificate in the certificate store.</source>
+        <target state="new">MSB3323: Unable to find manifest signing certificate in the certificate store.</target>
+        <note>{StrBegin="MSB3323: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.InvalidKeyName">
+        <source>MSB3324: Invalid key file name "{0}". {1}</source>
+        <target state="new">MSB3324: Invalid key file name "{0}". {1}</target>
+        <note>{StrBegin="MSB3324: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForSignAssemblyNotImported">
+        <source>MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</source>
+        <target state="new">MSB3325: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or manually install the certificate to the Strong Name CSP with the following key container name: {1}</target>
+        <note>{StrBegin="MSB3325: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.KeyFileForManifestNotImported">
+        <source>MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</source>
+        <target state="new">MSB3326: Cannot import the following key file: {0}. The key file may be password protected. To correct this, try to import the certificate again or import the certificate manually into the current user’s personal certificate store.</target>
+        <note>{StrBegin="MSB3326: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveKeySource.ResolvedThumbprintEmpty">
+        <source>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</source>
+        <target state="new">MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</target>
+        <note>{StrBegin="MSB3327: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveManifestFiles.PublishFileNotFound">
+        <source>MSB3331: Unable to apply publish properties for item "{0}".</source>
+        <target state="new">MSB3331: Unable to apply publish properties for item "{0}".</target>
+        <note>{StrBegin="MSB3331: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.Comment">
+        <source>Processing manifest file "{0}".</source>
+        <target state="new">Processing manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.ResolveReference">
+        <source>Attempting to resolve reference "{0}" on path(s):</source>
+        <target state="new">Attempting to resolve reference "{0}" on path(s):</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNativeReference.FailedToResolveReference">
+        <source>MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3341: Could not resolve reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <note>{StrBegin="MSB3341: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionFailure">
+        <source>MSB3582: Could not resolve project reference "{0}".</source>
+        <target state="new">MSB3582: Could not resolve project reference "{0}".</target>
+        <note>{StrBegin="MSB3582: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
+        <source>Project reference "{0}" has not been resolved.</source>
+        <target state="new">Project reference "{0}" has not been resolved.</target>
+        <note>
+      UE and LOCALIZATION: 
+      This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
+      processing in the .targets file.
+    </note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionStarting">
+        <source>Resolving project reference "{0}".</source>
+        <target state="new">Resolving project reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceResolutionSuccess">
+        <source>Project reference "{0}" resolved as "{1}".</source>
+        <target state="new">Project reference "{0}" resolved as "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SGen.ResourceNotFound">
+        <source>MSB3471: Non-existent reference "{0}" passed to the SGen task.</source>
+        <target state="new">MSB3471: Non-existent reference "{0}" passed to the SGen task.</target>
+        <note>{StrBegin="MSB3471: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.CouldNotDeleteSerializer">
+        <source>MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </source>
+        <target state="new">MSB3472: We were unable to delete the existing serializer "{0}" before creating a new one: {1}  </target>
+        <note>{StrBegin="MSB3472: "}</note>
+      </trans-unit>
+      <trans-unit id="SGen.InvalidPath">
+        <source>MSB3473: Path for "{0}" is invalid. {1}</source>
+        <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
+        <note>{StrBegin="MSB3473: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertNotInStore">
+        <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
+        <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>
+        <note>{StrBegin="MSB3481: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolError">
+        <source>MSB3482: An error occurred while signing: {0}</source>
+        <target state="new">MSB3482: An error occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3482: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.SignToolWarning">
+        <source>MSB3483: A warning occurred while signing: {0}</source>
+        <target state="new">MSB3483: A warning occurred while signing: {0}</target>
+        <note>{StrBegin="MSB3483: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.TargetFileNotFound">
+        <source>MSB3484: Signing target '{0}' could not be found.</source>
+        <target state="new">MSB3484: Signing target '{0}' could not be found.</target>
+        <note>{StrBegin="MSB3484: "}</note>
+      </trans-unit>
+      <trans-unit id="SignFile.CertMissingPrivateKey">
+        <source>MSB3487: The signing certificate does not include private key information.</source>
+        <target state="new">MSB3487: The signing certificate does not include private key information.</target>
+        <note>{StrBegin="MSB3487: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.BadKeyContainer">
+        <source>MSB3351: Unable to create a strong name key pair from key container '{0}'.</source>
+        <target state="new">MSB3351: Unable to create a strong name key pair from key container '{0}'.</target>
+        <note>{StrBegin="MSB3351: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.KeyFileReadFailure">
+        <source>MSB3352: The specified key file '{0}' could not be read.</source>
+        <target state="new">MSB3352: The specified key file '{0}' could not be read.</target>
+        <note>{StrBegin="MSB3352: "}</note>
+      </trans-unit>
+      <trans-unit id="StrongNameUtils.NoPublicKeySpecified">
+        <source>MSB3353: Public key necessary for delay signing was not specified.</source>
+        <target state="new">MSB3353: Public key necessary for delay signing was not specified.</target>
+        <note>{StrBegin="MSB3353: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.InvalidTransformParameter">
+        <source>MSB3661: Invalid value '{0}' passed to the Transform property.</source>
+        <target state="new">MSB3661: Invalid value '{0}' passed to the Transform property.</target>
+        <note>{StrBegin="MSB3661: "}</note>
+      </trans-unit>
+      <trans-unit id="TlbImp.NoInputFileSpecified">
+        <source>MSB3662: No input file has been passed to the task, exiting.</source>
+        <target state="new">MSB3662: No input file has been passed to the task, exiting.</target>
+        <note>{StrBegin="MSB3662: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotCreateFile">
+        <source>MSB3371: The file "{0}" cannot be created. {1}</source>
+        <target state="new">MSB3371: The file "{0}" cannot be created. {1}</target>
+        <note>{StrBegin="MSB3371: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotMakeFileWritable">
+        <source>MSB3372: The file "{0}" cannot be made writable. {1}</source>
+        <target state="new">MSB3372: The file "{0}" cannot be made writable. {1}</target>
+        <note>{StrBegin="MSB3372: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotRestoreAttributes">
+        <source>MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</source>
+        <target state="new">MSB3373: The attributes on file "{0}" cannot be restored to their original value. {1}</target>
+        <note>{StrBegin="MSB3373: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CannotTouch">
+        <source>MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</source>
+        <target state="new">MSB3374: The last access/last write time on file "{0}" cannot be set. {1}</target>
+        <note>{StrBegin="MSB3374: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.CreatingFile">
+        <source>Creating "{0}" because "{1}" was specified.</source>
+        <target state="new">Creating "{0}" because "{1}" was specified.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="Touch.FileDoesNotExist">
+        <source>MSB3375: The file "{0}" does not exist.</source>
+        <target state="new">MSB3375: The file "{0}" does not exist.</target>
+        <note>{StrBegin="MSB3375: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.TimeSyntaxIncorrect">
+        <source>MSB3376: The syntax of the Time parameter is incorrect. {0}</source>
+        <target state="new">MSB3376: The syntax of the Time parameter is incorrect. {0}</target>
+        <note>{StrBegin="MSB3376: "}</note>
+      </trans-unit>
+      <trans-unit id="Touch.Touching">
+        <source>Touching "{0}".</source>
+        <target state="new">Touching "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.AssemblyPathOrStateFileIsRequired">
+        <source>MSB3396: The "{0}" task needs either an assembly path or state file path.</source>
+        <target state="new">MSB3396: The "{0}" task needs either an assembly path or state file path.</target>
+        <note>{StrBegin="MSB3396: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.CantUnregisterAssembly">
+        <source>MSB3395: Cannot unregister assembly "{0}". {1}</source>
+        <target state="new">MSB3395: Cannot unregister assembly "{0}". {1}</target>
+        <note>{StrBegin="MSB3395: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.NoValidTypes">
+        <source>MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</source>
+        <target state="new">MSB3391: "{0}" does not contain any types that can be unregistered for COM Interop.</target>
+        <note>{StrBegin="MSB3391: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnauthorizedAccess">
+        <source>MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</source>
+        <target state="new">MSB3392: Cannot unregister assembly "{0}" - access denied. Please make sure you're running the application as administrator. {1}</target>
+        <note>{StrBegin="MSB3392: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterAsmFileDoesNotExist">
+        <source>MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</source>
+        <target state="new">MSB3393: Cannot unregister assembly "{0}" - file doesn't exist.</target>
+        <note>{StrBegin="MSB3393: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringAssembly">
+        <source>Unregistering assembly "{0}" for COM Interop.</source>
+        <target state="new">Unregistering assembly "{0}" for COM Interop.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisteringTypeLib">
+        <source>Unregistering type library "{0}".</source>
+        <target state="new">Unregistering type library "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbCantLoadFile">
+        <source>MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</source>
+        <target state="new">MSB3397: Cannot unregister type library "{0}" - cannot load file, check to make sure it's a valid type library.</target>
+        <note>{StrBegin="MSB3397: "}</note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileDoesNotExist">
+        <source>Cannot unregister type library "{0}" - file doesn't exist.</source>
+        <target state="new">Cannot unregister type library "{0}" - file doesn't exist.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UnregisterAssembly.UnregisterTlbFileNotRegistered">
+        <source>MSB3394: Type library "{0}" is not registered, cannot unregister.</source>
+        <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
+        <note>{StrBegin="MSB3394: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.EnumParameterHasInvalidValue">
+        <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
+        <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
+        <note>{StrBegin="MSB3401: "}</note>
+      </trans-unit>
+      <trans-unit id="VBC.RenamePDB">
+        <source>MSB3402: There was an error creating the pdb file "{0}". {1}</source>
+        <target state="new">MSB3402: There was an error creating the pdb file "{0}". {1}</target>
+        <note>{StrBegin="MSB3402: "}</note>
+      </trans-unit>
+      <trans-unit id="Vbc.ParameterHasInvalidValue">
+        <source>"{1}" is an invalid value for the "{0}" parameter.</source>
+        <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteLinesToFile.ErrorOrWarning">
+        <source>MSB3491: Could not write lines to file "{0}". {1}</source>
+        <target state="new">MSB3491: Could not write lines to file "{0}". {1}</target>
+        <note>{StrBegin="MSB3491: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.InvalidTargetFrameworkMoniker">
+        <source>MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3642: The Target Framework Moniker "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3642: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.ProblemGeneratingReferencePaths">
+        <source>MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</source>
+        <target state="new">MSB3643: There was an error generating reference assembly paths based on the TargetFrameworkMoniker "{0}". {1}</target>
+        <note>{StrBegin="MSB3643: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound">
+        <source>MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</source>
+        <target state="new">MSB3644: The reference assemblies for framework "{0}" were not found. To resolve this, install the SDK or Targeting Pack for this framework version or retarget your application to a version of the framework for which you have the SDK or Targeting Pack installed. Note that assemblies will be resolved from the Global Assembly Cache (GAC) and will be used in place of reference assemblies. Therefore your assembly may not be correctly targeted for the framework you intend.</target>
+        <note>{StrBegin="MSB3644: "}</note>
+      </trans-unit>
+      <trans-unit id="GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled">
+        <source>MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</source>
+        <target state="new">MSB3645: .NET Framework v3.5 Service Pack 1 was not found. In order to target "{0}", .NET Framework v3.5 Service Pack 1 or later must be installed.</target>
+        <note>{StrBegin="MSB3645: "}</note>
+      </trans-unit>
+      <trans-unit id="WinMDExp.MustPassReferences">
+        <source>MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</source>
+        <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
+        <note>{StrBegin="MSB3762: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.TaskCreationFailed">
+        <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
+        <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>
+        <note>{StrBegin="MSB3686: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleParseFailed">
+        <source>MSB3687: Unable to parse Xaml rule.  {0}</source>
+        <target state="new">MSB3687: Unable to parse Xaml rule.  {0}</target>
+        <note>{StrBegin="MSB3687: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleFileNotFound">
+        <source>MSB3688: Unable to create Xaml task.  File not found: {0}.</source>
+        <target state="new">MSB3688: Unable to create Xaml task.  File not found: {0}.</target>
+        <note>{StrBegin="MSB3688: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleMissingToolName">
+        <source>MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</source>
+        <target state="new">MSB3689: Unable to execute Xaml task.  If the CommandLineTemplate task parameter is not specified, then the ToolName attribute must be specified in the Rule or the ToolExe task parameter must be set.</target>
+        <note>{StrBegin="MSB3689: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.RuleNotFound">
+        <source>MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</source>
+        <target state="new">MSB3690: Unable to create Xaml task.  The Rule "{0}" was not found.</target>
+        <note>{StrBegin="MSB3690: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.InvalidRootObject">
+        <source>MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</source>
+        <target state="new">MSB3691: Unable to create Xaml task.  The root object was not of type ProjectSchemaDefinitions.</target>
+        <note>{StrBegin="MSB3691: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingTaskBody">
+        <source>MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</source>
+        <target state="new">MSB3692: Unable to create Xaml task.  The &lt;UsingTask&gt; does not contain a &lt;Task&gt; definition.</target>
+        <note>{StrBegin="MSB3692: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.ArgumentOutOfRange">
+        <source>MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</source>
+        <target state="new">MSB3693: Unable to execute Xaml task.  The value "{1}" specified for task parameter "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3693: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingSwitchValue">
+        <source>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</source>
+        <target state="new">MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</target>
+        <note>{StrBegin="MSB3694: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailed">
+        <source>MSB3721: The command "{0}" exited with code {1}.</source>
+        <target state="new">MSB3721: The command "{0}" exited with code {1}.</target>
+        <note>{StrBegin="MSB3721: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.CommandFailedAccessDenied">
+        <source>MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</source>
+        <target state="new">MSB3722: The command "{0}" exited with code {1}. Please verify that you have sufficient rights to run this command.</target>
+        <note>{StrBegin="MSB3722: "}</note>
+      </trans-unit>
+      <trans-unit id="Xaml.MissingRequiredArgument">
+        <source>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</source>
+        <target state="new">MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</target>
+        <note>{StrBegin="MSB3723: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.ArgumentError">
+        <source>MSB3701: Unable to load arguments for the XslTransformation task. {0}</source>
+        <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3701: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltArgumentsError">
+        <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
+        <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>
+        <note>{StrBegin="MSB3702: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.TransformError">
+        <source>MSB3703: Unable to execute transformation. {0}</source>
+        <target state="new">MSB3703: Unable to execute transformation. {0}</target>
+        <note>{StrBegin="MSB3703: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPaths arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPaths arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPaths arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPaths arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooMany">
+        <source>Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</source>
+        <target state="new">Only one of XslContent, XslInputPath or XslCompiledDllPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltInput.TooFew">
+        <source>One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</source>
+        <target state="new">One of XslContent, XslInputPath and XslCompiledDllPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltLoadError">
+        <source>MSB3704: Unable to load the specified Xslt. {0}</source>
+        <target state="new">MSB3704: Unable to load the specified Xslt. {0}</target>
+        <note>{StrBegin="MSB3704: "}</note>
+      </trans-unit>
+      <trans-unit id="XslTransform.MustSpecifyType">
+        <source>When specifying assembly "{0}", you must specify the type as well.</source>
+        <target state="new">When specifying assembly "{0}", you must specify the type as well.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNoAttribute">
+        <source>The specified Xslt Parameter doesn't have attribute "{0}".</source>
+        <target state="new">The specified Xslt Parameter doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.XsltParameterNotWellFormed">
+        <source>The specified Xslt Parameter attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Xslt Parameter attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XslTransform.UseTrustedSettings">
+        <source>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</source>
+        <target state="new">The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesError">
+        <source>MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</source>
+        <target state="new">MSB3731: Unable to process the Namespaces argument for the XmlPoke task. {0}</target>
+        <note>{StrBegin="MSB3731: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute doesn't have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute doesn't have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Replaced">
+        <source>Replaced "{0}" with "{1}".</source>
+        <target state="new">Replaced "{0}" with "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.Count">
+        <source>Made {0} replacement(s).</source>
+        <target state="new">Made {0} replacement(s).</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.XPathContextError">
+        <source>MSB3732: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3732: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3732: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.InputFileError">
+        <source>MSB3733: Input file "{0}" cannot be opened. {1}</source>
+        <target state="new">MSB3733: Input file "{0}" cannot be opened. {1}</target>
+        <note>{StrBegin="MSB3733: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeekPoke.XPathError">
+        <source>MSB3734: XPath Query "{0}" cannot be loaded. {1}</source>
+        <target state="new">MSB3734: XPath Query "{0}" cannot be loaded. {1}</target>
+        <note>{StrBegin="MSB3734: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPoke.PokeError">
+        <source>MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</source>
+        <target state="new">MSB3735: Error while executing poke operation with the Value parameter "{0}". {1}</target>
+        <note>{StrBegin="MSB3735: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.ArgumentError">
+        <source>MSB3741: Unable to load arguments for the XmlPeek task. {0}</source>
+        <target state="new">MSB3741: Unable to load arguments for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3741: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesError">
+        <source>MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</source>
+        <target state="new">MSB3742: Unable to process the Namespaces argument for the XmlPeek task. {0}</target>
+        <note>{StrBegin="MSB3742: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XPathContextError">
+        <source>MSB3743: Unable to set XPath expression's Context. {0}</source>
+        <target state="new">MSB3743: Unable to set XPath expression's Context. {0}</target>
+        <note>{StrBegin="MSB3743: "}</note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooMany">
+        <source>Only one of XmlContent or XmlInputPath arguments can be set.</source>
+        <target state="new">Only one of XmlContent or XmlInputPath arguments can be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.XmlInput.TooFew">
+        <source>One of XmlContent or XmlInputPath arguments must be set.</source>
+        <target state="new">One of XmlContent or XmlInputPath arguments must be set.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNoAttribute">
+        <source>The specified Namespaces attribute does not have attribute "{0}".</source>
+        <target state="new">The specified Namespaces attribute does not have attribute "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NamespacesParameterNotWellFormed">
+        <source>The specified Namespaces attribute is not a well-formed XML fragment.</source>
+        <target state="new">The specified Namespaces attribute is not a well-formed XML fragment.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.Found">
+        <source>Found "{0}".</source>
+        <target state="new">Found "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="XmlPeek.NotFound">
+        <source>The specified XPath query did not capture any nodes.</source>
+        <target state="new">The specified XPath query did not capture any nodes.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.MustSpecifyLocation">
+        <source>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</source>
+        <target state="new">MSB3711: At least one of OutputFile or OutputDirectory must be provided.</target>
+        <note>{StrBegin="MSB3711: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotCreateProvider">
+        <source>MSB3712: Code for the language "{0}" could not be generated. {1}</source>
+        <target state="new">MSB3712: Code for the language "{0}" could not be generated. {1}</target>
+        <note>{StrBegin="MSB3712: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.CouldNotWriteOutput">
+        <source>MSB3713: The file "{0}" could not be created. {1}</source>
+        <target state="new">MSB3713: The file "{0}" could not be created. {1}</target>
+        <note>{StrBegin="MSB3713: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.SkippedNumberedParameter">
+        <source>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</source>
+        <target state="new">MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</target>
+        <note>{StrBegin="MSB3714: "}</note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.NoWorkToDo">
+        <source>No output file was written because no code was specified to create.</source>
+        <target state="new">No output file was written because no code was specified to create.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.GeneratedFile">
+        <source>Emitted specified code into "{0}".</source>
+        <target state="new">Emitted specified code into "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WriteCodeFragment.Comment">
+        <source>Generated by the MSBuild WriteCodeFragment class.</source>
+        <target state="new">Generated by the MSBuild WriteCodeFragment class.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CodeElementIsMissing">
+        <source>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</source>
+        <target state="new">MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</target>
+        <note>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmpty">
+        <source>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NeedsITaskInterface">
+        <source>MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</source>
+        <target state="new">MSB3753: The task could not be instantiated because it does not implement the ITask interface. Make sure the task implements the Microsoft.Build.Framework.ITask interface.</target>
+        <note>{StrBegin="MSB3753: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.ReferenceAssemblyIsInvalid">
+        <source>MSB3754: The reference assembly "{0}" is invalid. "{1}"</source>
+        <target state="new">MSB3754: The reference assembly "{0}" is invalid. "{1}"</target>
+        <note>{StrBegin="MSB3754: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <note>{StrBegin="MSB3755: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidElementLocation">
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <note>{StrBegin="MSB3757: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilerError">
+        <source>MSB3758: An error has occurred during compilation. {0}</source>
+        <target state="new">MSB3758: An error has occurred during compilation. {0}</target>
+        <note>{StrBegin="MSB3758: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CouldNotFindTaskInAssembly">
+        <source>The task name "{0}" could not be found.</source>
+        <target state="new">The task name "{0}" could not be found.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.FindSourceFileAt">
+        <source>The source file for this compilation can be found at: "{0}"</source>
+        <target state="new">The source file for this compilation can be found at: "{0}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.HaveReflectionOnlyAssembly">
+        <source>The reference assembly "{0}" is a metadata only assembly.</source>
+        <target state="new">The reference assembly "{0}" is a metadata only assembly.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SearchingForSDK">
+        <source>Searching for SDK "{0}": </source>
+        <target state="new">Searching for SDK "{0}": </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundSDK">
+        <source>Found at search location "{0}".</source>
+        <target state="new">Found at search location "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorReadingManifest">
+        <source>There was a problem reading the SDK manifest file "{0}". {1}</source>
+        <target state="new">There was a problem reading the SDK manifest file "{0}". {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReadingSDKManifestFile">
+        <source>Reading SDK manifest file "{0}".</source>
+        <target state="new">Reading SDK manifest file "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetedConfigAndArchitecture">
+        <source>Targeted configuration and architecture "{0}|{1}"</source>
+        <target state="new">Targeted configuration and architecture "{0}|{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformSDK">
+        <source>Has a platform identity of "{0}".</source>
+        <target state="new">Has a platform identity of "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotFindFrameworkIdentity">
+        <source>Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </source>
+        <target state="new">Could not find "FrameworkIdentity" attribute "{0}" in the SDK manifest. </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoFrameworkIdentitiesFound">
+        <source>No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</source>
+        <target state="new">No FrameworkIdentity attributes were found in the SDK manifest, treating this SDK as a non-framework SDK.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoAppxLocationsFound">
+        <source>No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</source>
+        <target state="new">No "APPX" attributes indicating app package locations were found in the SDK manifest. If an app package is required at runtime the project may not run.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundFrameworkIdentity">
+        <source>Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "FrameworkIdentity" attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.FoundAppxLocation">
+        <source>Found "APPX" location attribute "{0}" in the SDK manifest.</source>
+        <target state="new">Found "APPX" location attribute "{0}" in the SDK manifest.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ReplaceAppxLocation">
+        <source>Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </source>
+        <target state="new">Updating the "{0}" architecture "APPX" location from "{1}" to "{2}". </target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoSDKLocationsSpecified">
+        <source>Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</source>
+        <target state="new">Cannot resolve "SDKReference" items because no installed SDK locations were passed into the property "InstalledSdks".</target>
+        <note>"SDKReference" and "InstalledSDKs" are property names on the task and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameFamily">
+        <source>MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</source>
+        <target state="new">MSB3773: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, as they all belong to the same SDK product Family "{2}". Please consider removing references to other SDKs of the same product family.</target>
+        <note>{StrBegin="MSB3773: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CouldNotResolveSDK">
+        <source>MSB3774: Could not find SDK "{0}".</source>
+        <target state="new">MSB3774: Could not find SDK "{0}".</target>
+        <note>{StrBegin="MSB3774: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.ErrorResolvingSDK">
+        <source>MSB3775: There was an error resolving the SDK "{0}". {1}</source>
+        <target state="new">MSB3775: There was an error resolving the SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB3775: "} "{0}" will be the root location which could not be searched. Ie (c:\program files\sdks\..) </note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKReferenceIncorrectFormat">
+        <source>MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</source>
+        <target state="new">MSB3776: The SDK Reference "{0}" is incorrectly formatted. It must be in the following format "&lt;SDKName&gt;, Version=&lt;SDKVersion&gt;. For example: "MySDK, Version=2.0"</target>
+        <note>{StrBegin="MSB3776: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingFrameworkIdentity">
+        <source>MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</source>
+        <target state="new">MSB3777: "FrameworkIdentity" attributes were found in the SDK manifest file "{0}", however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "FrameworkIdentity" attribute without configuration and architecture could be found. If this project is to be packaged, packaging will fail.</target>
+        <note>{StrBegin="MSB3777: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.NoMatchingAppxLocation">
+        <source>MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</source>
+        <target state="new">MSB3778: "APPX" attributes were found in the SDK manifest file "{0}" however none of the attributes matched the targeted configuration and architecture "{1} | {2}" and no "APPX" attribute without configuration and architecture could be found. If an app package is required then the project will fail at runtime.</target>
+        <note>{StrBegin="MSB3778: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetArchitectureNotSupported">
+        <source>MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</source>
+        <target state="new">MSB3779: The processor architecture of the project being built "{0}" is not supported by the referenced SDK "{1}". Please consider changing the targeted processor architecture of your project (in Visual Studio this can be done through the Configuration Manager) to one of the architectures supported by the SDK: "{2}".</target>
+        <note>{StrBegin="MSB3779: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.CannotReferenceTwoSDKsSameName">
+        <source>MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</source>
+        <target state="new">MSB3780: The SDK "{0}" cannot be referenced alongside SDK(s) {1}, because only one version of the SDK can be referenced from a project. Please consider removing references to the other SDKs.</target>
+        <note>{StrBegin="MSB3780: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.SDKMissingDependency">
+        <source>MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</source>
+        <target state="new">MSB3781: The SDK "{0}" depends on the following SDK(s) {1}, which have not been added to the project or were not found. Please ensure that you add these dependencies to your project or you may experience runtime issues. You can add dependencies to your project through the Reference Manager.</target>
+        <note>{StrBegin="MSB3781: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject">
+        <source>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</source>
+        <target state="new">MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</target>
+        <note>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion">
+        <source>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3783: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.InvalidDependencyInPlatform">
+        <source>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</source>
+        <target state="new">MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</target>
+        <note>{StrBegin="MSB3841: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.MaxPlatformVersionNotSpecified">
+        <source>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</source>
+        <target state="new">MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</target>
+        <note>{StrBegin="MSB3842: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.TargetPlatformIdentifierDoesNotMatch">
+        <source>MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</source>
+        <target state="new">MSB3843: Project "{0}" targets platform "{3}", but references SDK "{1} v{2}" which targets platform "{4}".</target>
+        <note>{StrBegin="MSB3843: "}</note>
+      </trans-unit>
+      <trans-unit id="ResolveSDKReference.PlatformVersionIsLessThanMinVersion">
+        <source>MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</source>
+        <target state="new">MSB3844: Project "{0}" targets platform version "{3}", but references SDK "{1} v{2}" which requires platform version "{4}" or higher.</target>
+        <note>{StrBegin="MSB3844: "}</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.ListInstalledSDKs">
+        <source>Installed SDKs:</source>
+        <target state="new">Installed SDKs:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SDKNameAndLocation">
+        <source>SDK "{0}" is installed at "{1}"</source>
+        <target state="new">SDK "{0}" is installed at "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.FoundSDKs">
+        <source>Found "{0}" SDKs.</source>
+        <target state="new">Found "{0}" SDKs.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.SearchingForSDKs">
+        <source>Searching for SDKs targeting "{0}, {1}".</source>
+        <target state="new">Searching for SDKs targeting "{0}, {1}".</target>
+        <note>{0} will be the platform identifier, "Windows" and {1} will be a version number</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.TargetPlatformInformationMissing">
+        <source>MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</source>
+        <target state="new">MSB3784: "TargetPlatformVersion" and "TargetPlatformIdentifier" cannot be empty.</target>
+        <note>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.NoSDksFound">
+        <source>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</source>
+        <target state="new">MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</target>
+        <note>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="GetInstalledSDKs.CouldNotGetSDKList">
+        <source>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</source>
+        <target state="new">MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</target>
+        <note>{StrBegin="MSB3786: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.GetSDKReferences">
+        <source>Enumerating SDK Reference "{0}" from "{1}".</source>
+        <target state="new">Enumerating SDK Reference "{0}" from "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandReferencesFrom">
+        <source>Looking for references under "{0}".</source>
+        <target state="new">Looking for references under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ExpandRedistFrom">
+        <source>Looking for redist files under "{0}".</source>
+        <target state="new">Looking for redist files under "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NotExpanding">
+        <source>Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</source>
+        <target state="new">Not enumerating SDK Reference "{0}" because the "ExpandReferences" metadata is not true on the reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingReference">
+        <source>Adding reference "{0}".</source>
+        <target state="new">Adding reference "{0}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.AddingRedistFile">
+        <source>Adding file "{0}" from redist folder with target path "{1}".</source>
+        <target state="new">Adding file "{0}" from redist folder with target path "{1}".</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistSameSDK">
+        <source>There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two redist files going to the same target path "{0}" within the "{1}" SDK. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictRedistDifferentSDK">
+        <source>There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two files from the redist folder files going to the same target path "{0}" between the "{1}" and "{2}" SDKs. Choosing "{3}" over "{4}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceSameSDK">
+        <source>There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name resolved within the "{0}" SDK. Choosing "{1}" over "{2}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictReferenceDifferentSDK">
+        <source>There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</source>
+        <target state="new">There was a conflict between two references with the same file name between the "{0}" and "{1}" SDKs. Choosing "{2}" over "{3}" because it was resolved first.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemReadingCacheFile">
+        <source>There was a problem reading the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem reading the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemDeletingCacheFile">
+        <source>There was a problem deleting the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem deleting the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGeneratingHash">
+        <source>There was a problem getting the time stamp of the current assembly "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the time stamp of the current assembly "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemGettingAssemblyMetadata">
+        <source>There was a problem getting the assembly metadata for "{0}". "{1}"</source>
+        <target state="new">There was a problem getting the assembly metadata for "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ProblemWritingCacheFile">
+        <source>There was a problem writing the cache file "{0}". "{1}"</source>
+        <target state="new">There was a problem writing the cache file "{0}". "{1}"</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.NoOriginalItemSpec">
+        <source>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</source>
+        <target state="new">The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles">
+        <source>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</source>
+        <target state="new">MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</target>
+        <note>{StrBegin="MSB3795: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.ConflictBetweenFiles">
+        <source>MSB3796: There was a conflict between two files. {0}</source>
+        <target state="new">MSB3796: There was a conflict between two files. {0}</target>
+        <note>{StrBegin="MSB3796: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetConfiguration">
+        <source>MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</source>
+        <target state="new">MSB3797: The targeted configuration for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted configuration.</target>
+        <note>{StrBegin="MSB3797: "}</note>
+      </trans-unit>
+      <trans-unit id="GetSDKReferenceFiles.CannotHaveEmptyTargetArchitecture">
+        <source>MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</source>
+        <target state="new">MSB3798: The targeted architecture for the resolved sdk reference "{0}" was empty. Cannot find reference or redist files without a targeted architecture.</target>
+        <note>{StrBegin="MSB3798: "}</note>
+      </trans-unit>
+      <trans-unit id="FindInvalidProjectReferences.WarnWhenVersionIsIncompatible">
+        <source>MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</source>
+        <target state="new">MSB3851: This project targets "{0}, Version={1}", but it is attempting to reference "{2}" targeting "{3}", which is invalid.</target>
+        <note>{StrBegin="MSB3851: "}</note>
+      </trans-unit>
+      <trans-unit id="ErrorFromResources.LogErrorFailure">
+        <source>MSB3861: Failed to log an error using resource string "{0}".  {1}</source>
+        <target state="new">MSB3861: Failed to log an error using resource string "{0}".  {1}</target>
+        <note>{StrBegin="MSB3861: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeSharing.CannotBuildSharedProject">
+        <source>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</source>
+        <target state="new">MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</target>
+        <note>{StrBegin="MSB3871: "}</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
We're changing the way we obtain localized builds of MSBuild. We will be storing localized resources in xlf files and keep them in sync with the resx files. This means that the community can contribute to translation.

I'm sending the xlf files ahead of the sync build code so the localization team can begin translating in advance