### PR TITLE
Update setup to drop x86 AnyCPU binaries for AMD64

### DIFF
--- a/setup/files.swr
+++ b/setup/files.swr
@@ -37,35 +37,36 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)Microsoft.WorkflowBuildExtensions.targets
 
 folder InstallDir:\MSBuild\15.0\Bin\amd64
-  file source=$(X64BinPath)Microsoft.Build.dll vs.file.ngen=yes
-  file source=$(X64BinPath)Microsoft.Build.Framework.dll vs.file.ngen=yes
-  file source=$(X64BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngen=yes
-  file source=$(X64BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngen=yes
   file source=$(X64BinPath)MSBuild.exe vs.file.ngen=yes
-  file source=$(X64BinPath)MSBuild.exe.config
   file source=$(X64BinPath)MSBuildTaskHost.exe vs.file.ngen=yes
-  file source=$(X64BinPath)MSBuildTaskHost.exe.config
-  file source=$(X64BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngen=yes
-  file source=$(X64BinPath)Microsoft.Common.CurrentVersion.targets
-  file source=$(X64BinPath)Microsoft.Common.overridetasks
-  file source=$(X64BinPath)Microsoft.Common.targets
-  file source=$(X64BinPath)Microsoft.Common.tasks
-  file source=$(X64BinPath)Microsoft.CSharp.CurrentVersion.targets
-  file source=$(X64BinPath)Microsoft.CSharp.targets
-  file source=$(X64BinPath)Microsoft.NetFramework.CurrentVersion.props
-  file source=$(X64BinPath)Microsoft.NetFramework.CurrentVersion.targets
-  file source=$(X64BinPath)Microsoft.NetFramework.props
-  file source=$(X64BinPath)Microsoft.NetFramework.targets
-  file source=$(X64BinPath)Microsoft.VisualBasic.CurrentVersion.targets
-  file source=$(X64BinPath)Microsoft.VisualBasic.targets
-  file source=$(X64BinPath)MSBuild.rsp
-  file source=$(X64BinPath)Workflow.targets
-  file source=$(X64BinPath)Workflow.VisualBasic.targets
-  file source=$(X64BinPath)Microsoft.Xaml.targets
-  file source=$(X64BinPath)Microsoft.Data.Entity.targets
-  file source=$(X64BinPath)Microsoft.ServiceModel.targets
-  file source=$(X64BinPath)Microsoft.WinFx.targets
-  file source=$(X64BinPath)Microsoft.WorkflowBuildExtensions.targets
+
+  file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngen=yes
+  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngen=yes
+  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngen=yes
+  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngen=yes
+  file source=$(X86BinPath)MSBuild.exe.config
+  file source=$(X86BinPath)MSBuildTaskHost.exe.config
+  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngen=yes
+  file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.Common.overridetasks
+  file source=$(X86BinPath)Microsoft.Common.targets
+  file source=$(X86BinPath)Microsoft.Common.tasks
+  file source=$(X86BinPath)Microsoft.CSharp.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.CSharp.targets
+  file source=$(X86BinPath)Microsoft.NetFramework.CurrentVersion.props
+  file source=$(X86BinPath)Microsoft.NetFramework.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.NetFramework.props
+  file source=$(X86BinPath)Microsoft.NetFramework.targets
+  file source=$(X86BinPath)Microsoft.VisualBasic.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.VisualBasic.targets
+  file source=$(X86BinPath)MSBuild.rsp
+  file source=$(X86BinPath)Workflow.targets
+  file source=$(X86BinPath)Workflow.VisualBasic.targets
+  file source=$(X86BinPath)Microsoft.Xaml.targets
+  file source=$(X86BinPath)Microsoft.Data.Entity.targets
+  file source=$(X86BinPath)Microsoft.ServiceModel.targets
+  file source=$(X86BinPath)Microsoft.WinFx.targets
+  file source=$(X86BinPath)Microsoft.WorkflowBuildExtensions.targets
 
 folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)Framework\Microsoft.Build.Framework.pkgdef


### PR DESCRIPTION
This will ensure that the AnyCPU binaries in the root and AMD64 folder are
bitwise identical. This was a suspected culprit in an issue where x64 OOP
MSBuild ended up loading multiple duplicate types.

Related to #764