### PR TITLE
Fix mono/OSX build - missing `Microsoft.DotNet.BuildTools.TestSuite`

### DIFF
--- a/targets/runtimeDependencies/project.json
+++ b/targets/runtimeDependencies/project.json
@@ -14,7 +14,8 @@
       "dependencies": {
         "xunit.runner.visualstudio": "2.1.0",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
-        "System.Threading.Tasks.Dataflow": "4.6.0"
+        "System.Threading.Tasks.Dataflow": "4.6.0",
+        "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01"
       }
     },
     "netcoreapp1.0": {


### PR DESCRIPTION
.. nuget . This can be seen if you clean the global/user and local nuget
cache and then build:

  Microsoft.Build.Framework -> /Users/ankit/dev/msbuild/bin/x86/OSX/Debug-MONO/Output/Microsoft.Build.Framework.dll
MSBUILD : error : The package Microsoft.DotNet.BuildTools.TestSuite with version 1.0.0-prerelease-00508-01 could not be found in /Users/ankit/.nuget/packages. Run a NuGet package restore to download the package. [/Users/ankit/dev/msbuild/targets/DeployDependencies.proj]