### PR TITLE
Import design time targets for Roslyn Project System

### DIFF
--- a/src/XMakeTasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.CSharp.CurrentVersion.targets
@@ -361,6 +361,12 @@ using System.Reflection%3b
         <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
     </ItemGroup>
 
+    <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
+    <PropertyGroup>
+       <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
+    </PropertyGroup>
+    <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
+
     <Import Project="$(CustomAfterMicrosoftCSharpTargets)" Condition="'$(CustomAfterMicrosoftCSharpTargets)' != '' and Exists('$(CustomAfterMicrosoftCSharpTargets)')" />
 
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.CSharp.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfterMicrosoftCSharpTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.CSharp.targets\ImportAfter')"/>

--- a/src/XMakeTasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -364,6 +364,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <_ExplicitReference Include="$(FrameworkPathOverride)\System.dll" />
     </ItemGroup>
 
+    <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
+    <PropertyGroup>
+       <VisualBasicDesignTimeTargetsPath Condition="'$(VisualBasicDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.VisualBasic.DesignTime.targets</VisualBasicDesignTimeTargetsPath>
+    </PropertyGroup>
+    <Import Project="$(VisualBasicDesignTimeTargetsPath)" Condition="'$(VisualBasicDesignTimeTargetsPath)' != '' and Exists('$(VisualBasicDesignTimeTargetsPath)')" />
+
     <Import Project="$(CustomAfterMicrosoftVisualBasicTargets)" Condition="'$(CustomAfterMicrosoftVisualBasicTargets)' != '' and Exists('$(CustomAfterMicrosoftVisualBasicTargets)')" />
 
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.VisualBasic.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfterMicrosoftVisualBasicTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.VisualBasic.targets\ImportAfter')"/>


### PR DESCRIPTION
Conditionally import design time targets that will be installed with the next Preview of Visual Studio 15. These targets override CPS project properties schema to enable functionality introduced by the [Roslyn Project System](https://github.com/dotnet/roslyn-project-system).

/cc @AndyGerlicher @srivatsn @davkean 

For reference:
- Roslyn Project System [Design Time targets](https://github.com/dotnet/roslyn-project-system/tree/SigningTesting/src/Targets)
- Work Item: https://github.com/dotnet/roslyn-project-system/issues/128