### PR TITLE
Update MyGet feed URLs

### DIFF
--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -5,8 +5,8 @@
   </packageRestore>
   <packageSources>
     <clear />
-    <add key="myget.org buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
-    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+    <add key="myget.org buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="myget.org dotnet-corefx" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <activePackageSource>


### PR DESCRIPTION
Pretty sure the stale feed URLs were causing CI failures like in #797.

Not 100% sure why we'd need the corefx feed in master, but I suspect it's for transitive dependencies from buildtools.