### PR TITLE
Gracefully handle missing .NET SDK in SignFile

### DIFF
--- a/src/XMakeTasks/ManifestUtil/SecurityUtil.cs
+++ b/src/XMakeTasks/ManifestUtil/SecurityUtil.cs
@@ -765,7 +765,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             if (toolPath == null)
                 toolPath = ToolLocationHelper.GetPathToWindowsSdkFile(ToolName, TargetDotNetFrameworkVersion.Version45, VisualStudioVersion.Version110);
             if (toolPath == null)
-                toolPath = Path.Combine(ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version40, VisualStudioVersion.Version100), "bin", ToolName);
+            {
+                var pathToDotNetFrameworkSdk = ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version40, VisualStudioVersion.Version100);
+                if (pathToDotNetFrameworkSdk != null)
+                {
+                    toolPath = Path.Combine(pathToDotNetFrameworkSdk, "bin", ToolName);
+                }
+            }
             if (toolPath == null)
                 toolPath = Path.Combine(Directory.GetCurrentDirectory(), ToolName);
             if (!File.Exists(toolPath))


### PR DESCRIPTION
With the previous code, if `signtool.exe` wasn't found in the Windows SDK *and* the .NET 4.0 SDK wasn't installed, `SignFile` would throw instead of failing gracefully.

Closes #787.