### PR TITLE
Fix project import search paths when property undefined.

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -2083,7 +2083,7 @@ namespace Microsoft.Build.Evaluation
 
             var pathsToSearch =
                 // The actual value of the property, with no fallbacks
-                new[] {prop.EvaluatedValue}
+                new[] { prop?.EvaluatedValue }
                 // The list of fallbacks, in order
                 .Concat(fallbackSearchPathMatch.SearchPaths).ToList();
 
@@ -2100,6 +2100,11 @@ namespace Microsoft.Build.Evaluation
             // 2. 1 or more project files *found* but ignored (like circular, self imports)
             foreach (var extensionPath in pathsToSearch)
             {
+                // In the rare case that the property we've enabled for search paths hasn't been defined
+                // we will skip it, but continue with other paths in the fallback order.
+                if (string.IsNullOrEmpty(extensionPath))
+                    continue;
+
                 string extensionPathExpanded = _data.ExpandString(extensionPath);
 
                 if (!Directory.Exists(extensionPathExpanded))

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -605,6 +605,71 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
+        // Fall-back search path on a property that is not defined.
+        [Fact]
+        public void FallbackImportWithUndefinedProperty()
+        {
+            string mainTargetsFileContent = @"
+               <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                   <Import Project='$(UndefinedProperty)\file.props' Condition=""Exists('$(UndefinedProperty)\file.props')"" />
+                   <Target Name='Main' DependsOnTargets='FromExtn' />
+               </Project>";
+
+            string extnTargetsFileContentTemplate = @"
+               <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                   <Target Name='FromExtn'>
+                       <Message Text='Running FromExtn'/>
+                   </Target>
+               </Project>";
+
+            var configFileContents = @"
+                <configuration>
+                  <configSections>
+                    <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                  </configSections>
+                  <msbuildToolsets default=""14.1"">
+                    <toolset toolsVersion=""14.1"">
+                      <property name=""MSBuildToolsPath"" value="".""/>
+                      <property name=""MSBuildBinPath"" value="".""/>
+                      <projectImportSearchPaths>
+                        <searchPaths os=""" + NativeMethodsShared.GetOSNameForExtensionsPath() + @""">
+                          <property name=""UndefinedProperty"" value=""$(FallbackExpandDir1)"" />
+                        </searchPaths>
+                      </projectImportSearchPaths>
+                     </toolset>
+                  </msbuildToolsets>
+                </configuration>";
+
+            string extnDir1 = null;
+            string mainProjectPath = null;
+
+            try
+            {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("file.props"),
+                    extnTargetsFileContentTemplate);
+
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
+
+                ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
+                var reader = GetStandardConfigurationReader();
+
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
+
+                projectCollection.ResetToolsetsForTests(reader);
+                var logger = new MockLogger();
+                projectCollection.RegisterLogger(logger);
+
+                var project = projectCollection.LoadProject(mainProjectPath);
+                Assert.True(project.Build("Main"));
+                logger.AssertLogContains("Running FromExtn");
+            }
+            finally
+            {
+                FileUtilities.DeleteNoThrow(mainProjectPath);
+                FileUtilities.DeleteDirectoryNoThrow(extnDir1, true);
+            }
+        }
+
         void CreateAndBuildProjectForImportFromExtensionsPath(string extnPathPropertyName, Action<Project, MockLogger> action)
         {
             string extnDir1 = null, extnDir2 = null, mainProjectPath = null;


### PR DESCRIPTION
Fix a null ref Exception when the evaluator tries to implement import
search paths for a property that does not (yet) exist. In this case the
search path(s) will still be checked but the current null value will be
ignored.