### PR TITLE
Add BuildEnvironmentHelper support for Blend.exe

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Build.Shared
         };
 
         /// <summary>
-        /// Name of the Visual Studio process(es)
+        /// Name of the Visual Studio (and Blend) process.
         /// </summary>
-        private static readonly string[] s_visualStudioProcess = {"DEVENV"};
+        private static readonly string[] s_visualStudioProcess = {"DEVENV", "BLEND"};
 
         /// <summary>
         /// Name of the MSBuild process(es)
@@ -143,10 +143,9 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Look for Visual Studio
         /// </summary>
-        /// <param name="processName"></param>
-        /// <param name="processName2"></param>
-        /// <param name="runningInVisualStudio"></param>
-        /// <returns></returns>
+        /// <param name="processNames">Name(s) of Visual Studio processes.</param>
+        /// <param name="runningInVisualStudio">True if running in Visual Studio</param>
+        /// <returns>Path to Visual Studio install root.</returns>
         private static string FindVisualStudio(string[] processNames, out bool runningInVisualStudio)
         {
             runningInVisualStudio = false;
@@ -158,7 +157,7 @@ namespace Microsoft.Build.Shared
                 {
                     runningInVisualStudio = true;
 
-                    // This assumes running from VS\Common7\IDE\devenv.exe.
+                    // This assumes running from VS\Common7\IDE\<process>.exe.
                     return FileUtilities.GetFolderAbove(process, 3);
                 }
             }

--- a/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -154,6 +154,18 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        public void BuildEnvironmentDetectsVisualStudioByBlendProcess()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.BlendPath, ReturnNull, () => env.MSBuildExePath, ReturnNull);
+
+                Assert.True(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
+                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
+            }
+        }
+
+        [Fact]
         public void BuildEnvironmentFindsAmd64()
         {
             using (var env = new EmptyBuildEnviroment())
@@ -199,6 +211,8 @@ namespace Microsoft.Build.Engine.UnitTests
 
             public string DevEnvPath { get; }
 
+            public string BlendPath { get; }
+
             public string BuildDirectory { get; }
 
             public string BuildDirectory64 { get; }
@@ -223,6 +237,7 @@ namespace Microsoft.Build.Engine.UnitTests
                     BuildDirectory = Path.Combine(TempFolderRoot, "MSBuild", "15.0", "Bin");
                     BuildDirectory64 = Path.Combine(BuildDirectory, "amd64");
                     DevEnvPath = Path.Combine(TempFolderRoot, "Common7", "IDE", "devenv.exe");
+                    BlendPath = Path.Combine(TempFolderRoot, "Common7", "IDE", "blend.exe");
 
                     Directory.CreateDirectory(BuildDirectory);
                     foreach (var file in files)


### PR DESCRIPTION
 - When running in Blend.exe, treat as if we're in Visual Studio.
   Previously we could not find Visual Studio and ended up setting the
   value to null.