### PR TITLE
Fix Debug compilation problems in xplat

### DIFF
--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -10,8 +10,10 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.IO;
+#if !FEATURE_ASSEMBLY_LOADFROM
 using System.Reflection.PortableExecutable;
 using System.Reflection.Metadata;
+#endif
 
 namespace Microsoft.Build.Shared
 {

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -18,7 +18,9 @@ using System.Threading;
 
 using Microsoft.Build.Shared;
 using System.Reflection;
+#if !FEATURE_APM
 using System.Threading.Tasks;
+#endif
 
 namespace Microsoft.Build.Internal
 {
@@ -448,6 +450,7 @@ namespace Microsoft.Build.Internal
             return result;
         }
 
+#if !FEATURE_APM
         internal static async Task<int> ReadAsync(Stream stream, byte[] buffer, int bytesToRead)
         {
             int totalBytesRead = 0;
@@ -462,6 +465,7 @@ namespace Microsoft.Build.Internal
             }
             return totalBytesRead;
         }
+#endif
 
         /// <summary>
         /// Given the appropriate information, return the equivalent TaskHostContext.  

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -21,7 +21,9 @@ using System.Security;
 using System.Security.AccessControl;
 #endif
 using System.Security.Principal;
+#if !FEATURE_APM
 using System.Threading.Tasks;
+#endif
 #if FEATURE_SECURITY_PERMISSIONS
 using System.Security.Permissions;
 #endif

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -659,7 +659,7 @@ namespace Microsoft.Build.BackEnd
 #endif
             }
 
-
+#if !FEATURE_APM
             public async Task RunPacketReadLoopAsync()
             {
                 while (true)
@@ -723,6 +723,7 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
             }
+#endif
 
             /// <summary>
             /// Sends the specified packet to this node.

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -862,7 +862,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// Bad path when getting metadata through ->Metadata function
         /// </summary>
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void InvalidPathAndMetadataItemFunctionPathTooLong()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -883,7 +883,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// Bad path with illegal windows chars when getting metadata through ->Metadata function
         /// </summary>
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void InvalidPathAndMetadataItemFunctionInvalidWindowsPathChars()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -923,7 +923,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// Bad path when getting metadata through ->WithMetadataValue function
         /// </summary>
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void InvalidPathAndMetadataItemFunctionPathTooLong2()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -944,7 +944,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// Bad path with illegal windows chars when getting metadata through ->WithMetadataValue function
         /// </summary>
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void InvalidPathAndMetadataItemFunctionInvalidWindowsPathChars2()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -984,7 +984,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// Bad path when getting metadata through ->AnyHaveMetadataValue function
         /// </summary>
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void InvalidPathAndMetadataItemFunctionPathTooLong3()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -1005,7 +1005,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// Bad path with illegal windows chars when getting metadata through ->AnyHaveMetadataValue function
         /// </summary>
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void InvalidPathAndMetadataItemInvalidWindowsPathChars3()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"


### PR DESCRIPTION
Note: *compilation*. Tests fail all over the place.

This also doesn't get MSBuildTaskHost building. That'll require more work. But everything else compiles.