### PR TITLE
Add _CppCommonExtensionTargets search path workaround.

### DIFF
--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -67,6 +67,7 @@
             <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
+            <property name="_CppCommonExtensionTargets" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.Cpp.targets)"/>
           </searchPaths>
         </projectImportSearchPaths>
       </toolset>


### PR DESCRIPTION
Common C++ targets import this property whose value includes
$(MSBuildExtensionsPath). This workaround will allow for the extension
targets to be found when MSBuild is installed next to Visual Studio.