### PR TITLE
Evaluate item lists lazily

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -816,11 +816,41 @@ namespace Microsoft.Build.Evaluation
             string endPass2 = String.Format(CultureInfo.CurrentCulture, "Evaluate Project {0} - End Pass 2 (Item Definitions)", projectFile);
             DataCollection.CommentMarkProfile(8818, endPass2);
 #endif
+            LazyItemEvaluator<P, I, M, D> lazyEvaluator = null;
+            lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _buildEventContext, _loggingService);
+
             // Pass3: evaluate project items
             foreach (ProjectItemGroupElement itemGroupElement in _itemGroupElements)
             {
-                EvaluateItemGroupElement(itemGroupElement);
+                EvaluateItemGroupElement(itemGroupElement, lazyEvaluator);
             }
+
+            if (lazyEvaluator != null)
+            {
+                IList<LazyItemEvaluator<P, I, M, D>.ItemData> items = lazyEvaluator.GetAllItems();
+                foreach (var itemData in items)
+                {
+                    if (itemData.ConditionResult)
+                    {
+                        _data.AddItem(itemData.Item);
+
+                        if (_data.ShouldEvaluateForDesignTime)
+                        {
+                            _data.AddToAllEvaluatedItemsList(itemData.Item);
+                        }
+                    }
+                }
+
+                if (_data.ShouldEvaluateForDesignTime)
+                {
+                    foreach (var itemData in items)
+                    {
+                        _data.AddItemIgnoringCondition(itemData.Item);
+                    }
+                }
+
+            }
+
 #if (!STANDALONEBUILD)
             CodeMarkers.Instance.CodeMarker(CodeMarkerEvent.perfMSBuildProjectEvaluatePass3End);
 #endif
@@ -1200,7 +1230,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Evaluate the items in the itemgroup and add the applicable ones to the data passed in
         /// </summary>
-        private void EvaluateItemGroupElement(ProjectItemGroupElement itemGroupElement)
+        private void EvaluateItemGroupElement(ProjectItemGroupElement itemGroupElement, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
         {
 #if FEATURE_MSBUILD_DEBUGGER
             if (DebuggerManager.DebuggingEnabled)
@@ -1209,13 +1239,21 @@ namespace Microsoft.Build.Evaluation
             }
 #endif
 
-            bool itemGroupConditionResult = EvaluateCondition(itemGroupElement, ExpanderOptions.ExpandPropertiesAndItems, ParserOptions.AllowPropertiesAndItemLists);
+            bool itemGroupConditionResult;
+            if (lazyEvaluator != null)
+            {
+                itemGroupConditionResult = lazyEvaluator.EvaluateConditionWithCurrentState(itemGroupElement, ExpanderOptions.ExpandPropertiesAndItems, ParserOptions.AllowPropertiesAndItemLists);
+            }
+            else
+            {
+                itemGroupConditionResult = EvaluateCondition(itemGroupElement, ExpanderOptions.ExpandPropertiesAndItems, ParserOptions.AllowPropertiesAndItemLists);
+            }
 
             if (itemGroupConditionResult || _data.ShouldEvaluateForDesignTime)
             {
                 foreach (ProjectItemElement itemElement in itemGroupElement.Items)
                 {
-                    EvaluateItemElement(itemGroupConditionResult, itemElement);
+                    EvaluateItemElement(itemGroupConditionResult, itemElement, lazyEvaluator);
                 }
             }
         }
@@ -1572,7 +1610,7 @@ namespace Microsoft.Build.Evaluation
         /// If specified, or if the condition on the item itself is false, only gathers the result into the list of items-ignoring-condition,
         /// and not into the real list of items.
         /// </summary>
-        private void EvaluateItemElement(bool itemGroupConditionResult, ProjectItemElement itemElement)
+        private void EvaluateItemElement(bool itemGroupConditionResult, ProjectItemElement itemElement, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
         {
 #if FEATURE_MSBUILD_DEBUGGER
             if (DebuggerManager.DebuggingEnabled)
@@ -1581,7 +1619,15 @@ namespace Microsoft.Build.Evaluation
             }
 #endif
 
-            bool itemConditionResult = EvaluateCondition(itemElement, ExpanderOptions.ExpandPropertiesAndItems, ParserOptions.AllowPropertiesAndItemLists);
+            bool itemConditionResult;
+            if (lazyEvaluator != null)
+            {
+                itemConditionResult = lazyEvaluator.EvaluateConditionWithCurrentState(itemElement, ExpanderOptions.ExpandPropertiesAndItems, ParserOptions.AllowPropertiesAndItemLists);
+            }
+            else
+            {
+                itemConditionResult = EvaluateCondition(itemElement, ExpanderOptions.ExpandPropertiesAndItems, ParserOptions.AllowPropertiesAndItemLists);
+            }
 
             if (!itemConditionResult && !_data.ShouldEvaluateForDesignTime)
             {
@@ -1595,6 +1641,12 @@ namespace Microsoft.Build.Evaluation
                 return;
             }
 
+            if (lazyEvaluator != null)
+            {
+                lazyEvaluator.ProcessItemElement(_projectRootElement.DirectoryPath, itemElement, itemGroupConditionResult && itemConditionResult);
+                return;
+            }
+            
             // Paths in items are evaluated relative to the outer project file, rather than relative to any targets file they may be contained in
             IList<I> items = CreateItemsFromInclude(_projectRootElement.DirectoryPath, itemElement, _itemFactory, itemElement.Include, _expander);
 

--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -396,6 +396,22 @@ namespace Microsoft.Build.Evaluation
             return ItemExpander.ExpandSingleItemVectorExpressionIntoItems(this, expression, _items, itemFactory, options, includeNullItems, out isTransformExpression, elementLocation);
         }
 
+        internal static ExpressionShredder.ItemExpressionCapture ExpandSingleItemVectorExpressionIntoExpressionCapture(
+                string expression, ExpanderOptions options, IElementLocation elementLocation)
+        {
+            return ItemExpander.ExpandSingleItemVectorExpressionIntoExpressionCapture(expression, options, elementLocation);
+        }
+
+        internal IList<T> ExpandExpressionCaptureIntoItems<S, T>(
+                ExpressionShredder.ItemExpressionCapture expressionCapture, IItemProvider<S> items, IItemFactory<S, T> itemFactory,
+                ExpanderOptions options, bool includeNullEntries, out bool isTransformExpression, IElementLocation elementLocation)
+            where S : class, IItem
+            where T : class, IItem
+        {
+            return ItemExpander.ExpandExpressionCaptureIntoItems<S, T>(expressionCapture, this, items, itemFactory, options,
+                includeNullEntries, out isTransformExpression, elementLocation);
+        }
+
         /// <summary>
         /// Returns true if the supplied string contains a valid property name
         /// </summary>
@@ -1518,18 +1534,31 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             /// <typeparam name="S">Type of the items provided by the item source used for expansion</typeparam>
             /// <typeparam name="T">Type of the items that should be returned</typeparam>
-            internal static IList<T> ExpandSingleItemVectorExpressionIntoItems<S, T>(Expander<P, I> expander, string expression, IItemProvider<S> items, IItemFactory<S, T> itemFactory, ExpanderOptions options, bool includeNullEntries, out bool isTransformExpression, IElementLocation elementLocation)
+            internal static IList<T> ExpandSingleItemVectorExpressionIntoItems<S, T>(
+                    Expander<P, I> expander, string expression, IItemProvider<S> items, IItemFactory<S, T> itemFactory, ExpanderOptions options,
+                    bool includeNullEntries, out bool isTransformExpression, IElementLocation elementLocation)
                 where S : class, IItem
                 where T : class, IItem
             {
                 isTransformExpression = false;
 
-                if (((options & ExpanderOptions.ExpandItems) == 0) || (expression.Length == 0))
+                var expressionCapture = ExpandSingleItemVectorExpressionIntoExpressionCapture(expression, options, elementLocation);
+                if (expressionCapture == null)
                 {
                     return null;
                 }
 
-                ErrorUtilities.VerifyThrow(items != null, "Cannot expand items without providing items");
+                return ExpandExpressionCaptureIntoItems(expressionCapture, expander, items, itemFactory, options, includeNullEntries,
+                    out isTransformExpression, elementLocation);
+            }
+
+            internal static ExpressionShredder.ItemExpressionCapture ExpandSingleItemVectorExpressionIntoExpressionCapture(
+                    string expression, ExpanderOptions options, IElementLocation elementLocation)
+            {
+                if (((options & ExpanderOptions.ExpandItems) == 0) || (expression.Length == 0))
+                {
+                    return null;
+                }
 
                 List<ExpressionShredder.ItemExpressionCapture> matches = null;
 
@@ -1556,18 +1585,31 @@ namespace Microsoft.Build.Evaluation
                 ProjectErrorUtilities.VerifyThrowInvalidProject(match.Value == expression, elementLocation, "EmbeddedItemVectorCannotBeItemized", expression);
                 ErrorUtilities.VerifyThrow(matches.Count == 1, "Expected just one item vector");
 
+                return match;
+            }
+
+            internal static IList<T> ExpandExpressionCaptureIntoItems<S, T>(
+                    ExpressionShredder.ItemExpressionCapture expressionCapture, Expander<P, I> expander, IItemProvider<S> items, IItemFactory<S, T> itemFactory,
+                    ExpanderOptions options, bool includeNullEntries, out bool isTransformExpression, IElementLocation elementLocation)
+                where S : class, IItem
+                where T : class, IItem
+            {
+                ErrorUtilities.VerifyThrow(items != null, "Cannot expand items without providing items");
+
+                isTransformExpression = false;
+
                 // If the incoming factory doesn't have an item type that it can use to 
                 // create items, it's our indication that the caller wants its items to have the type of the
                 // expression being expanded. For example, items from expanding "@(Compile") should
                 // have the item type "Compile".
                 if (itemFactory.ItemType == null)
                 {
-                    itemFactory.ItemType = match.ItemType;
+                    itemFactory.ItemType = expressionCapture.ItemType;
                 }
 
                 IList<T> result = null;
 
-                if (match.Separator != null)
+                if (expressionCapture.Separator != null)
                 {
                     // Reference contains a separator, for example @(Compile, ';').
                     // We need to flatten the list into 
@@ -1576,7 +1618,7 @@ namespace Microsoft.Build.Evaluation
                     string expandedItemVector;
                     using (var builder = new ReuseableStringBuilder())
                     {
-                        bool brokeEarlyNonEmpty = ExpandItemVectorMatchIntoStringBuilder(expander, match, items, elementLocation, builder, options);
+                        bool brokeEarlyNonEmpty = ExpandItemVectorMatchIntoStringBuilder(expander, expressionCapture, items, elementLocation, builder, options);
 
                         if (brokeEarlyNonEmpty)
                         {
@@ -1603,18 +1645,18 @@ namespace Microsoft.Build.Evaluation
                 // eg.,:
                 // expands @(Compile) to a set of items cloned from the items in the "Compile" list
                 // expands @(Compile->'%(foo)') to a set of items with the Include value of items in the "Compile" list.
-                if (match.Captures != null)
+                if (expressionCapture.Captures != null)
                 {
                     isTransformExpression = true;
                 }
 
-                ICollection<S> itemsOfType = items.GetItems(match.ItemType);
+                ICollection<S> itemsOfType = items.GetItems(expressionCapture.ItemType);
 
                 // If there are no items of the given type, then bail out early
                 if (itemsOfType.Count == 0)
                 {
                     // .. but only if there isn't a function "Count()", since that will want to return something (zero) for an empty list
-                    if (match.Captures == null || !match.Captures.Any(capture => String.Equals(capture.FunctionName, "Count", StringComparison.OrdinalIgnoreCase)))
+                    if (expressionCapture.Captures == null || !expressionCapture.Captures.Any(capture => String.Equals(capture.FunctionName, "Count", StringComparison.OrdinalIgnoreCase)))
                     {
                         return new List<T>();
                     }
@@ -1640,7 +1682,7 @@ namespace Microsoft.Build.Evaluation
                     return result;
                 }
 
-                Stack<TransformFunction<S>> transformFunctionStack = PrepareTransformStackFromMatch<S>(elementLocation, match);
+                Stack<TransformFunction<S>> transformFunctionStack = PrepareTransformStackFromMatch<S>(elementLocation, expressionCapture);
 
                 // iterate over our tranform chain, creating the final items from its results
                 foreach (Tuple<string, S> itemTuple in Transform<S>(expander, includeNullEntries, transformFunctionStack, IntrinsicItemFunctions<S>.GetItemTupleEnumerator(itemsOfType)))

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -1,0 +1,285 @@
+﻿using Microsoft.Build.Collections;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal partial class LazyItemEvaluator<P, I, M, D>
+    {
+        class EvaluatorData : IEvaluatorData<P, I, M, D>
+        {
+            IEvaluatorData<P, I, M, D> _wrappedData;
+            Func<string, ICollection<I>> _itemGetter;
+
+            public EvaluatorData(IEvaluatorData<P, I, M, D> wrappedData, Func<string, ICollection<I>> itemGetter)
+            {
+                _wrappedData = wrappedData;
+                _itemGetter = itemGetter;
+            }
+
+            public ItemDictionary<I> Items
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public ICollection<I> GetItems(string itemType)
+            {
+                return _itemGetter(itemType);
+            }
+
+
+            public IDictionary<string, List<TargetSpecification>> AfterTargets
+            {
+                get
+                {
+                    return _wrappedData.AfterTargets;
+                }
+
+                set
+                {
+                    _wrappedData.AfterTargets = value;
+                }
+            }
+
+            public IDictionary<string, List<TargetSpecification>> BeforeTargets
+            {
+                get
+                {
+                    return _wrappedData.BeforeTargets;
+                }
+
+                set
+                {
+                    _wrappedData.BeforeTargets = value;
+                }
+            }
+
+            public Dictionary<string, List<string>> ConditionedProperties
+            {
+                get
+                {
+                    return _wrappedData.ConditionedProperties;
+                }
+            }
+
+            public List<string> DefaultTargets
+            {
+                get
+                {
+                    return _wrappedData.DefaultTargets;
+                }
+
+                set
+                {
+                    _wrappedData.DefaultTargets = value;
+                }
+            }
+
+            public string Directory
+            {
+                get
+                {
+                    return _wrappedData.Directory;
+                }
+            }
+
+            public string ExplicitToolsVersion
+            {
+                get
+                {
+                    return _wrappedData.ExplicitToolsVersion;
+                }
+            }
+
+            public PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary
+            {
+                get
+                {
+                    return _wrappedData.GlobalPropertiesDictionary;
+                }
+            }
+
+            public ISet<string> GlobalPropertiesToTreatAsLocal
+            {
+                get
+                {
+                    return _wrappedData.GlobalPropertiesToTreatAsLocal;
+                }
+            }
+
+            public List<string> InitialTargets
+            {
+                get
+                {
+                    return _wrappedData.InitialTargets;
+                }
+
+                set
+                {
+                    _wrappedData.InitialTargets = value;
+                }
+            }
+
+            public IEnumerable<D> ItemDefinitionsEnumerable
+            {
+                get
+                {
+                    return _wrappedData.ItemDefinitionsEnumerable;
+                }
+            }
+
+           
+
+            public PropertyDictionary<P> Properties
+            {
+                get
+                {
+                    return _wrappedData.Properties;
+                }
+            }
+
+            public bool ShouldEvaluateForDesignTime
+            {
+                get
+                {
+                    return _wrappedData.ShouldEvaluateForDesignTime;
+                }
+            }
+
+            public string SubToolsetVersion
+            {
+                get
+                {
+                    return _wrappedData.SubToolsetVersion;
+                }
+            }
+
+            public TaskRegistry TaskRegistry
+            {
+                get
+                {
+                    return _wrappedData.TaskRegistry;
+                }
+
+                set
+                {
+                    _wrappedData.TaskRegistry = value;
+                }
+            }
+
+            public Toolset Toolset
+            {
+                get
+                {
+                    return _wrappedData.Toolset;
+                }
+            }
+
+            public void AddItem(I item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public IItemDefinition<M> AddItemDefinition(string itemType)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void AddItemIgnoringCondition(I item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void AddTarget(ProjectTargetInstance target)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void AddToAllEvaluatedItemDefinitionMetadataList(M itemDefinitionMetadatum)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void AddToAllEvaluatedItemsList(I item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void AddToAllEvaluatedPropertiesList(P property)
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool EvaluateCondition(string condition)
+            {
+                throw new NotSupportedException();
+            }
+
+            public string ExpandString(string unexpandedValue)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void FinishEvaluation()
+            {
+                _wrappedData.FinishEvaluation();
+            }
+
+            public IItemDefinition<M> GetItemDefinition(string itemType)
+            {
+                return _wrappedData.GetItemDefinition(itemType);
+            }
+
+            public P GetProperty(string name)
+            {
+                return _wrappedData.GetProperty(name);
+            }
+
+            public P GetProperty(string name, int startIndex, int endIndex)
+            {
+                return _wrappedData.GetProperty(name, startIndex, endIndex);
+            }
+
+            public ProjectTargetInstance GetTarget(string targetName)
+            {
+                return _wrappedData.GetTarget(targetName);
+            }
+
+            public void InitializeForEvaluation(IToolsetProvider toolsetProvider)
+            {
+                _wrappedData.InitializeForEvaluation(toolsetProvider);
+            }
+
+            public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated)
+            {
+                _wrappedData.RecordImport(importElement, import, versionEvaluated);
+            }
+
+            public void RecordImportWithDuplicates(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated)
+            {
+                _wrappedData.RecordImportWithDuplicates(importElement, import, versionEvaluated);
+            }
+
+            public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, P predecessor)
+            {
+                return _wrappedData.SetProperty(propertyElement, evaluatedValueEscaped, predecessor);
+            }
+
+            public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+            {
+                return _wrappedData.SetProperty(name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved);
+            }
+        }
+    }
+
+    
+}

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.ItemFactoryWrapper.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.ItemFactoryWrapper.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.Build.Collections;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal partial class LazyItemEvaluator<P, I, M, D>
+    {
+        class ItemFactoryWrapper : IItemFactory<I, I>
+        {
+            ProjectItemElement _itemElement;
+            IItemFactory<I, I> _wrappedItemFactory;
+
+            public ItemFactoryWrapper(ProjectItemElement itemElement, IItemFactory<I, I> wrappedItemFactory)
+            {
+                _itemElement = itemElement;
+                _wrappedItemFactory = wrappedItemFactory;
+            }
+
+            void SetItemElement()
+            {
+                _wrappedItemFactory.ItemElement = _itemElement;
+            }
+
+            public ProjectItemElement ItemElement
+            {
+                set
+                {
+                    _itemElement = value;
+                    SetItemElement();
+                }
+            }
+
+            public string ItemType
+            {
+                get
+                {
+                    SetItemElement();
+                    return _wrappedItemFactory.ItemType;
+                }
+
+                set
+                {
+                    throw new NotSupportedException();
+                }
+            }
+
+            public I CreateItem(I source, string definingProject)
+            {
+                SetItemElement();
+                return _wrappedItemFactory.CreateItem(source, definingProject);
+            }
+
+            public I CreateItem(string include, string definingProject)
+            {
+                SetItemElement();
+                return _wrappedItemFactory.CreateItem(include, definingProject);
+            }
+
+            public I CreateItem(string include, string includeBeforeWildcardExpansion, string definingProject)
+            {
+                SetItemElement();
+                return _wrappedItemFactory.CreateItem(include, includeBeforeWildcardExpansion, definingProject);
+            }
+
+            public I CreateItem(string include, I baseItem, string definingProject)
+            {
+                SetItemElement();
+                return _wrappedItemFactory.CreateItem(include, baseItem, definingProject);
+            }
+
+            public void SetMetadata(IEnumerable<Pair<ProjectMetadataElement, string>> metadata, IEnumerable<I> destinationItems)
+            {
+                SetItemElement();
+                _wrappedItemFactory.SetMetadata(metadata, destinationItems);
+            }
+        }
+    }
+}

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
@@ -1,0 +1,704 @@
+﻿using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Debugging;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal partial class LazyItemEvaluator<P, I, M, D>
+        where P : class, IProperty, IEquatable<P>, IValued
+        where I : class, IItem<M>, IMetadataTable
+        where M : class, IMetadatum
+        where D : class, IItemDefinition<M>
+    {
+        private readonly IEvaluatorData<P, I, M, D> _outerEvaluatorData;
+        private readonly Expander<P, I> _outerExpander;
+        private readonly IEvaluatorData<P, I, M, D> _evaluatorData;
+        private readonly Expander<P, I> _expander;
+
+        private readonly IItemFactory<I, I> _itemFactory;
+
+        private int _nextElementOrder = 0;
+
+        /// <summary>
+        /// Build event context to log evaluator events in.
+        /// </summary>
+        private BuildEventContext _buildEventContext = null;
+
+        /// <summary>
+        /// The logging service for use during evaluation
+        /// </summary>
+        private readonly ILoggingService _loggingService;
+
+        /// <summary>
+        /// The CultureInfo from the invariant culture. Used to avoid allocations for
+        /// perfoming IndexOf etc.
+        /// </summary>
+        private static CompareInfo s_invariantCompareInfo = CultureInfo.InvariantCulture.CompareInfo;
+
+        Dictionary<string, LazyItemList> _itemLists = new Dictionary<string, LazyItemList>();
+
+        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, BuildEventContext buildEventContext, ILoggingService loggingService)
+        {
+            _outerEvaluatorData = data;
+            _outerExpander = new Expander<P, I>(_outerEvaluatorData, _outerEvaluatorData);
+            _evaluatorData = new EvaluatorData(_outerEvaluatorData, itemType => GetItems(itemType).Select(itemData => itemData.Item).ToList());
+            _expander = new Expander<P, I>(_evaluatorData, _evaluatorData);
+            _itemFactory = itemFactory;
+
+            _buildEventContext = buildEventContext;
+            _loggingService = loggingService;
+        }
+
+        ICollection<ItemData> GetItems(string itemType)
+        {
+            LazyItemList itemList = GetItemList(itemType);
+            if (itemList == null)
+            {
+                return ImmutableList<ItemData>.Empty;
+            }
+            return itemList.GetItems(ImmutableHashSet<string>.Empty);
+        }
+
+        public bool EvaluateConditionWithCurrentState(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions)
+        {
+            return EvaluateCondition(element, expanderOptions, parserOptions, _expander, this);
+        }
+
+        static bool EvaluateCondition(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions, Expander<P, I> expander, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
+        {
+            if (element.Condition.Length == 0)
+            {
+                return true;
+            }
+
+            bool result = ConditionEvaluator.EvaluateCondition
+                (
+                element.Condition,
+                parserOptions,
+                expander,
+                expanderOptions,
+                GetCurrentDirectoryForConditionEvaluation(element, lazyEvaluator),
+                element.ConditionLocation,
+                lazyEvaluator._loggingService,
+                lazyEvaluator._buildEventContext
+                );
+
+            return result;
+
+        }
+
+        /// <summary>
+        /// COMPAT: Whidbey used the "current project file/targets" directory for evaluating Import and PropertyGroup conditions
+        /// Orcas broke this by using the current root project file for all conditions
+        /// For Dev10+, we'll fix this, and use the current project file/targets directory for Import, ImportGroup and PropertyGroup
+        /// but the root project file for the rest. Inside of targets will use the root project file as always.
+        /// </summary>
+        private static string GetCurrentDirectoryForConditionEvaluation(ProjectElement element, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
+        {
+            if (element is ProjectPropertyGroupElement || element is ProjectImportElement || element is ProjectImportGroupElement)
+            {
+                return element.ContainingProject.DirectoryPath;
+            }
+            else
+            {
+                return lazyEvaluator._outerEvaluatorData.Directory;
+            }
+        }
+
+        public struct ItemData
+        {
+            I _item;
+            int _elementOrder;
+            bool _conditionResult;
+
+            public ItemData(I item, int elementOrder, bool conditionResult)
+            {
+                _item = item;
+                _elementOrder = elementOrder;
+                _conditionResult = conditionResult;
+            }
+
+            public I Item { get { return _item; } }
+            public int ElementOrder { get { return _elementOrder; } }
+            public bool ConditionResult { get { return _conditionResult; } }
+        }
+
+
+        class LazyItemList
+        {
+            readonly LazyItemList _previous;
+            readonly LazyItemOperation _operation;
+
+            public LazyItemList(LazyItemList previous, LazyItemOperation operation)
+            {
+                _previous = previous;
+                _operation = operation;
+            }
+
+            public ImmutableList<ItemData>.Builder GetItems(ImmutableHashSet<string> globsToIgnore)
+            {
+                ImmutableList<ItemData>.Builder items;
+                if (_previous == null)
+                {
+                    items = ImmutableList.CreateBuilder<ItemData>();
+                }
+                else
+                {
+                    //  TODO: remove operation should modify globsToIgnore
+                    items = _previous.GetItems(globsToIgnore);
+                }
+
+                _operation.Apply(items, globsToIgnore);
+
+                //  TODO: cache result if any globs were executed
+
+                return items;
+            }
+        }
+
+        //  Operations:
+        //  Add
+        //      Previous value
+        //      List<string> globs
+        //      List<string> values
+        //      List<LazyItemList> itemLists
+        //      List<string> excludes
+        //  Remove
+        //      Previous value
+        //      List<string> globsToRemove
+        //      List<string> valuesToRemove
+        //      List<LazyItemList> itemListsToRemove
+        //  Update - ???
+
+        abstract class LazyItemOperation
+        {
+            public abstract void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore);
+        }
+
+        enum IncludeOperationType
+        {
+            //  Values are escaped
+            Value,
+            //  Globs are not escaped
+            Glob,
+            Expression
+        }
+
+        class IncludeOperation : LazyItemOperation
+        {
+            readonly int _elementOrder;
+            readonly ProjectItemElement _itemElement;
+            readonly string _rootDirectory;
+            readonly string _itemType;
+            readonly bool _conditionResult;
+
+            readonly ImmutableList<Tuple<IncludeOperationType, object>> _operations;
+
+            readonly ImmutableDictionary<string, LazyItemList> _referencedItemLists;
+
+            readonly ImmutableList<string> _excludes;
+
+            readonly ImmutableList<ProjectMetadataElement> _metadata;
+
+            readonly LazyItemEvaluator<P, I, M, D> _lazyEvaluator;
+            readonly EvaluatorData _evaluatorData;
+            readonly Expander<P, I> _expander;
+            readonly IItemFactory<I, I> _itemFactory;
+
+            public IncludeOperation(IncludeOperationBuilder builder, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
+            {
+                _elementOrder = builder.ElementOrder;
+                _itemElement = builder.ItemElement;
+                _rootDirectory = builder.RootDirectory;
+                _itemType = builder.ItemType;
+                _conditionResult = builder.ConditionResult;
+
+                _operations = builder.Operations.ToImmutable();
+                _referencedItemLists = builder.ReferencedItemLists.ToImmutable();
+                _excludes = builder.Excludes.ToImmutable();
+                if (builder.Metadata != null)
+                {
+                    _metadata = builder.Metadata.ToImmutable();
+                }
+
+                _lazyEvaluator = lazyEvaluator;
+
+                _evaluatorData = new EvaluatorData(_lazyEvaluator._outerEvaluatorData, itemType => GetReferencedItems(itemType, ImmutableHashSet<string>.Empty));
+                _expander = new Expander<P, I>(_evaluatorData, _evaluatorData);
+
+                _itemFactory = new ItemFactoryWrapper(_itemElement, _lazyEvaluator._itemFactory);
+            }
+
+            public override void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
+            {
+                List<I> itemsToAdd = new List<I>();
+
+                foreach (var operation in _operations)
+                {
+                    if (operation.Item1 == IncludeOperationType.Expression)
+                    {
+                        // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
+                        bool throwaway;
+                        var itemsFromExpression = _expander.ExpandExpressionCaptureIntoItems(
+                            (ExpressionShredder.ItemExpressionCapture) operation.Item2, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
+                            false /* do not include null expansion results */, out throwaway, _itemElement.IncludeLocation);
+
+                        itemsToAdd.AddRange(itemsFromExpression);
+                    }
+                    else if (operation.Item1 == IncludeOperationType.Value)
+                    {
+                        string value = (string)operation.Item2;
+                        var item = _itemFactory.CreateItem(value, value, _itemElement.ContainingProject.FullPath);
+                        itemsToAdd.Add(item);
+                    }
+                    else if (operation.Item1 == IncludeOperationType.Glob)
+                    {
+                        string glob = (string)operation.Item2;
+                        string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(_rootDirectory, glob);
+                        foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
+                        {
+                            itemsToAdd.Add(_itemFactory.CreateItem(includeSplitFileEscaped, glob, _itemElement.ContainingProject.FullPath));
+                        }
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException(operation.Item1.ToString());
+                    }
+                }
+
+                if (_excludes.Any())
+                {
+                    //  TODO: Pass exclusion list to globbing code so excluded files don't need to be scanned (twice)
+
+                    HashSet<string> excludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (string exclude in _excludes)
+                    {
+                        string excludeExpanded = _expander.ExpandIntoStringLeaveEscaped(exclude, ExpanderOptions.ExpandPropertiesAndItems, _itemElement.ExcludeLocation);
+                        foreach (var excludeSplit in ExpressionShredder.SplitSemiColonSeparatedList(excludeExpanded))
+                        {
+                            string[] excludeSplitFiles = EngineFileUtilities.GetFileListEscaped(_rootDirectory, excludeSplit);
+
+                            foreach (string excludeSplitFile in excludeSplitFiles)
+                            {
+                                excludes.Add(EscapingUtilities.UnescapeAll(excludeSplitFile));
+                            }
+                        }
+                    }
+
+                    List<I> remainingItems = new List<I>();
+
+                    for (int i = 0; i < itemsToAdd.Count; i++)
+                    {
+                        if (!excludes.Contains(itemsToAdd[i].EvaluatedInclude))
+                        {
+                            remainingItems.Add(itemsToAdd[i]);
+                        }
+                    }
+
+                    itemsToAdd = remainingItems;
+                }
+
+                if (_metadata != null)
+                {
+                    ////////////////////////////////////////////////////
+                    // UNDONE: Implement batching here.
+                    //
+                    // We want to allow built-in metadata in metadata values here. 
+                    // For example, so that an Idl file can specify that its Tlb output should be named %(Filename).tlb.
+                    // 
+                    // In other words, we want batching. However, we won't need to go to the trouble of using the regular batching code!
+                    // That's because that code is all about grouping into buckets of similar items. In this context, we're not
+                    // invoking a task, and it's fine to process each item individually, which will always give the correct results.
+                    //
+                    // For the CTP, to make the minimal change, we will not do this quite correctly.
+                    //
+                    // We will do this:
+                    // -- check whether any metadata values or their conditions contain any bare built-in metadata expressions,
+                    //    or whether they contain any custom metadata && the Include involved an @(itemlist) expression.
+                    // -- if either case is found, we go ahead and evaluate all the metadata separately for each item.
+                    // -- otherwise we can do the old thing (evaluating all metadata once then applying to all items)
+                    // 
+                    // This algorithm gives the correct results except when:
+                    // -- batchable expressions exist on the include, exclude, or condition on the item element itself
+                    //
+                    // It means that 99% of cases still go through the old code, which is best for the CTP.
+                    // When we ultimately implement this correctly, we should make sure we optimize for the case of very many items
+                    // and little metadata, none of which varies between items.
+                    List<string> values = new List<string>(_metadata.Count * 2);
+
+                    foreach (ProjectMetadataElement metadatumElement in _metadata)
+                    {
+                        values.Add(metadatumElement.Value);
+                        values.Add(metadatumElement.Condition);
+                    }
+
+                    ItemsAndMetadataPair itemsAndMetadataFound = ExpressionShredder.GetReferencedItemNamesAndMetadata(values);
+
+                    bool needToProcessItemsIndividually = false;
+
+                    if (itemsAndMetadataFound.Metadata != null && itemsAndMetadataFound.Metadata.Values.Count > 0)
+                    {
+                        // If there is bare metadata of any kind, and the Include involved an item list, we should
+                        // run items individually, as even non-built-in metadata might differ between items
+
+                        if (_referencedItemLists.Count >= 0)
+                        {
+                            needToProcessItemsIndividually = true;
+                        }
+                        else
+                        {
+                            // If there is bare built-in metadata, we must always run items individually, as that almost
+                            // always differs between items.
+
+                            // UNDONE: When batching is implemented for real, we need to make sure that
+                            // item definition metadata is included in all metadata operations during evaluation
+                            if (itemsAndMetadataFound.Metadata.Values.Count > 0)
+                            {
+                                needToProcessItemsIndividually = true;
+                            }
+                        }
+                    }
+
+                    if (needToProcessItemsIndividually)
+                    {
+                        foreach (I item in itemsToAdd)
+                        {
+                            _expander.Metadata = item;
+
+                            foreach (ProjectMetadataElement metadatumElement in _metadata)
+                            {
+#if FEATURE_MSBUILD_DEBUGGER
+                                //if (DebuggerManager.DebuggingEnabled)
+                                //{
+                                //    DebuggerManager.PulseState(metadatumElement.Location, _itemPassLocals);
+                                //}
+#endif
+
+                                if (!EvaluateCondition(metadatumElement, ExpanderOptions.ExpandAll, ParserOptions.AllowAll, _expander, _lazyEvaluator))
+                                {
+                                    continue;
+                                }
+
+                                string evaluatedValue = _expander.ExpandIntoStringLeaveEscaped(metadatumElement.Value, ExpanderOptions.ExpandAll, metadatumElement.Location);
+
+                                item.SetMetadata(metadatumElement, evaluatedValue);
+                            }
+                        }
+
+                        // End of legal area for metadata expressions.
+                        _expander.Metadata = null;
+                    }
+
+                    // End of pseudo batching
+                    ////////////////////////////////////////////////////
+                    // Start of old code
+                    else
+                    {
+                        // Metadata expressions are allowed here.
+                        // Temporarily gather and expand these in a table so they can reference other metadata elements above.
+                        EvaluatorMetadataTable metadataTable = new EvaluatorMetadataTable(_itemType);
+                        _expander.Metadata = metadataTable;
+
+                        // Also keep a list of everything so we can get the predecessor objects correct.
+                        List<Pair<ProjectMetadataElement, string>> metadataList = new List<Pair<ProjectMetadataElement, string>>();
+
+                        foreach (ProjectMetadataElement metadatumElement in _metadata)
+                        {
+                            // Because of the checking above, it should be safe to expand metadata in conditions; the condition
+                            // will be true for either all the items or none
+                            if (!EvaluateCondition(metadatumElement, ExpanderOptions.ExpandAll, ParserOptions.AllowAll, _expander, _lazyEvaluator))
+                            {
+                                continue;
+                            }
+
+#if FEATURE_MSBUILD_DEBUGGER
+                        //if (DebuggerManager.DebuggingEnabled)
+                        //{
+                        //    DebuggerManager.PulseState(metadatumElement.Location, _itemPassLocals);
+                        //}
+#endif
+
+                            string evaluatedValue = _expander.ExpandIntoStringLeaveEscaped(metadatumElement.Value, ExpanderOptions.ExpandAll, metadatumElement.Location);
+
+                            metadataTable.SetValue(metadatumElement, evaluatedValue);
+                            metadataList.Add(new Pair<ProjectMetadataElement, string>(metadatumElement, evaluatedValue));
+                        }
+
+                        // Apply those metadata to each item
+                        // Note that several items could share the same metadata objects
+
+                        // Set all the items at once to make a potential copy-on-write optimization possible.
+                        // This is valuable in the case where one item element evaluates to
+                        // many items (either by semicolon or wildcards)
+                        // and that item also has the same piece/s of metadata for each item.
+                        _itemFactory.SetMetadata(metadataList, itemsToAdd);
+
+                        // End of legal area for metadata expressions.
+                        _expander.Metadata = null;
+                    }
+                }
+
+                listBuilder.AddRange(itemsToAdd.Select(item => new ItemData(item, _elementOrder, _conditionResult)));
+            }
+
+            IList<I> GetReferencedItems(string itemType, ImmutableHashSet<string> globsToIgnore)
+            {
+                LazyItemList itemList;
+                if (_referencedItemLists.TryGetValue(itemType, out itemList))
+                {
+                    return itemList.GetItems(globsToIgnore).Select(itemData => itemData.Item).ToList();
+                }
+                else
+                {
+                    return ImmutableList<I>.Empty;
+                }
+            }
+        }
+
+        class IncludeOperationBuilder
+        {
+            public int ElementOrder { get; set; }
+            public ProjectItemElement ItemElement { get; set; }
+            public string RootDirectory { get; set; }
+            public string ItemType { get; set; }
+            public bool ConditionResult { get; set; }
+
+            public ImmutableList<Tuple<IncludeOperationType, object>>.Builder Operations = ImmutableList.CreateBuilder<Tuple<IncludeOperationType, object>>();
+            //public ImmutableList<string>.Builder Values { get; set; } = ImmutableList.CreateBuilder<string>();
+            //public ImmutableList<string>.Builder Globs { get; set; } = ImmutableList.CreateBuilder<string>();
+            public ImmutableDictionary<string, LazyItemList>.Builder ReferencedItemLists { get; set; } = ImmutableDictionary.CreateBuilder<string, LazyItemList>();
+            //public ImmutableList<ExpressionShredder.ItemExpressionCapture>.Builder ItemExpressions { get; set; } = ImmutableList.CreateBuilder<ExpressionShredder.ItemExpressionCapture>();
+            public ImmutableList<string>.Builder Excludes { get; set; } = ImmutableList.CreateBuilder<string>();
+            public ImmutableList<ProjectMetadataElement>.Builder Metadata;
+
+            public IncludeOperation CreateOperation(LazyItemEvaluator<P, I, M, D> lazyEvaluator)
+            {
+                return new IncludeOperation(this, lazyEvaluator);
+            }
+        }
+
+        LazyItemList GetItemList(string itemType)
+        {
+            LazyItemList ret;
+            _itemLists.TryGetValue(itemType, out ret);
+            return ret;
+        }
+
+        public IList<ItemData> GetAllItems()
+        {
+            var ret = _itemLists.Values.SelectMany(itemList => itemList.GetItems(ImmutableHashSet<string>.Empty))
+                .OrderBy(itemData => itemData.ElementOrder)
+                .ToList();
+
+            return ret;
+        }
+
+        public void ProcessItemElement(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)
+        {
+            if (itemElement.Include != null)
+            {
+                ProcessItemElementInclude(rootDirectory, itemElement, conditionResult);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        void ProcessItemElementInclude(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)
+        {
+            IncludeOperationBuilder operationBuilder = new IncludeOperationBuilder();
+            operationBuilder.ElementOrder = _nextElementOrder++;
+            operationBuilder.ItemElement = itemElement;
+            operationBuilder.RootDirectory = rootDirectory;
+            operationBuilder.ItemType = itemElement.ItemType;
+            operationBuilder.ConditionResult = conditionResult;
+
+            //  Code corresponds to Evaluator.CreateItemsFromInclude
+
+            // STEP 1: Expand properties in Include
+            string evaluatedIncludeEscaped = _outerExpander.ExpandIntoStringLeaveEscaped(itemElement.Include, ExpanderOptions.ExpandProperties, itemElement.IncludeLocation);
+
+            // STEP 2: Split Include on any semicolons, and take each split in turn
+            if (evaluatedIncludeEscaped.Length > 0)
+            {
+                IList<string> includeSplitsEscaped = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedIncludeEscaped);
+
+                foreach (string includeSplitEscaped in includeSplitsEscaped)
+                {
+                    // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
+                    bool isItemListExpression;
+                    ProcessSingleItemVectorExpressionForInclude(includeSplitEscaped, operationBuilder, itemElement.IncludeLocation, out isItemListExpression);
+
+                    if (!isItemListExpression)
+                    {
+                        // The expression is not of the form "@(X)". Treat as string
+
+                        //  Code corresponds to EngineFileUtilities.GetFileList
+                        bool containsEscapedWildcards = EscapingUtilities.ContainsEscapedWildcards(includeSplitEscaped);
+                        bool containsRealWildcards = FileMatcher.HasWildcards(includeSplitEscaped);
+
+                        if (containsEscapedWildcards && containsRealWildcards)
+                        {
+                            // Umm, this makes no sense.  The item's Include has both escaped wildcards and 
+                            // real wildcards.  What does he want us to do?  Go to the file system and find
+                            // files that literally have '*' in their filename?  Well, that's not going to 
+                            // happen because '*' is an illegal character to have in a filename.
+
+                            // Just return the original string.
+                            operationBuilder.Operations.Add(Tuple.Create(IncludeOperationType.Value, (object) includeSplitEscaped));
+                        }
+                        else if (!containsEscapedWildcards && containsRealWildcards)
+                        {
+                            // Unescape before handing it to the filesystem.
+                            string filespecUnescaped = EscapingUtilities.UnescapeAll(includeSplitEscaped);
+                            operationBuilder.Operations.Add(Tuple.Create(IncludeOperationType.Glob, (object)filespecUnescaped));
+                        }
+                        else
+                        {
+                            // No real wildcards means we just return the original string.  Don't even bother 
+                            // escaping ... it should already be escaped appropriately since it came directly
+                            // from the project file
+                            operationBuilder.Operations.Add(Tuple.Create(IncludeOperationType.Value, (object) includeSplitEscaped));
+                        }
+
+                    }
+                }
+            }
+
+            //  Code corresponds to Evaluator.EvaluateItemElement
+
+            // STEP 4: Evaluate, split, expand and subtract any Exclude
+            if (itemElement.Exclude.Length > 0)
+            {
+                string evaluatedExclude = _expander.ExpandIntoStringLeaveEscaped(itemElement.Exclude, ExpanderOptions.ExpandProperties, itemElement.ExcludeLocation);
+
+                if (evaluatedExclude.Length > 0)
+                {
+                    IList<string> excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedExclude);
+
+                    operationBuilder.Excludes.AddRange(excludeSplits);
+                    
+                    foreach (var excludeSplit in excludeSplits)
+                    {
+                        AddItemReferences(excludeSplit, operationBuilder, itemElement.ExcludeLocation);
+                    }
+                }
+            }
+
+            // STEP 5: Evaluate each metadata XML and apply them to each item we have so far
+            if (itemElement.HasMetadata)
+            {
+                operationBuilder.Metadata = ImmutableList.CreateBuilder<ProjectMetadataElement>();
+                operationBuilder.Metadata.AddRange(itemElement.Metadata);
+
+                List<string> values = new List<string>(itemElement.Metadata.Count * 2);
+
+                foreach (ProjectMetadataElement metadatumElement in itemElement.Metadata)
+                {
+                    values.Add(metadatumElement.Value);
+                    values.Add(metadatumElement.Condition);
+                }
+
+                ItemsAndMetadataPair itemsAndMetadataFound = ExpressionShredder.GetReferencedItemNamesAndMetadata(values);
+                if (itemsAndMetadataFound.Items != null)
+                {
+                    foreach (var itemType in itemsAndMetadataFound.Items)
+                    {
+                        var itemList = GetItemList(itemType);
+                        if (itemList != null)
+                        {
+                            operationBuilder.ReferencedItemLists[itemType] = itemList;
+                        }
+                    }
+                }
+            }
+
+            var operation = operationBuilder.CreateOperation(this);
+
+            LazyItemList previousItemList = GetItemList(itemElement.ItemType);
+            LazyItemList newList = new LazyItemList(previousItemList, operation);
+            _itemLists[itemElement.ItemType] = newList;
+            
+        }
+
+        void AddItemReferences(string expression, IncludeOperationBuilder operationBuilder, IElementLocation elementLocation)
+        {
+            if (expression.Length == 0)
+            {
+                return;
+            }
+            else
+            {
+                ExpressionShredder.ItemExpressionCapture match = Expander<P, I>.ExpandSingleItemVectorExpressionIntoExpressionCapture(
+                    expression, ExpanderOptions.ExpandItems, elementLocation);
+
+                if (match == null)
+                {
+                    return;
+                }
+
+                AddReferencedItemLists(operationBuilder, match);
+            }
+        }
+
+        void ProcessSingleItemVectorExpressionForInclude(string expression, IncludeOperationBuilder operationBuilder, IElementLocation elementLocation, out bool isItemListExpression)
+        {
+            isItemListExpression = false;
+
+            //  Code corresponds to Expander.ExpandSingleItemVectorExpressionIntoItems
+            if (expression.Length == 0)
+            {
+                return;
+            }
+            else
+            {
+                ExpressionShredder.ItemExpressionCapture match = Expander<P, I>.ExpandSingleItemVectorExpressionIntoExpressionCapture(
+                    expression, ExpanderOptions.ExpandItems, elementLocation);
+
+                if (match == null)
+                {
+                    return;
+                }
+
+                isItemListExpression = true;
+
+                operationBuilder.Operations.Add(Tuple.Create(IncludeOperationType.Expression, (object) match));
+
+                AddReferencedItemLists(operationBuilder, match);
+            }
+        }
+
+        void AddReferencedItemLists(IncludeOperationBuilder operationBuilder, ExpressionShredder.ItemExpressionCapture match)
+        {
+            if (match.ItemType != null)
+            {
+                var itemList = GetItemList(match.ItemType);
+                if (itemList != null)
+                {
+                    operationBuilder.ReferencedItemLists[match.ItemType] = itemList;
+                }
+            }
+            if (match.Captures != null)
+            {
+                foreach (var subMatch in match.Captures)
+                {
+                    AddReferencedItemLists(operationBuilder, subMatch);
+                }
+            }
+        }
+
+    }
+}

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Build.Evaluation
             {
                 return ImmutableList<ItemData>.Empty;
             }
-            return itemList.GetItems(ImmutableHashSet<string>.Empty);
+            return itemList.GetItems(ImmutableHashSet<string>.Empty).Where(itemData => itemData.ConditionResult).ToList();
         }
 
         public bool EvaluateConditionWithCurrentState(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions)
@@ -458,7 +458,10 @@ namespace Microsoft.Build.Evaluation
                 LazyItemList itemList;
                 if (_referencedItemLists.TryGetValue(itemType, out itemList))
                 {
-                    return itemList.GetItems(globsToIgnore).Select(itemData => itemData.Item).ToList();
+                    return itemList.GetItems(globsToIgnore)
+                        .Where(ItemData => ItemData.ConditionResult)
+                        .Select(itemData => itemData.Item)
+                        .ToList();
                 }
                 else
                 {

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -163,6 +163,8 @@
     <Compile Include="Definition\ProjectCollectionChangedEventArgs.cs" />
     <Compile Include="Definition\ProjectImportPathMatch.cs" />
     <Compile Include="Evaluation\ItemsAndMetadataPair.cs" />
+    <Compile Include="Evaluation\LazyItemEvaluator.cs" />
+    <Compile Include="Evaluation\LazyItemEvaluator.ItemFactoryWrapper.cs" />
     <Compile Include="Evaluation\MetadataReference.cs" />
     <Compile Include="Evaluation\ProjectChangedEventArgs.cs" />
     <Compile Include="Evaluation\ProjectXmlChangedEventArgs.cs" />
@@ -657,6 +659,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Evaluation\LazyItemEvaluator.EvaluatorData.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectItemElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectItemElement_Tests.cs
@@ -211,26 +211,27 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Equal("v3", metadata[2].Value);
         }
 
-        /// <summary>
-        /// Read item with Remove outside of Target: not currently supported
-        /// </summary>
-        [Fact]
-        public void ReadInvalidRemoveOutsideTarget()
-        {
-            Assert.Throws<InvalidProjectFileException>(() =>
-            {
-                string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
-                        <ItemGroup>
-                            <i Remove='i1'/>
-                        </ItemGroup>
-                    </Project>
-                ";
+        ///// <summary>
+        ///// Read item with Remove outside of Target: not currently supported
+        ///// </summary>
+        //[Fact]
+        //public void ReadInvalidRemoveOutsideTarget()
+        //{
+        //    Assert.Throws<InvalidProjectFileException>(() =>
+        //    {
+        //        string content = @"
+        //            <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+        //                <ItemGroup>
+        //                    <i Remove='i1'/>
+        //                </ItemGroup>
+        //            </Project>
+        //        ";
 
-                ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-            }
-           );
-        }
+        //        ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
+        //    }
+        //   );
+        //}
+
         /// <summary>
         /// Read item with Remove inside of Target, but with metadata
         /// </summary>

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.Tpl.Dataflow": "4.5.24"
+    "Microsoft.Tpl.Dataflow": "4.5.24",
+    "System.Collections.Immutable": "1.1.36"
   },
   "frameworks": {
     "net46": { }


### PR DESCRIPTION
This is a first step towards efficient support for updating item metadata (#733) and removing items (#734) during evaluation.  So far, it doesn't support either of those.

What it does is instead of fully evaluating items as item elements are encountered during the evaluation, it builds an operation graph, with immutable, lazily evaluated item lists.  Take the case where you have the following in ItemGroups:

```xml
<Compile include="**\*.cs" />

<Compile remove="bin\**\*.*;obj\**\*.*;node_modules\**\*.*" />
```

The idea is that this would basically create a Glob Include operation followed by a Remove operation.  The Remove operation would depend on the value of the Glob Include operation, but when it requests the value of the item list, it could pass the list of globs that should be excluded, so when the file system code globs for `**\*.cs`, it can ignore traversing any directories where the results would subsequently be removed in the subsequent operation.