### PR TITLE
Reset the current directory for flaky Project_Internal_Tests.Build() …

### DIFF
--- a/src/XMakeBuildEngine/UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -15,6 +15,7 @@ using Microsoft.Build.Construction;
 using System.IO;
 using System.Xml;
 using System.Linq;
+using Microsoft.Build.Shared;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -516,6 +517,11 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         [Fact]
         public void Build()
         {
+            // Setting the current directory to the MSBuild running location. It *should* be this
+            // already, but if it's not some other test changed it and didn't change it back. If
+            // the directory does not include the reference dlls the compilation will fail.
+            Directory.SetCurrentDirectory(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
+
             string projectFileContent = @"
                     <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
                         <UsingTask TaskName='Microsoft.Build.Tasks.Message' AssemblyFile='Microsoft.Build.Tasks.Core.dll'/>


### PR DESCRIPTION
Spent half a day with that fix and the test did not fail, so I guess it's a fix :)
Also managed to break into the test when it failed, and the current working directory was indeed set to temp. Could not figure out what changed it.