### PR TITLE
Add MSBuildTaskHost to MSBuild.sln

### DIFF
--- a/src/MSBuild.sln
+++ b/src/MSBuild.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.Framework", "Framework\Microsoft.Build.Framework.csproj", "{571F09DB-A81A-4444-945C-6F7B530054CD}"
 EndProject
@@ -45,6 +45,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskUsageLogger", "..\Sampl
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.Engine.OM.UnitTests", "XMakeBuildEngine\UnitTestsPublicOM\Microsoft.Build.Engine.OM.UnitTests.csproj", "{9D858C8F-8D71-467E-808E-4E4F48DD0A49}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuildTaskHost", "XMakeCommandLine\MSBuildTaskHost\MSBuildTaskHost.csproj", "{53733ECF-0D81-43DA-B602-2AE9417F614F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -92,14 +94,13 @@ Global
 		{16CD7635-7CF4-4C62-A77B-CF87D0F09A58}.Release|x64.Build.0 = Release|x64
 		{16CD7635-7CF4-4C62-A77B-CF87D0F09A58}.Release|x86.ActiveCfg = Release|x86
 		{16CD7635-7CF4-4C62-A77B-CF87D0F09A58}.Release|x86.Build.0 = Release|x86
-		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Debug|Any CPU.Build.0 = Debug|x86
 		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Debug|x64.ActiveCfg = Debug|x64
 		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Debug|x64.Build.0 = Debug|x64
 		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Debug|x86.ActiveCfg = Debug|x86
 		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Debug|x86.Build.0 = Debug|x86
-		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Release|Any CPU.ActiveCfg = Release|x86
 		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Release|x64.ActiveCfg = Release|x64
 		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Release|x64.Build.0 = Release|x64
 		{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}.Release|x86.ActiveCfg = Release|x86
@@ -200,6 +201,17 @@ Global
 		{9D858C8F-8D71-467E-808E-4E4F48DD0A49}.Release|x64.Build.0 = Release|x64
 		{9D858C8F-8D71-467E-808E-4E4F48DD0A49}.Release|x86.ActiveCfg = Release|x86
 		{9D858C8F-8D71-467E-808E-4E4F48DD0A49}.Release|x86.Build.0 = Release|x86
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Debug|Any CPU.Build.0 = Debug|x86
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Debug|x64.ActiveCfg = Debug|x64
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Debug|x64.Build.0 = Debug|x64
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Debug|x86.ActiveCfg = Debug|x86
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Debug|x86.Build.0 = Debug|x86
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Release|Any CPU.ActiveCfg = Release|x86
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Release|x64.ActiveCfg = Release|x64
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Release|x64.Build.0 = Release|x64
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Release|x86.ActiveCfg = Release|x86
+		{53733ECF-0D81-43DA-B602-2AE9417F614F}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -14,8 +14,6 @@
     <ApplicationManifest>MSBuild.exe.manifest</ApplicationManifest>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" />

--- a/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -18,8 +18,6 @@
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" />


### PR DESCRIPTION
MSBuildTaskHost.csproj has been building since 2e2298a, but it wasn't
added to the solution, so it didn't show up in Visual Studio.

I also removed the AnyCPU configuration for MSBuild.exe and
MSBuildTaskHost.exe, since they should both always be built for an
explicit architecture.

@AndyGerlicher objection?