### PR TITLE
Only include GitVersioning when it exists

### DIFF
--- a/src/dir.targets
+++ b/src/dir.targets
@@ -50,8 +50,9 @@
     <StartAction>Program</StartAction>
   </PropertyGroup>
 
+  <!-- TODO: re-enable Versioning https://github.com/Microsoft/msbuild/issues/694
   <Import Project="$(ToolPackagesDir)\Nerdbank.GitVersioning\1.4.19\build\dotnet\Nerdbank.GitVersioning.targets"
-          Condition="'$(MSBuildRuntimeType)' != 'Core'" />
+          Condition="'$(MSBuildRuntimeType)' != 'Core'" /> -->
 
   <!-- Restore packages -->
   <PropertyGroup>


### PR DESCRIPTION
Extracting this from #693, because it's causing us to fail to build NuGet packages in our (internal) build that produces them. On my machine, this can build after clean when invoked like the build definition does (with machine MSBuild).

Thanks for the fix, @mfilippov!