### PR TITLE
Workaround for issue causing ToolsPath character escaping

### DIFF
--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -35,7 +35,9 @@
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
     <msbuildToolsets default="15.0">
       <toolset toolsVersion="15.0">
-        <property name="MSBuildToolsPath" value="$([MSBuild]::GetCurrentExecutableDirectory())" />
+        <property name="MSBuildRootWorkaround704" value="$([MSBuild]::GetCurrentExecutableDirectory())" />
+        <!-- See https://github.com/Microsoft/msbuild/issues/704 -->
+        <property name="MSBuildToolsPath" value="$(MSBuildRootWorkaround704)" />
         <property name="MSBuildToolsPath32" value="$(MSBuildToolsPath)" />
         <property name="MSBuildToolsPath64" value="$(MSBuildToolsPath)\amd64" />
         <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1@InstallationFolder)" />


### PR DESCRIPTION
Related to #704
When referring to a function in a property definition MSBuild will escape
the value. This was causing the MSBuildToolsPath to contain escape
characters since the value is used directly. Referring to an already
defined property (VsInstallRoot) will workaround this issue.