### PR TITLE
Fix temp path issue

### DIFF
--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Utilities
     {
         #region Static Member Data
         // The default path to temp, used to create explicitly short and long paths
-        private static string s_tempPath = Path.GetDirectoryName(Path.GetTempPath());
+        private static string s_tempPath = Path.GetTempPath();
 
         // The short path to temp
         private static string s_tempShortPath = FileUtilities.EnsureTrailingSlash(NativeMethodsShared.GetShortFilePath(s_tempPath).ToUpperInvariant());

--- a/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -885,7 +885,7 @@ class X
             string localApplicationDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             string localLowApplicationDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData\\LocalLow");
             // The default path to temp, used to create explicitly short and long paths
-            string tempPath = Path.GetDirectoryName(Path.GetTempPath());
+            string tempPath = Path.GetTempPath();
             // The short path to temp
             string tempShortPath = FileUtilities.EnsureTrailingSlash(NativeMethodsShared.GetShortFilePath(tempPath).ToUpperInvariant());
             // The long path to temp


### PR DESCRIPTION
When TEMP/TMP environment variable points to a drive root folder (D:\) without any further folder nesting, TEMP path results in null. This fix allows TEMP path to point to a drive root and also fixes #606.