### PR TITLE
Remove workaround fallback for _CppCommonExtensionTargets

### DIFF
--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -67,7 +67,6 @@
             <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
-            <property name="_CppCommonExtensionTargets" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.Cpp.targets)"/>
           </searchPaths>
         </projectImportSearchPaths>
       </toolset>


### PR DESCRIPTION
This was added as a temporary workaround. Removing fallback from that
import property.