### PR TITLE
Avoid XmlLicenseTransform in AuthenticodeSignLicenseDom

### DIFF
--- a/src/XMakeTasks/ManifestUtil/mansign2.cs
+++ b/src/XMakeTasks/ManifestUtil/mansign2.cs
@@ -1415,7 +1415,9 @@ namespace System.Deployment.Internal.CodeSigning
 
             // Add an enveloped and an Exc-C14N transform.
             reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
-            reference.AddTransform(new XmlLicenseTransform());
+#if (false) // BUGBUG: LTA transform complaining about issuer node not found.
+            reference.AddTransform(new XmlLicenseTransform()); 
+#endif
             reference.AddTransform(new XmlDsigExcC14NTransform());
 
             // Add the reference.


### PR DESCRIPTION
Resolves #791

This line was #ifed out in the VS repo for quite a long time, but the
initial GitHub code drop was missing the condition. Restoring it to
prevent a regression in signing scenarios.