### PR TITLE
Calculate a better MSBuild tools/extensions path

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -1,0 +1,342 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace Microsoft.Build.Shared
+{
+    internal class BuildEnvironmentHelper
+    {
+        private static readonly string[] s_testRunners =
+        {
+            "XUNIT", "NUNIT", "MSTEST", "VSTEST", "TASKRUNNER",
+            "VSTESTHOST", "QTAGENT32", "CONCURRENT", "RESHARPER", "MDHOST", "TE.PROCESSHOST"
+        };
+
+        /// <summary>
+        /// Name of the Visual Studio process(es)
+        /// </summary>
+        private static readonly string[] s_visualStudioProcess = {"DEVENV"};
+
+        /// <summary>
+        /// Name of the MSBuild process(es)
+        /// </summary>
+        private static readonly string[] s_msBuildProcess = {"MSBUILD"};
+
+        /// <summary>
+        /// Gets the cached Build Environment instance.
+        /// </summary>
+        public static BuildEnvironment Instance => BuildEnvironmentHelperSingleton.s_instance;
+        
+        /// <summary>
+        /// Find the location of MSBuild.exe based on the current environment.
+        /// </summary>
+        /// <returns>Build environment.</returns>
+        private static BuildEnvironment Initialize()
+        {
+            // Get the executable we are running
+            var processNameCommandLine = s_getProcessFromCommandLine();
+            var processNameCurrentProcess = s_getProcessFromRunningProcess();
+            var executingAssembly = s_getExecutingAssmblyPath();
+            var currentDirectory = s_getCurrentDirectory();
+
+
+            // Check if our current process name is in the list of own test runners
+            var runningTests = IsProcessInList(processNameCommandLine, s_testRunners) ||
+                               IsProcessInList(processNameCurrentProcess, s_testRunners);
+
+            // Check to see if we're running inside of Visual Studio
+            bool runningInVisualStudio;
+            var visualStudioPath = FindVisualStudio(
+                new[] {processNameCommandLine, processNameCurrentProcess},
+                out runningInVisualStudio);
+
+            string msbuildFromVisualStudioRoot = null;
+            if (!string.IsNullOrEmpty(visualStudioPath))
+            {
+                msbuildFromVisualStudioRoot = FileUtilities.CombinePaths(visualStudioPath, "MSBuild", "15.0", "Bin");
+            }
+
+            var possibleLocations = new Func<BuildEnvironment>[]
+            {
+                // See if we're running from MSBuild.exe
+                () => TryFromCurrentProcess(processNameCommandLine, runningTests, runningInVisualStudio, visualStudioPath),
+                () => TryFromCurrentProcess(processNameCurrentProcess, runningTests, runningInVisualStudio, visualStudioPath),
+
+                // Check explicit %MSBUILD_EXE_PATH% environment variable.
+                () => TryFromEnvironmentVariable(runningTests, runningInVisualStudio, visualStudioPath),
+
+                // Try from our current executing assembly (e.g. path to Microsoft.Build.dll)
+                () => TryFromFolder(Path.GetDirectoryName(executingAssembly), runningTests, runningInVisualStudio, visualStudioPath),
+
+                // Try based on the Visual Studio Root
+                ()=> TryFromFolder(msbuildFromVisualStudioRoot, runningTests, runningInVisualStudio, visualStudioPath),
+
+                // Try from the current directory
+                () => TryFromFolder(currentDirectory, runningTests, runningInVisualStudio, visualStudioPath)
+            };
+
+            foreach (var location in possibleLocations)
+            {
+                var env = location();
+                if (env != null)
+                    return env;
+            }
+
+            ErrorUtilities.ThrowInvalidOperation("Shared.CanNotFindValidMSBuildLocation");
+            return null; // Not reachable
+        }
+
+        private static BuildEnvironment TryFromCurrentProcess(string runningProcess, bool runningTests, bool runningInVisualStudio, string visualStudioPath)
+        {
+            // No need to check the current process if we know we're running in VS or a test harness
+            if (runningTests || runningInVisualStudio) return null;
+            if (!IsProcessInList(runningProcess, s_msBuildProcess)) return null;
+
+            return IsValidMSBuildPath(runningProcess)
+                ? new BuildEnvironment(runningProcess, runningTests, runningInVisualStudio, visualStudioPath)
+                : null;
+        }
+
+        private static BuildEnvironment TryFromEnvironmentVariable(bool runningTests, bool runningInVisualStudio, string visualStudioPath)
+        {
+            var msBuildExePath = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH");
+
+            return IsValidMSBuildPath(msBuildExePath)
+                ? new BuildEnvironment(msBuildExePath, runningTests, runningInVisualStudio, visualStudioPath)
+                : null;
+        }
+
+        private static BuildEnvironment TryFromFolder(string folder, bool runningTests, bool runningInVisualStudio, string visualStudioPath)
+        {
+            if (string.IsNullOrEmpty(folder)) return null;
+
+            var msBuildPath = Path.Combine(folder, "MSBuild.exe");
+
+            return IsValidMSBuildPath(msBuildPath)
+                ? new BuildEnvironment(msBuildPath, runningTests, runningInVisualStudio, visualStudioPath)
+                : null;
+        }
+
+        /// <summary>
+        /// Determine whether the given path is considered to be an acceptable path to MSBuild.
+        /// </summary>
+        /// <remarks>
+        /// If we are running in an orphaned way (i.e. running from Microsoft.Build.dll in someone else's process),
+        /// that folder will not be sufficient as a build tools folder (e.g. we can't launch MSBuild.exe from that
+        /// location). At minimum, it must have MSBuild.exe and MSBuild.exe.config.
+        /// </remarks>
+        /// <param name="path">Full path to MSBuild.exe</param>
+        /// <returns>True when the path to MSBuild is valid.</returns>
+        private static bool IsValidMSBuildPath(string path)
+        {
+            return !string.IsNullOrEmpty(path) &&
+                   Path.GetFileName(path).Equals("MSBuild.exe", StringComparison.OrdinalIgnoreCase) &&
+                   File.Exists(path) &&
+                   File.Exists($"{path}.config");
+        }
+
+        /// <summary>
+        /// Look for Visual Studio
+        /// </summary>
+        /// <param name="processName"></param>
+        /// <param name="processName2"></param>
+        /// <param name="runningInVisualStudio"></param>
+        /// <returns></returns>
+        private static string FindVisualStudio(string[] processNames, out bool runningInVisualStudio)
+        {
+            runningInVisualStudio = false;
+
+            // Check to see if we're running inside of Visual Studio
+            foreach (var process in processNames)
+            {
+                if (IsProcessInList(process, s_visualStudioProcess))
+                {
+                    runningInVisualStudio = true;
+
+                    // This assumes running from VS\Common7\IDE\devenv.exe.
+                    return FileUtilities.GetFolderAbove(process, 3);
+                }
+            }
+
+            // VSInstallDir is set from the Developer Command Prompt
+            var vsInstallDir = Environment.GetEnvironmentVariable("VSINSTALLDIR");
+            var vsVersion = Environment.GetEnvironmentVariable("VisualStudioVersion");
+
+            if (!string.IsNullOrEmpty(vsInstallDir) &&
+                !string.IsNullOrEmpty(vsVersion) &&
+                vsVersion == "15.0" &&
+                Directory.Exists(vsInstallDir))
+            {
+                return vsInstallDir;
+            }
+
+            // Check assuming we're running in VS\MSBuild\15.0\Bin\MSBuild.exe
+            foreach (var process in processNames)
+            {
+                if (IsProcessInList(process, s_msBuildProcess))
+                {
+                    var vsPath = FileUtilities.GetFolderAbove(process, 4);
+                    var devEnv = FileUtilities.CombinePaths(vsPath, "Common7", "IDE", "devenv.exe");
+
+                    // Make sure VS is actually there before we suggest this root.
+                    if (File.Exists(devEnv))
+                    {
+                        return vsPath;
+                    }
+
+                    // VS\MSBuild\15.0\Bin\amd64\MSBuild.exe
+                    var vsPath64 = FileUtilities.GetFolderAbove(process, 5);
+                    var devEnv64 = FileUtilities.CombinePaths(vsPath64, "Common7", "IDE", "devenv.exe");
+
+                    // Make sure VS is actually there before we suggest this root.
+                    if (File.Exists(devEnv64))
+                    {
+                        return vsPath64;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns true if processName appears in the processList
+        /// </summary>
+        /// <param name="processName">Name of the process</param>
+        /// <param name="processList">List of processes to check</param>
+        /// <returns></returns>
+        private static bool IsProcessInList(string processName, string[] processList)
+        {
+            return processList.Any(s => Path.GetFileNameWithoutExtension(processName)?.IndexOf(s, StringComparison.InvariantCultureIgnoreCase) >= 0);
+        }
+
+        private static string GetProcessFromCommandLine()
+        {
+            return Environment.GetCommandLineArgs()[0];
+        }
+
+        private static string GetProcessFromRunningProcess()
+        {
+            return Process.GetCurrentProcess().MainModule.FileName;
+        }
+
+        private static string GetExecutingAssmblyPath()
+        {
+            return FileUtilities.ExecutingAssemblyPath;
+        }
+
+        private static string GetCurrentDirectory()
+        {
+            return Directory.GetCurrentDirectory();
+        }
+
+        /// <summary>
+        /// Resets the current singleton instance (for testing).
+        /// </summary>
+        internal static void ResetInstance_ForUnitTestsOnly(Func<string> getProcessFromCommandLine = null,
+            Func<string> getProcessFromRunningProcess = null, Func<string> getExecutingAssmblyPath = null,
+            Func<string> getCurrentDirectory = null)
+        {
+            s_getProcessFromCommandLine = getProcessFromCommandLine ?? GetProcessFromCommandLine;
+            s_getProcessFromRunningProcess = getProcessFromRunningProcess ?? GetProcessFromRunningProcess;
+            s_getExecutingAssmblyPath = getExecutingAssmblyPath ?? GetExecutingAssmblyPath;
+            s_getCurrentDirectory = getCurrentDirectory ?? GetCurrentDirectory;
+
+            BuildEnvironmentHelperSingleton.s_instance = Initialize();
+        }
+
+        private static Func<string> s_getProcessFromCommandLine = GetProcessFromRunningProcess;
+        private static Func<string> s_getProcessFromRunningProcess = GetProcessFromRunningProcess;
+        private static Func<string> s_getExecutingAssmblyPath = GetExecutingAssmblyPath;
+        private static Func<string> s_getCurrentDirectory = GetCurrentDirectory;
+
+        private static class BuildEnvironmentHelperSingleton
+        {
+            public static BuildEnvironment s_instance = Initialize();
+        }
+    }
+
+    /// <summary>
+    /// Defines the current environment for build tools.
+    /// </summary>
+    internal class BuildEnvironment
+    {
+        public BuildEnvironment(string processNameCommandLine, bool runningTests, bool runningInVisualStudio, string visualStudioPath)
+        {
+            RunningTests = runningTests;
+            RunningInVisualStudio = runningInVisualStudio;
+
+            CurrentMSBuildExePath = processNameCommandLine;
+            CurrentMSBuildToolsDirectory = Path.GetDirectoryName(processNameCommandLine);
+            CurrentMSBuildConfigurationFile = string.Concat(processNameCommandLine, ".config");
+
+            VisualStudioInstallRootDirectory = visualStudioPath;
+
+            var isAmd64 = FileUtilities.EnsureNoTrailingSlash(CurrentMSBuildToolsDirectory)
+                .EndsWith("amd64", StringComparison.OrdinalIgnoreCase);
+
+            if (isAmd64)
+            {
+                MSBuildToolsDirectory32 = FileUtilities.GetFolderAbove(CurrentMSBuildToolsDirectory);
+                MSBuildToolsDirectory64 = CurrentMSBuildToolsDirectory;
+            }
+            else
+            {
+                MSBuildToolsDirectory32 = CurrentMSBuildToolsDirectory;
+                MSBuildToolsDirectory64 = Path.Combine(CurrentMSBuildToolsDirectory, "amd64");
+            }
+        }
+
+        /// <summary>
+        /// Gets the flag that indicates if we are running in a test harness.
+        /// </summary>
+        internal bool RunningTests { get; private set; }
+
+        /// <summary>
+        /// Returns true when the entry point application is Visual Studio.
+        /// </summary>
+        internal bool RunningInVisualStudio { get; }
+
+        /// <summary>
+        /// Path to the MSBuild 32-bit tools directory.
+        /// </summary>
+        internal string MSBuildToolsDirectory32 { get; }
+
+        /// <summary>
+        /// Path to the MSBuild 64-bit (AMD64) tools directory.
+        /// </summary>
+        internal string MSBuildToolsDirectory64 { get; private set; }
+
+        /// <summary>
+        /// Full path to the current MSBuild configuration file.
+        /// </summary>
+        internal string CurrentMSBuildConfigurationFile { get; private set; }
+
+        /// <summary>
+        /// Full path to current MSBuild.exe.
+        /// <remarks>
+        /// This path is likely not the current running process. We may be inside
+        /// Visual Studio or a test harness. In that case this will point to the
+        /// version of MSBuild found to be associated with the current environment.
+        /// </remarks>
+        /// </summary>
+        internal string CurrentMSBuildExePath { get; private set; }
+
+        /// <summary>
+        /// Full path to the current MSBuild tools directory. This will be 32-bit unless
+        /// we're executing from the 'AMD64' folder.
+        /// </summary>
+        internal string CurrentMSBuildToolsDirectory { get; }
+
+        /// <summary>
+        /// Path to the root Visual Studio install directory
+        /// (e.g. 'c:\Program Files (x86)\Microsoft Visual Studio 15.0')
+        /// </summary>
+        internal string VisualStudioInstallRootDirectory { get; private set; }
+    }
+}

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -29,35 +29,13 @@ namespace Microsoft.Build.Shared
     {
         // A list of possible test runners. If the program running has one of these substrings in the name, we assume
         // this is a test harness.
-        private static readonly string[] s_testRunners =
-        {
-            "XUNIT", "NUNIT", "MSTEST", "VSTEST", "TASKRUNNER",
-            "VSTESTHOST", "QTAGENT32", "CONCURRENT", "RESHARPER", "MDHOST", "TE.PROCESSHOST"
-        };
-
-        /// <summary>
-        /// Name of the Visual Studio process(es)
-        /// </summary>
-        private static readonly string[] s_visualStudioProcess = {"DEVENV"};
-
-        /// <summary>
-        /// Name of the MSBuild process(es)
-        /// </summary>
-        private static readonly string[] s_msBuildProcess = {"MSBUILD"};
 
 
         // This flag, when set, indicates that we are running tests. Initially assume it's true. It also implies that
         // the currentExecutableOverride is set to a path (that is non-null). Assume this is not initialized when we
         // have the impossible combination of runningTests = false and currentExecutableOverride = null.
-        private static bool s_runningTests = true;
-
-        /// <summary>
-        /// Set to true/false when we know whether or not we're running inside Visual Studio
-        /// </summary>
-        private static bool? s_runningInVisualStudio;
 
         // This is the fake current executable we use in case we are running tests.
-        private static string s_currentExecutableOverride = null;
 
         // MaxPath accounts for the null-terminating character, for example, the maximum path on the D drive is "D:\<256 chars>\0". 
         // See: ndp\clr\src\BCL\System\IO\Path.cs
@@ -67,75 +45,6 @@ namespace Microsoft.Build.Shared
         /// The directory where MSBuild stores cache information used during the build.
         /// </summary>
         internal static string cacheDirectory = null;
-
-        /// <summary>
-        /// Check if we are running unit tests (under some kind of test runner) or in Visual Studio. If so, set the 
-        /// flag and come up with a (potentially) fake executable path. Generally, the path will be used to find 
-        /// the config file, but also to start msbuild.exe for remote nodes.
-        /// </summary>
-        private static void GetExecutionInfo()
-        {
-            // Get the executable we are running
-            var processNameCommandLine = Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]);
-            var processNameCurrentProcess = Process.GetCurrentProcess().ProcessName;
-
-            // Check if our current process name is in the list of own test runners
-            s_runningTests = IsProcessInList(processNameCommandLine, s_testRunners) ||
-                             IsProcessInList(processNameCurrentProcess, s_testRunners);
-
-            // Check to see if we're running inside of Visual Studio
-            s_runningInVisualStudio = IsProcessInList(processNameCommandLine, s_visualStudioProcess) ||
-                                      IsProcessInList(processNameCurrentProcess, s_visualStudioProcess);
-
-            bool runningInMsBuildExe = IsProcessInList(processNameCommandLine, s_msBuildProcess) ||
-                                       IsProcessInList(processNameCurrentProcess, s_msBuildProcess);
-
-            // No need to customize execution info if we're running in msbuild.exe
-            if (runningInMsBuildExe)
-            {
-                s_currentExecutableOverride = null;
-                return;
-            }
-
-            // We are running test harness. Pretend instead that we are running msbuild.exe.
-            // See if the path is provided.
-            s_currentExecutableOverride = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH");
-
-            if (s_currentExecutableOverride == null)
-            {
-                // Try to find msbuild.exe. Assume it's where the current assembly is
-                var dir = ExecutingAssemblyPath;
-                if (dir == null)
-                {
-                    // Can't get the assembly path, use current directory
-                    dir = Directory.GetCurrentDirectory();
-                }
-                else
-                {
-                    // Get directory name from the assembly and make sure it does not end with a slash
-                    var path = Path.GetDirectoryName(dir);
-
-                    // The result may be null if we were looking at a drive root. Strange, but keep it
-                    // if it was the drive root
-                    dir = (path ?? dir).TrimEnd(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
-                }
-
-                // The executable is msbuild.exe. This should come up with a valid path to msbuild.exe, but
-                // no need to check it here.
-                s_currentExecutableOverride = Path.Combine(dir, "MSBuild.exe");
-            }
-        }
-
-        /// <summary>
-        /// Returns true if processName appears in the processList
-        /// </summary>
-        /// <param name="processName">Name of the process</param>
-        /// <param name="processList">List of processes to check</param>
-        /// <returns></returns>
-        private static bool IsProcessInList(string processName, string[] processList)
-        {
-            return processList.Any(s => processName?.IndexOf(s, StringComparison.InvariantCultureIgnoreCase) >= 0);
-        }
 
         /// <summary>
         /// FOR UNIT TESTS ONLY
@@ -481,11 +390,6 @@ namespace Microsoft.Build.Shared
         internal const string FileTimeFormat = "yyyy'-'MM'-'dd HH':'mm':'ss'.'fffffff";
 
         /// <summary>
-        /// Cached path to the current exe
-        /// </summary>
-        private static string s_executablePath;
-
-        /// <summary>
         /// Get the currently executing assembly path
         /// </summary>
         internal static string ExecutingAssemblyPath
@@ -503,67 +407,6 @@ namespace Microsoft.Build.Shared
                     ExceptionHandling.DumpExceptionToFile(e);
                     return System.Reflection.Assembly.GetExecutingAssembly().Location;
                 }
-            }
-        }
-
-        /// <summary>
-        /// Name of the current .exe without extension, such as "MSBuild" "Devenv" or "Blend".
-        /// This is much cheaper than calling Process.GetCurrentProcess().ProcessName.
-        /// </summary>
-        internal static string CurrentExecutableName
-        {
-            get
-            {
-                return Path.GetFileNameWithoutExtension(CurrentExecutablePath);
-            }
-        }
-
-        /// <summary>
-        /// Full path to the current exe (for example, msbuild.exe) including the file name
-        /// </summary>
-        internal static string CurrentExecutablePath
-        {
-            get
-            {
-                if (s_executablePath == null)
-                {
-                    s_executablePath = CurrentExecutableOverride;
-                }
-
-                if (s_executablePath == null)
-                {
-                    StringBuilder sb = new StringBuilder(NativeMethodsShared.MAX_PATH);
-                    if (NativeMethodsShared.GetModuleFileName(NativeMethodsShared.NullHandleRef, sb, sb.Capacity) == 0)
-                    {
-                        throw new System.ComponentModel.Win32Exception();
-                    }
-
-                    s_executablePath = sb.ToString();
-                }
-
-                return s_executablePath;
-            }
-        }
-
-        /// <summary>
-        /// Full path to the directory that the current exe (for example, msbuild.exe) is located in
-        /// </summary>
-        internal static string CurrentExecutableDirectory
-        {
-            get
-            {
-                return Path.GetDirectoryName(CurrentExecutablePath);
-            }
-        }
-
-        /// <summary>
-        /// Full path to the current config file (for example, msbuild.exe.config)
-        /// </summary>
-        internal static string CurrentExecutableConfigurationFilePath
-        {
-            get
-            {
-                return String.Concat(CurrentExecutablePath, ".config");
             }
         }
 
@@ -900,52 +743,42 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
-        /// Gets the flag that indicates if we are running in a test harness
+        /// Get the folder N levels above the given. Will stop and return current path when rooted.
         /// </summary>
-        internal static bool RunningTests
+        /// <param name="path">Path to get the folder above.</param>
+        /// <param name="count">Number of levels up to walk.</param>
+        /// <returns>Full path to the folder N levels above the path.</returns>
+        internal static string GetFolderAbove(string path, int count = 1)
         {
-            get
+            if (count < 1)
+                return path;
+
+            var parent = Directory.GetParent(path);
+
+            while (count > 1 && parent?.Parent != null)
             {
-                // Check if initialized and do so if not yet
-                if (s_runningTests && s_currentExecutableOverride == null)
-                {
-                    GetExecutionInfo();
-                }
-                return s_runningTests;
+                parent = parent.Parent;
+                count--;
             }
+
+            return parent?.FullName ?? path;
         }
 
         /// <summary>
-        /// Gets a supposed (computed) path for the msbuild.exe if running
-        /// in a test harness. Otherwise returns null.
+        /// Combine multiple paths. Should only be used when compiling against .NET 2.0.
+        /// <remarks>
+        /// Only use in .NET 2.0. Otherwise, use System.IO.Path.Combine(...)
+        /// </remarks>
         /// </summary>
-        private static string CurrentExecutableOverride
+        /// <param name="root">Root path.</param>
+        /// <param name="paths">Paths to concatenate.</param>
+        /// <returns>Combined path.</returns>
+        internal static string CombinePaths(string root, params string[] paths)
         {
-            get
-            {
-                // Check if initialized and do so if not yet
-                if (s_runningTests && s_currentExecutableOverride == null)
-                {
-                    GetExecutionInfo();
-                }
-                return s_currentExecutableOverride;
-            }
-        }
+            ErrorUtilities.VerifyThrowArgumentNull(root, nameof(root));
+            ErrorUtilities.VerifyThrowArgumentNull(paths, nameof(paths));
 
-        /// <summary>
-        /// Returns true when the entry point application is Visual Studio.
-        /// </summary>
-        internal static bool RunningInVisualStudio
-        {
-            get
-            {
-                // Check if initialized and do so if not yet
-                if (!s_runningInVisualStudio.HasValue)
-                {
-                    GetExecutionInfo();
-                }
-                return s_runningInVisualStudio.Value;
-            }
+            return paths.Aggregate(root, Path.Combine);
         }
     }
 }

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -709,20 +709,21 @@ namespace Microsoft.Build.Shared
         /// Given a ToolsVersion, find the path to the build tools folder for that ToolsVersion. 
         /// </summary>
         /// <param name="toolsVersion">The ToolsVersion to look up</param>
+        /// <param name="architecture">Target build tools architecture.</param>
         /// <returns>The path to the build tools folder for that ToolsVersion, if it exists, or 
         /// null otherwise</returns>
         internal static string GeneratePathToBuildToolsForToolsVersion(string toolsVersion, DotNetFrameworkArchitecture architecture)
         {
-            // Much like when reading toolsets, first check the .exe.config
-            string toolsPath = GetPathToBuildToolsFromConfig(toolsVersion, architecture);
-
-            if (String.IsNullOrEmpty(toolsPath))
+            if (string.Compare(toolsVersion, MSBuildConstants.CurrentToolsVersion, StringComparison.Ordinal) == 0)
             {
-                // Or if it's not defined there, look it up in the registry
-                toolsPath = GetPathToBuildToolsFromRegistry(toolsVersion, architecture);
+                return GetPathToBuildToolsFromEnvironment(architecture);
             }
 
-            return toolsPath;
+            // If we're not looking for the current tools version, try the registry.
+            var toolsPath = GetPathToBuildToolsFromRegistry(toolsVersion, architecture);
+
+            // If all else fails, always use the current environment.
+            return toolsPath ?? GetPathToBuildToolsFromEnvironment(architecture);
         }
 
         /// <summary>
@@ -807,50 +808,17 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Look up the path to the build tools directory for the requested ToolsVersion in the .exe.config file of this executable 
         /// </summary>
-        private static string GetPathToBuildToolsFromConfig(string toolsVersion, DotNetFrameworkArchitecture architecture)
+        private static string GetPathToBuildToolsFromEnvironment(DotNetFrameworkArchitecture architecture)
         {
-            string toolPath = null;
-
-            if (ToolsetConfigurationReaderHelpers.ConfigurationFileMayHaveToolsets())
+            switch (architecture)
             {
-                string toolsPathPropertyName = architecture == DotNetFrameworkArchitecture.Bitness64
-                    ? MSBuildConstants.ToolsPath64
-                    : MSBuildConstants.ToolsPath;
-
-                try
-                {
-                    Configuration configuration = ReadApplicationConfiguration();
-                    ToolsetConfigurationSection configurationSection = ToolsetConfigurationReaderHelpers.ReadToolsetConfigurationSection(configuration);
-
-                    ToolsetElement toolset = configurationSection?.Toolsets.GetElement(toolsVersion);
-                    PropertyElement toolsPathFromConfiguration = toolset?.PropertyElements.GetElement(toolsPathPropertyName);
-
-                    if (toolsPathFromConfiguration != null)
-                    {
-                        toolPath = toolsPathFromConfiguration.Value;
-
-                        if (toolPath != null)
-                        {
-                            if (!FileUtilities.IsRootedNoThrow(toolPath))
-                            {
-                                toolPath = FileUtilities.NormalizePath(Path.Combine(FileUtilities.CurrentExecutableDirectory, toolPath));
-                            }
-
-                            toolPath = FileUtilities.EnsureTrailingSlash(toolPath);
-                        }
-                    }
-                }
-                catch (ConfigurationException)
-                {
-                    // may happen if the .exe.config contains bad data.  Shouldn't ever happen in 
-                    // practice since we'll long since have loaded all toolsets in the toolset loading 
-                    // code and thrown errors to the user at that point if anything was invalid, but just 
-                    // in case, just eat the exception here, so that we can go on to look in the registry
-                    // to see if there is any valid data there.  
-                }
+                case DotNetFrameworkArchitecture.Bitness64:
+                    return BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64;
+                case DotNetFrameworkArchitecture.Bitness32:
+                    return BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
+                default:
+                    return BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
             }
-
-            return toolPath;
         }
 
         /// <summary>
@@ -971,10 +939,10 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private static Configuration ReadApplicationConfiguration()
         {
-            var msbuildExeConfig = FileUtilities.CurrentExecutableConfigurationFilePath;
+            var msbuildExeConfig = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile;
 
             // When running from the command-line or from VS, use the msbuild.exe.config file
-            if (!FileUtilities.RunningTests && File.Exists(msbuildExeConfig))
+            if (!BuildEnvironmentHelper.Instance.RunningTests && File.Exists(msbuildExeConfig))
             {
                 var configFile = new ExeConfigurationFileMap { ExeConfigFilename = msbuildExeConfig };
                 return ConfigurationManager.OpenMappedExeConfiguration(configFile, ConfigurationUserLevel.None);

--- a/src/Shared/InternalErrorException.cs
+++ b/src/Shared/InternalErrorException.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Shared
             {
                 string processName = Process.GetCurrentProcess().ProcessName.ToUpperInvariant();
 
-                if (!FileUtilities.RunningTests)
+                if (!BuildEnvironmentHelper.Instance.RunningTests)
                 {
                     if (Environment.GetEnvironmentVariable("_NTROOT") == null)
                     {

--- a/src/Shared/Strings.shared.resx
+++ b/src/Shared/Strings.shared.resx
@@ -247,10 +247,14 @@
     <value>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</value>
     <comment>{StrBegin="MSB5021: "}</comment>
   </data>
+  <data name="Shared.CanNotFindValidMSBuildLocation">
+    <value>MSB5024: Could not determine a valid location to MSBuild. Try running this process from the Developer Command Prompt for Visual Studio.</value>
+    <comment>{StrBegin="MSB5021: "}</comment>
+  </data>
   <!--
         The shared message bucket is: MSB5001 - MSB5999
 
-        Next message code should be MSB5024
+        Next message code should be MSB5025
 
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Shared/TaskLoader.cs
+++ b/src/Shared/TaskLoader.cs
@@ -79,12 +79,12 @@ namespace Microsoft.Build.Shared
                         // Apply the appdomain settings to the new appdomain before creating it
                         appDomainInfo.SetConfigurationBytes(currentAppdomainBytes);
 
-                        if (FileUtilities.RunningTests)
+                        if (BuildEnvironmentHelper.Instance.RunningTests)
                         {
                             // Prevent the new app domain from looking in the VS test runner location. If this
                             // is not done, we will not be able to find Microsoft.Build.* assemblies.
-                            appDomainInfo.ApplicationBase = FileUtilities.CurrentExecutableDirectory;
-                            appDomainInfo.ConfigurationFile = FileUtilities.CurrentExecutableConfigurationFilePath;
+                            appDomainInfo.ApplicationBase = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
+                            appDomainInfo.ConfigurationFile = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile;
                         }
 
                         AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolver;

--- a/src/Shared/ToolsetElement.cs
+++ b/src/Shared/ToolsetElement.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Evaluation
 
             try
             {
-                var configFile = FileUtilities.CurrentExecutableConfigurationFilePath;
+                var configFile = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile;
                 result = File.Exists(configFile) && File.ReadAllText(configFile).Contains("toolsVersion");
             }
             catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -304,25 +304,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        public void GetExecutablePath()
-        {
-            // This test will fail when CurrentDirectory is changed in another test. We will change it here
-            // to the path to Microsoft.Build.dll (debug build output folder). This is what it *should* be
-            // anyway.
-            var msbuildPath = Path.GetDirectoryName(typeof(Project).Assembly.Location);
-            Directory.SetCurrentDirectory(msbuildPath);
-
-            string path = Path.Combine(Directory.GetCurrentDirectory(), "msbuild.exe").ToLowerInvariant();
-            string configPath = FileUtilities.CurrentExecutableConfigurationFilePath.ToLowerInvariant();
-            string directoryName = FileUtilities.CurrentExecutableDirectory.ToLowerInvariant();
-            string executablePath = FileUtilities.CurrentExecutablePath.ToLowerInvariant();
-
-            Assert.Equal(configPath, executablePath + ".config");
-            Assert.Equal(path, executablePath);
-            Assert.Equal(directoryName, Path.GetDirectoryName(path));
-        }
-
-        [Fact]
         public void NormalizePathThatFitsIntoMaxPath()
         {
             string currentDirectory = @"c:\aardvark\aardvark\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890\1234567890";
@@ -755,6 +736,37 @@ namespace Microsoft.Build.UnitTests
                 Shared.FileUtilities.GetTemporaryFile("|", ".tmp");
             }
            );
+        }
+
+        [Fact]
+        public void GetFolderAboveTest()
+        {
+            string path = @"c:\1\2\3\4\5";
+
+            Assert.Equal(@"c:\1\2\3\4\5", FileUtilities.GetFolderAbove(path, 0));
+            Assert.Equal(@"c:\1\2\3\4", FileUtilities.GetFolderAbove(path));
+            Assert.Equal(@"c:\1\2\3", FileUtilities.GetFolderAbove(path, 2));
+            Assert.Equal(@"c:\1\2", FileUtilities.GetFolderAbove(path, 3));
+            Assert.Equal(@"c:\1", FileUtilities.GetFolderAbove(path, 4));
+            Assert.Equal(@"c:\", FileUtilities.GetFolderAbove(path, 5));
+            Assert.Equal(@"c:\", FileUtilities.GetFolderAbove(path, 99));
+
+            Assert.Equal(@"c:\", FileUtilities.GetFolderAbove(@"c:\", 99));
+        }
+
+        [Fact]
+        public void CombinePathsTest()
+        {
+            // These tests run in .NET 4+, so we can cheat
+            var root = @"c:\";
+
+            Assert.Equal(
+                Path.Combine(root, "path1"),
+                FileUtilities.CombinePaths(root, "path1"));
+
+            Assert.Equal(
+                Path.Combine(root, "path1", "path2", "file.txt"),
+                FileUtilities.CombinePaths(root, "path1", "path2", "file.txt"));
         }
     }
 }

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -20,6 +20,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'" />
   <ItemGroup>
     <!-- Source Files -->
+    <Compile Include="..\Shared\BuildEnvironmentHelper.cs">
+      <Link>BuildEnvironmentHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
@@ -986,29 +986,7 @@ namespace Microsoft.Build.Execution
             }
 
             // Try what we think is the current executable path.
-            location = FileUtilities.CurrentExecutablePath;
-
-            if (CheckMSBuildExeExistsAt(location))
-            {
-                return location;
-            }
-
-            // Get the location pointed to by the MSBuildToolsPath in the "current" ToolsVersion 
-            // for this version of MSBuild. In certain strange circumstances (e.g. checked-in redist
-            // the current toolset might not be available.  In which case, shrug and move on.) 
-            EnsureToolsets();
-            Toolset currentToolset = _toolsetProvider.GetToolset(MSBuildConstants.CurrentToolsVersion);
-
-            if (currentToolset != null && !string.IsNullOrEmpty(currentToolset.ToolsPath))
-            {
-                location = Path.Combine(currentToolset.ToolsPath, "MSBuild.exe");
-                if (CheckMSBuildExeExistsAt(location))
-                {
-                    return location;
-                }
-            }
-
-            return location;
+            return BuildEnvironmentHelper.Instance.CurrentMSBuildExePath;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderInProc.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderInProc.cs
@@ -11,7 +11,7 @@ using System.Globalization;
 using System.Text;
 using System.Threading;
 using System.Diagnostics;
-
+using System.IO;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
@@ -206,19 +206,6 @@ namespace Microsoft.Build.BackEnd
                 // We can only create additional in-proc nodes if we have decided not to save the operating environment.  This is the global
                 // DTAR case in Visual Studio, but other clients might enable this as well under certain special circumstances.
                 ErrorUtilities.VerifyThrow(_inProcNodeOwningOperatingEnvironment == null, "Unexpected non-null in-proc node semaphore.");
-
-                // Blend.exe v4.x or earlier launches two nodes that co-own the same operating environment
-                // and they will not patch this
-                var p = Process.GetCurrentProcess();
-                {
-                    // This should be reasonably sufficient to assume MS Expression Blend 4 or earlier
-                    if ((FileUtilities.CurrentExecutableName.Equals("Blend", StringComparison.OrdinalIgnoreCase)) &&
-                        (p.MainModule.FileVersionInfo.OriginalFilename.Equals("Blend.exe", StringComparison.OrdinalIgnoreCase)) &&
-                        (p.MainModule.FileVersionInfo.ProductMajorPart < 5))
-                    {
-                        _exclusiveOperatingEnvironment = false;
-                    }
-                }
 
                 if (Environment.GetEnvironmentVariable("MSBUILDINPROCENVCHECK") == "1")
                 {

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -413,8 +413,8 @@ namespace Microsoft.Build.BackEnd
             string toolName = GetTaskHostNameFromHostContext(hostContext);
             string toolPath = null;
 
-            s_baseTaskHostPath = FileUtilities.CurrentExecutableDirectory;
-            s_baseTaskHostPath64 = Path.Combine(FileUtilities.CurrentExecutableDirectory, "amd64");
+            s_baseTaskHostPath = BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
+            s_baseTaskHostPath64 = BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64;
 
             switch (hostContext)
             {

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -252,10 +252,10 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private static Configuration ReadApplicationConfiguration()
         {
-            var msbuildExeConfig = FileUtilities.CurrentExecutableConfigurationFilePath;
+            var msbuildExeConfig = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile;
 
             // When running from the command-line or from VS, use the msbuild.exe.config file
-            if (!FileUtilities.RunningTests && File.Exists(msbuildExeConfig))
+            if (!BuildEnvironmentHelper.Instance.RunningTests && File.Exists(msbuildExeConfig))
             {
                 var configFile = new ExeConfigurationFileMap { ExeConfigFilename = msbuildExeConfig };
                 return ConfigurationManager.OpenMappedExeConfiguration(configFile, ConfigurationUserLevel.None);

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -611,7 +611,7 @@ namespace Microsoft.Build.Evaluation
                 if (trimmedValue.Length > 0 && !Path.IsPathRooted(trimmedValue))
                 {
                     path = Path.GetFullPath(
-                        Path.Combine(FileUtilities.CurrentExecutableDirectory, trimmedValue));
+                        Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, trimmedValue));
                 }
             }
             catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -351,27 +351,12 @@ namespace Microsoft.Build.Evaluation
 
         public static string GetCurrentExecutableDirectory()
         {
-            return FileUtilities.CurrentExecutableDirectory;
+            return BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
         }
 
         public static string GetVsInstallRoot()
         {
-            var vsInstallDir = Environment.GetEnvironmentVariable("VSINSTALLDIR");
-            var vsVersion = Environment.GetEnvironmentVariable("VisualStudioVersion");
-
-            if (!string.IsNullOrEmpty(vsInstallDir) && !string.IsNullOrEmpty(vsVersion))
-            {
-                if (vsVersion == "15.0" && Directory.Exists(vsInstallDir))
-                {
-                    return vsInstallDir;
-                }
-            }
-
-            // This assumes MSBuild is in VS\MSBuild\15.0\Bin.
-            var msbuildDir = FileUtilities.CurrentExecutableDirectory;
-            vsInstallDir = Path.GetFullPath(Path.Combine(msbuildDir, @"..\..\.."));
-
-            return vsInstallDir;
+            return BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory;
         }
 
         #region Debug only intrinsics

--- a/src/XMakeBuildEngine/Instance/TaskRegistry.cs
+++ b/src/XMakeBuildEngine/Instance/TaskRegistry.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Build.Execution
         /// references it with just a simple name, used for shimming in loading 
         /// task factory UsingTasks
         /// </summary>
-        private static string s_potentialTasksV4Location = Path.Combine(FileUtilities.CurrentExecutableDirectory, s_tasksV4Filename);
+        private static string s_potentialTasksV4Location = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, s_tasksV4Filename);
 
         /// <summary>
         /// Simple name for the MSBuild tasks (v12), used for shimming in loading 
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Execution
         /// references it with just a simple name, used for shimming in loading 
         /// task factory UsingTasks
         /// </summary>
-        private static string s_potentialTasksV12Location = Path.Combine(FileUtilities.CurrentExecutableDirectory, s_tasksV12Filename);
+        private static string s_potentialTasksV12Location = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, s_tasksV12Filename);
 
         /// <summary>
         /// Simple name for the MSBuild tasks (v14+), used for shimming in loading 
@@ -122,7 +122,7 @@ namespace Microsoft.Build.Execution
         /// references it with just a simple name, used for shimming in loading 
         /// task factory UsingTasks
         /// </summary>
-        private static string s_potentialTasksCoreLocation = Path.Combine(FileUtilities.CurrentExecutableDirectory, s_tasksCoreFilename);
+        private static string s_potentialTasksCoreLocation = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, s_tasksCoreFilename);
 
         /// <summary>
         /// Cache of tasks already found using exact matching,

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -31,6 +31,9 @@
     <DefineConstants>$(DefineConstants);BUILD_ENGINE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Shared\BuildEnvironmentHelper.cs">
+      <Link>SharedUtilities\BuildEnvironmentHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -77,7 +77,7 @@ namespace TestTask
             // Setting the current directory to the MSBuild running location. It *should* be this
             // already, but if it's not some other test changed it and didn't change it back. If
             // the directory does not include the reference dlls the compilation will fail.
-            Directory.SetCurrentDirectory(FileUtilities.CurrentExecutableDirectory);
+            Directory.SetCurrentDirectory(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
 
             try
             {

--- a/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -1,0 +1,260 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Shared;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests
+{
+    public class BuildEnvironmentHelper_Tests
+    {
+        [Fact]
+        public void GetExecutablePath()
+        {
+            // This test will fail when CurrentDirectory is changed in another test. We will change it here
+            // to the path to Microsoft.Build.dll (debug build output folder). This is what it *should* be
+            // anyway.
+            var msbuildPath = Path.GetDirectoryName(typeof(Project).Assembly.Location);
+            Directory.SetCurrentDirectory(msbuildPath);
+
+            string path = Path.Combine(Directory.GetCurrentDirectory(), "msbuild.exe").ToLowerInvariant();
+            string configPath = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile.ToLowerInvariant();
+            string directoryName = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.ToLowerInvariant();
+            string executablePath = BuildEnvironmentHelper.Instance.CurrentMSBuildExePath.ToLowerInvariant();
+
+            Assert.Equal(configPath, executablePath + ".config");
+            Assert.Equal(path, executablePath);
+            Assert.Equal(directoryName, Path.GetDirectoryName(path));
+        }
+
+        [Fact]
+        public void FindBuildEnvironmentByEnvironmentVariable()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                var path = env.BuildDirectory;
+                var msBuildPath = Path.Combine(path, "msbuild.exe");
+                var msBuildConfig = Path.Combine(path, "msbuild.exe.config");
+
+                Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", env.MSBuildExePath);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull);
+
+                Assert.Equal(path, BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
+                Assert.Equal(msBuildPath, BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
+                Assert.Equal(msBuildConfig, BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile);
+                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
+                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
+            }
+        }
+
+        [Fact]
+        public void FindBuildEnvironmentFromCommandLine()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                // All we know about is path to msbuild.exe as the command-line arg[0]
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull);
+
+                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
+                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
+                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
+                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
+            }
+        }
+
+        [Fact]
+        public void FindBuildEnvironmentFromRunningProcess()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                // All we know about is path to msbuild.exe as the current process
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, ReturnNull);
+
+                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
+                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
+                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
+                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
+            }
+        }
+
+        [Fact]
+        public void FindBuildEnvironmentFromVisualStudioRoot()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                // All we know about is path to DevEnv.exe
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, ReturnNull, ReturnNull);
+
+                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
+                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
+                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
+                Assert.True(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
+                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
+            }
+        }
+
+        [Fact]
+        public void BuildEnvironmentDetectsVisualStudioByEnvironment()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                Environment.SetEnvironmentVariable("VSINSTALLDIR", env.TempFolderRoot);
+                Environment.SetEnvironmentVariable("VisualStudioVersion", "15.0");
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
+                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
+            }
+        }
+
+        [Fact]
+        public void BuildEnvironmentDetectsVisualStudioByMSBuildProcess()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                // We only know we're in msbuild.exe, we should still be able to attempt to find Visual Studio
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull);
+
+                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
+            }
+        }
+
+        [Fact]
+        public void BuildEnvironmentDetectsVisualStudioByMSBuildProcessAmd64()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                // We only know we're in amd64\msbuild.exe, we should still be able to attempt to find Visual Studio
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, ReturnNull);
+
+                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
+            }
+        }
+
+        [Fact]
+        public void BuildEnvironmentDetectsRunningTests()
+        {
+            Assert.True(BuildEnvironmentHelper.Instance.RunningTests);
+            Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
+        }
+
+        [Fact]
+        public void BuildEnvironmentDetectsVisualStudioByProcessName()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, () => env.MSBuildExePath, ReturnNull);
+
+                Assert.True(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
+                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
+            }
+        }
+
+        [Fact]
+        public void BuildEnvironmentFindsAmd64()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", env.MSBuildExePath);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+
+                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
+                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
+            }
+        }
+
+        [Fact]
+        public void BuildEnvironmentFindsAmd64RunningInAmd64()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", env.MSBuildExePath64);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull);
+
+                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
+                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
+            }
+        }
+
+        [Fact]
+        public void FindBuildEnvironmentThrowsWhenNotAvailable()
+        {
+            using (new EmptyBuildEnviroment())
+            {
+                Assert.Throws<InvalidOperationException>(() => BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull));
+            }
+        }
+
+        private static string ReturnNull()
+        {
+            return null;
+        }
+
+        private class EmptyBuildEnviroment : IDisposable
+        {
+            public string TempFolderRoot { get; }
+
+            public string DevEnvPath { get; }
+
+            public string BuildDirectory { get; }
+
+            public string BuildDirectory64 { get; }
+
+            public string MSBuildExePath => Path.Combine(BuildDirectory, "msbuild.exe");
+
+            public string MSBuildExePath64 => Path.Combine(BuildDirectory64, "msbuild.exe");
+
+            private readonly Dictionary<string, string> _originalEnvironment = new Dictionary<string, string>
+            {
+                ["MSBUILD_EXE_PATH"] = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH"),
+                ["VSINSTALLDIR"] = Environment.GetEnvironmentVariable("VSINSTALLDIR"),
+                ["VisualStudioVersion"] = Environment.GetEnvironmentVariable("VisualStudioVersion"),
+            };
+
+            public EmptyBuildEnviroment()
+            {
+                try
+                {
+                    var files = new[] { "msbuild.exe", "msbuild.exe.config" };
+                    TempFolderRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+                    BuildDirectory = Path.Combine(TempFolderRoot, "MSBuild", "15.0", "Bin");
+                    BuildDirectory64 = Path.Combine(BuildDirectory, "amd64");
+                    DevEnvPath = Path.Combine(TempFolderRoot, "Common7", "IDE", "devenv.exe");
+
+                    Directory.CreateDirectory(BuildDirectory);
+                    foreach (var file in files)
+                    {
+                        File.WriteAllText(Path.Combine(BuildDirectory, file), string.Empty);
+                    }
+
+                    Directory.CreateDirectory(BuildDirectory64);
+                    foreach (var file in files)
+                    {
+                        File.WriteAllText(Path.Combine(BuildDirectory64, file), string.Empty);
+                    }
+
+                    Directory.CreateDirectory(Path.Combine(TempFolderRoot, "Common7", "IDE"));
+                    File.WriteAllText(DevEnvPath, string.Empty);
+                }
+                catch (Exception)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(BuildDirectory, true);
+                    throw;
+                }
+            }
+
+            public void Dispose()
+            {
+                FileUtilities.DeleteDirectoryNoThrow(TempFolderRoot, true);
+
+                foreach (var env in _originalEnvironment)
+                    Environment.SetEnvironmentVariable(env.Key, env.Value);
+
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+            }
+        }
+    }
+}

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
@@ -189,8 +189,8 @@ namespace Microsoft.Build.UnitTests.Definition
             string defaultOverrideToolsVersion = null;
             reader.ReadToolsets(values, new PropertyDictionary<ProjectPropertyInstance>(), pg, true, out msbuildOverrideTasksPath, out defaultOverrideToolsVersion);
 
-            string expected1 = Path.GetFullPath(Path.Combine(FileUtilities.CurrentExecutableDirectory, @"..\foo"));
-            string expected2 = Path.GetFullPath(Path.Combine(FileUtilities.CurrentExecutableDirectory, @"..\bar"));
+            string expected1 = Path.GetFullPath(Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, @"..\foo"));
+            string expected2 = Path.GetFullPath(Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, @"..\bar"));
             Console.WriteLine(values["2.0"].ToolsPath);
             Assert.Equal(expected1, values["2.0"].ToolsPath);
             Assert.Equal(expected2, values["3.0"].ToolsPath);

--- a/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="BackEnd\TargetEntry_Tests.cs" />
     <Compile Include="BackEnd\TargetResult_Tests.cs" />
     <Compile Include="BackEnd\TargetUpToDateChecker_Tests.cs" />
+    <Compile Include="BuildEnvironmentHelper_Tests.cs" />
     <Compile Include="Definition\Project_Internal_Tests.cs" />
     <Compile Include="BackEnd\TaskBuilder_Tests.cs" />
     <Compile Include="BackEnd\TaskItemComparer.cs" />

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
      Tests only the public OM of Microsoft.Build.
 
@@ -24,6 +24,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'" />
   <ItemGroup>
     <!-- Source Files -->
+    <Compile Include="..\..\Shared\BuildEnvironmentHelper.cs">
+      <Link>BuildEnvironmentHelper.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\Constants.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -21,6 +21,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'" />
   <ItemGroup>
+    <Compile Include="..\Shared\BuildEnvironmentHelper.cs">
+      <Link>BuildEnvironmentHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -39,6 +39,9 @@
 
   <ItemGroup>
     <!-- Source Files -->
+    <Compile Include="..\..\Shared\BuildEnvironmentHelper.cs">
+      <Link>BuildEnvironmentHelper.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\AssemblyNameComparer.cs">
       <Link>AssemblyNameComparer.cs</Link>
     </Compile>

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -41,6 +41,9 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Source Files -->
+    <Compile Include="..\Shared\BuildEnvironmentHelper.cs">
+      <Link>BuildEnvironmentHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>


### PR DESCRIPTION
Move all build path environment discovery to new class
 - With Dev15, finding MSBuild is a bit trickier. This change tries to
   address that by moving the logic to a single place and streamlining the
   usage.
 - Audited code that needed to find the MSBuild path to use this.
   Previously there were a variety of methods used, ideally this should be
   the only one (other than perhaps finding tools from another toolset).

Closes #704