### PR TITLE
Get item provenance

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -461,6 +461,46 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
+        /// Compare if two paths, relative to the given currentDirectory are equal.
+        /// Does not throw IO exceptions. See <see cref="GetFullPathNoThrow(string, string)"/>
+        /// </summary>
+        /// <param name="first"></param>
+        /// <param name="second"></param>
+        /// <param name="currentDirectory"></param>
+        /// <returns></returns>
+        internal static bool ComparePathsNoThrow(string first, string second, string currentDirectory)
+        {
+            // todo: on xplat, figure out if file system is case sensitive or not
+            var stringComparison = StringComparison.OrdinalIgnoreCase;
+
+            var firstFullPath = GetFullPathNoThrow(first, currentDirectory);
+            var secondFullPath = GetFullPathNoThrow(second, currentDirectory);
+
+            return string.Equals(firstFullPath, secondFullPath, stringComparison);
+        }
+
+        /// <summary>
+        /// A variation of Path.GetFullPath that will return the input value 
+        /// instead of throwing any IO exception.
+        /// Useful to get a better path for an error message, without the risk of throwing
+        /// if the error message was itself caused by the path being invalid!
+        /// </summary>
+        internal static string GetFullPathNoThrow(string fileSpec, string currentDirectory)
+        {
+            var fullPath = fileSpec;
+
+            try
+            {
+                fullPath = GetFullPath(fileSpec, currentDirectory);
+            }
+            catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
+            {
+            }
+
+            return fullPath;
+        }
+
+        /// <summary>
         /// A variation on File.Delete that will throw ExceptionHandling.NotExpectedException exceptions
         /// </summary>
         internal static void DeleteNoThrow(string path)

--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -2529,6 +2529,12 @@ namespace Microsoft.Build.Evaluation
                 get { return _items; }
             }
 
+            public List<ProjectItemElement> EvaluatedItemElements
+            {
+                get;
+                private set;
+            }
+
             /// <summary>
             /// List of items that link the XML items and evaluated items,
             /// evaluated as if their conditions were true.
@@ -2758,6 +2764,7 @@ namespace Microsoft.Build.Evaluation
                 this.AllEvaluatedProperties = new List<ProjectProperty>();
                 this.AllEvaluatedItemDefinitionMetadata = new List<ProjectMetadata>();
                 this.AllEvaluatedItems = new List<ProjectItem>();
+                this.EvaluatedItemElements = new List<ProjectItemElement>();
 
                 if (_globalPropertiesToTreatAsLocal != null)
                 {

--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -1030,6 +1031,225 @@ namespace Microsoft.Build.Evaluation
             ErrorUtilities.VerifyThrowArgumentNull(item, "item");
 
             return ((IItem)item).EvaluatedIncludeEscaped;
+        }
+
+        /// <summary>
+        /// Finds all the item elements in the logical project with itemspecs that match the given string:
+        /// - elements that would include (or exclude) the string
+        /// - elements that would update the string (not yet implemented)
+        /// - elements that would remove the string (not yet implemented)
+        /// </summary>
+        /// 
+        /// <example>
+        /// The following snippet shows what <c>GetItemProvenance("a.cs")</c> returns for various item elements
+        /// <code>
+        /// <A Include="a.cs;*.cs"/> // Occurences:2; Operation: Include; Provenance: StringLiteral | Glob
+        /// <B Include="*.cs" Exclude="a.cs"/> // Occurences: 1; Operation: Exclude; Provenance: StringLiteral
+        /// <C Include="b.cs"/> // NA
+        /// <D Include="@(A)"/> // Occurences: 2; Operation: Include; Provenance: Inconclusive (it is an indirect occurence from a referenced item)
+        /// <E Include="$(P)"/> // Occurences: 4; Operation: Include; Provenance: FromLiteral (direct reference in $P) | Glob (direct reference in $P) | Inconclusive (it is an indirect occurence from referenced properties and items)
+        /// <PropertyGroup>
+        ///     <P>a.cs;*.cs;@(A)</P>
+        /// </PropertyGroup>
+        /// </code>
+        /// 
+        /// </example>
+        /// 
+        /// <remarks>
+        /// This method and its overloads are useful for clients that need to inspect all the item elements
+        /// that might refer to a specific item instance. For example, Visual Studio uses it to inspect
+        /// projects with globs. Upon a file system or IDE file artifact change, VS calls this method to find all the items
+        /// that might refer to the detected file change (e.g. 'which item elements refer to "Program.cs"?').
+        /// It uses such information to know which elements it should edit to reflect the user or file system changes.
+        /// 
+        /// Literal string matching tries to first match the strings. If the check fails, it then tries to match
+        /// the strings as if they represented files: it normalizes both strings as files relative to the current project directory
+        ///
+        /// GetItemProvenance suffers from some sources of innacuracy:
+        /// - it is performed after evaluation, thus is insensitive to item data flow when item references are present
+        /// (it sees items as they are at the end of evaluation)
+        /// 
+        /// This API and its return types are prone to change.
+        /// </remarks>
+        /// 
+        /// <param name="itemToMatch">The string to perform matching against</param>
+        /// 
+        /// <returns>
+        /// A list of <see cref="ProvenanceResult"/>, sorted in project evaluation order.
+        /// </returns>
+        public List<ProvenanceResult> GetItemProvenance(string itemToMatch)
+        {
+            return GetItemProvenance(itemToMatch, _data.EvaluatedItemElements);
+        }
+
+        /// <summary>
+        /// Overload of <see cref="GetItemProvenance(string)"/>
+        /// </summary>
+        /// <param name="itemToMatch">The string to perform matching against</param>
+        /// <param name="itemType">The item type to constrain the search in</param>
+        public List<ProvenanceResult> GetItemProvenance(string itemToMatch, string itemType)
+        {
+            return GetItemProvenance(itemToMatch, _data.EvaluatedItemElements.Where(i => i.ItemType.Equals(itemType)));
+        }
+
+        /// <summary>
+        /// Overload of <see cref="GetItemProvenance(string)"/>
+        /// </summary>
+        /// <param name="item"> 
+        /// The ProjectItem object that indicates: the itemspec to match and the item type to constrain the search in.
+        /// The search is also constrained on item elements appearing before the item element that produced this <paramref name="item"/>.
+        /// The element that produced this <paramref name="item"/> is included in the results.
+        /// </param>
+        public List<ProvenanceResult> GetItemProvenance(ProjectItem item)
+        {
+            var itemElementsAbove = _data.EvaluatedItemElements
+                                            .Where(i => i.ItemType.Equals(item.ItemType))
+                                            .TakeWhile(i => i != item.Xml)
+                                            .ToList();
+            itemElementsAbove.Add(item.Xml);
+
+            return GetItemProvenance(item.EvaluatedInclude, itemElementsAbove);
+        }
+
+
+        private List<ProvenanceResult> GetItemProvenance(string itemToMatch, IEnumerable<ProjectItemElement> projectItemElements )
+        {
+            return
+                projectItemElements.Select(i => ComputeProvenanceResult(itemToMatch, i))
+                    .Where(r => r != null)
+                    .ToList();
+        }
+
+        private ProvenanceResult ComputeProvenanceResult(string itemToMatch, ProjectItemElement itemElement)
+        {
+            var expander = new Expander<ProjectProperty, ProjectItem>(_data.Properties, _data.Items);
+            Func<IElementLocation, Func<string, ExpanderOptions, string>> expandForXmlLocation = (l) => (s, o) => expander.ExpandIntoStringLeaveEscaped(s, o, l);
+
+            var includeResult = ComputeProvenanceResult(itemToMatch, itemElement.Include, expandForXmlLocation(itemElement.IncludeLocation));
+
+            if (includeResult == null)
+            {
+                return null;
+            }
+
+            var excludeResult = ComputeProvenanceResult(itemToMatch, itemElement.Exclude, expandForXmlLocation(itemElement.ExcludeLocation));
+
+            return excludeResult != null
+                ? new ProvenanceResult(itemElement, Operation.Exclude, excludeResult.Item1, excludeResult.Item2)
+                : new ProvenanceResult(itemElement, Operation.Include, includeResult.Item1, includeResult.Item2);
+        }
+
+        private Tuple<Provenance, int> ComputeProvenanceResult(string itemToMatch, string itemSpecToLookIn, Func<string, ExpanderOptions, string> expand)
+        {
+            Provenance provenance;
+            var matchOccurrences = ItemMatchesInSpecCompareViaExpander(itemToMatch, itemSpecToLookIn, expand, out provenance);
+
+            return matchOccurrences > 0 ? Tuple.Create(provenance, matchOccurrences) : null;
+        }
+
+        /// <summary>
+        /// Since:
+        ///     - we have no proper AST and interpreter for itemspecs that we can do analysis on
+        ///     - GetItemProvenance needs to have correct counts for exclude strings (as correct as it can get while doing it after evaluation)
+        /// 
+        /// The temporary hack is to use the expander to expand the strings, and if any property or item references were encountered, return Provenance.Inconclusive
+        /// </summary>
+        private int ItemMatchesInSpecCompareViaExpander(string itemToMatch, string itemSpec, Func<string, ExpanderOptions, string> expand, out Provenance provenance)
+        {
+            if (string.IsNullOrEmpty(itemSpec))
+            {
+                provenance = Provenance.Undefined;
+                return 0;
+            }
+
+            // look into the itemspec as if it were expanded by the Expander
+            Provenance provenanceFromExpandedPropertiesAndItems;
+            var expandedMatches = ItemMatchesInSpec(itemToMatch, expand(itemSpec, ExpanderOptions.ExpandPropertiesAndItems), out provenanceFromExpandedPropertiesAndItems);
+
+            // look into the raw itemspec
+            Provenance provenanceFromNonExpandedString;
+            var nonExpandedMatches = ItemMatchesInSpec(itemToMatch, itemSpec, out provenanceFromNonExpandedString);
+
+            if (expandedMatches > nonExpandedMatches)
+            {
+                // return the number of occurences when properties AND items are expanded to get the correct occurence count
+
+                // return the provenance WITHOUT item expansion. Otherwise the items coming from a referenced item get interpreted as StringLiteral
+                // include="*.cs;@(Compile)" needs to return Inconclusive|Glob and not Inconclusive|Glob|StringLiteral
+                Provenance provenanceFromExpandedProperties;
+                ItemMatchesInSpec(itemToMatch, expand(itemSpec, ExpanderOptions.ExpandProperties), out provenanceFromExpandedProperties);
+
+                provenance = Provenance.Inconclusive | provenanceFromExpandedProperties;
+                return expandedMatches;
+            }
+            else
+            {
+                provenance = provenanceFromNonExpandedString;
+                return nonExpandedMatches;
+            }
+        }
+
+        private int ItemMatchesInSpec(string itemToMatch, string itemSpec, out Provenance provenance)
+        {
+            provenance = Provenance.Undefined;
+
+            var occurrences = 0;
+
+            if (string.IsNullOrEmpty(itemSpec))
+            {
+                return occurrences;
+            }
+
+            foreach (var itemFragment in ExpressionShredder.SplitSemiColonSeparatedList(itemSpec))
+            {
+                if (IsPropertyReferenceFragment(itemFragment) || IsItemReferenceFragment(itemFragment))
+                {
+                    continue;
+                }
+
+                if (IsGlobFragment(itemFragment) && ItemMatchesGlob(itemFragment, itemToMatch))
+                {
+                    provenance |= Provenance.Glob;
+                    occurrences++;
+                }
+
+                if (ItemMatchesStringLiteral(itemToMatch, itemFragment))
+                {
+                    provenance |= Provenance.StringLiteral;
+                    occurrences++;
+                }
+            }
+
+            return occurrences;
+        }
+
+        private bool ItemMatchesStringLiteral(string itemToMatch, string itemFragment)
+        {
+            var thisProjectPath = _data.Directory;
+
+            // It is either a direct string match or the two strings refer to the same file, relative to the project directory
+            return itemToMatch.Equals(itemFragment) || FileUtilities.ComparePathsNoThrow(itemToMatch, itemFragment, thisProjectPath);
+        }
+
+        private static bool ItemMatchesGlob(string globPattern, string file)
+        {
+            var match = FileMatcher.FileMatch(globPattern, file);
+            return match.isLegalFileSpec && match.isMatch;
+        }
+
+        private static bool IsGlobFragment(string itemFragment)
+        {
+            return FileMatcher.HasWildcards(itemFragment);
+        }
+
+        private static bool IsItemReferenceFragment(string itemFragment)
+        {
+            return itemFragment.Contains("@(");
+        }
+
+        private static bool IsPropertyReferenceFragment(string itemFragment)
+        {
+            return itemFragment.Contains("$(");
         }
 
         /// <summary>
@@ -2310,6 +2530,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
+
         /// <summary>
         /// Encapsulates the backing data of a Project, so that it can be passed to the Evaluator to
         /// fill in on a re-evaluation without having to expose property setters.
@@ -3147,6 +3368,61 @@ namespace Microsoft.Build.Evaluation
                 string value = (property == null) ? String.Empty : property.EvaluatedValue;
                 return value;
             }
+        }
+    }
+
+    /// <summary>
+    /// Bit flag enum that specifies how a string representing an item matched against an itemspec.
+    /// </summary>
+    [Flags]
+    public enum Provenance
+    {
+        /// <summary>
+        /// Undefined is the bottom element and should not appear in actual results 
+        /// </summary>
+        Undefined = 0,
+
+        /// <summary>
+        /// A string matched against a string literal from an itemspec
+        /// </summary>
+        StringLiteral = 1,
+
+        /// <summary>
+        /// A string matched against a glob pattern from an itemspec
+        /// </summary>
+        Glob = 2,
+
+        /// <summary>
+        /// Inconclusive means that the match is indirect, coming from either property or item references.
+        /// </summary>
+        Inconclusive = 4
+    }
+
+    /// <summary>
+    /// Enum that specifies how an item element references an item
+    /// </summary>
+    public enum Operation
+    {
+        Include, 
+        Exclude
+    }
+
+    /// <summary>
+    /// Data class representing a result from <see cref="Project.GetItemProvenance(string)"/> and its overloads.
+    /// </summary>
+    public class ProvenanceResult
+    {
+        public Operation Operation { get; private set; }
+        public ProjectItemElement ItemElement { get; private set; }
+        public Provenance Provenance { get; private set; }
+        public int Occurrences { get; private set; }
+
+        public ProvenanceResult(ProjectItemElement itemElement, Operation operation, Provenance provenance, int occurrences)
+        {
+            ItemElement = itemElement;
+            Operation = operation;
+            Provenance = provenance;
+            Occurrences = occurrences;
         }
     }
 }

--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -1780,6 +1780,8 @@ namespace Microsoft.Build.Evaluation
             // FINALLY: Add the items to the project
             if (itemConditionResult && itemGroupConditionResult)
             {
+                _data.EvaluatedItemElements.Add(itemElement);
+
                 foreach (I item in items)
                 {
                     _data.AddItem(item);

--- a/src/XMakeBuildEngine/Evaluation/IEvaluatorData.cs
+++ b/src/XMakeBuildEngine/Evaluation/IEvaluatorData.cs
@@ -181,6 +181,15 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Evaluation ordered list of project item elements that were evaluated by the Evaluator
+        /// It means that both the item element's condition and the item group element's conditions evaluated to true
+        /// </summary>
+        List<ProjectItemElement> EvaluatedItemElements
+        {
+            get;
+        }
+
+        /// <summary>
         /// Prepares the data block for a new evaluation pass
         /// </summary>
         void InitializeForEvaluation(IToolsetProvider toolsetProvider);

--- a/src/XMakeBuildEngine/Instance/ProjectInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectInstance.cs
@@ -327,6 +327,8 @@ namespace Microsoft.Build.Execution
             this.TaskRegistry = projectToInheritFrom.TaskRegistry;
             _isImmutable = projectToInheritFrom._isImmutable;
 
+            this.EvaluatedItemElements = new List<ProjectItemElement>();
+
             IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance> thisAsIEvaluatorData = (IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>)this;
             thisAsIEvaluatorData.AfterTargets = new Dictionary<string, List<TargetSpecification>>();
             thisAsIEvaluatorData.BeforeTargets = new Dictionary<string, List<TargetSpecification>>();
@@ -420,6 +422,8 @@ namespace Microsoft.Build.Execution
 
             this.ProjectRootElementCache = data.Project.ProjectCollection.ProjectRootElementCache;
 
+            this.EvaluatedItemElements = new List<ProjectItemElement>(data.EvaluatedItemElements);
+
             _usingDifferentToolsVersionFromProjectFile = data.UsingDifferentToolsVersionFromProjectFile;
             _originalProjectToolsVersion = data.OriginalProjectToolsVersion;
             _explicitToolsVersionSpecified = data.ExplicitToolsVersion != null;
@@ -496,6 +500,8 @@ namespace Microsoft.Build.Execution
             _targets = that._targets;
             _itemDefinitions = that._itemDefinitions;
             _explicitToolsVersionSpecified = that._explicitToolsVersionSpecified;
+
+            this.EvaluatedItemElements = that.EvaluatedItemElements;
 
             this.ProjectRootElementCache = that.ProjectRootElementCache;
         }
@@ -579,6 +585,12 @@ namespace Microsoft.Build.Execution
                     (ICollection<ProjectItemInstance>)ReadOnlyEmptyCollection<ProjectItemInstance>.Instance :
                     new ReadOnlyCollection<ProjectItemInstance>(_items);
             }
+        }
+
+        public List<ProjectItemElement> EvaluatedItemElements
+        {
+            get;
+            private set;
         }
 
         /// <summary>
@@ -2181,6 +2193,8 @@ namespace Microsoft.Build.Execution
             _itemDefinitions = new RetrievableEntryHashSet<ProjectItemDefinitionInstance>(MSBuildNameIgnoreCaseComparer.Default);
             _hostServices = buildParameters.HostServices;
             this.ProjectRootElementCache = buildParameters.ProjectRootElementCache;
+
+            this.EvaluatedItemElements = new List<ProjectItemElement>();
 
             string toolsVersionToUse = explicitToolsVersion;
             _explicitToolsVersionSpecified = (explicitToolsVersion != null);

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,6 +18,8 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
+// can't use an actual ProvenanceResult because it points to a ProjectItemElement which is hard to mock. 
+using ProvenanceResultTupleList = System.Collections.Generic.List<System.Tuple<string, Microsoft.Build.Evaluation.Operation, Microsoft.Build.Evaluation.Provenance, int>>;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using ToolLocationHelper = Microsoft.Build.Utilities.ToolLocationHelper;
 using TargetDotNetFrameworkVersion = Microsoft.Build.Utilities.TargetDotNetFrameworkVersion;
@@ -2415,6 +2418,425 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             }
            );
         }
+
+        [Fact]
+        public void GetItemProvenanceShouldReturnEmptyListOnNoMatches()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`1;2;3`/>
+                    <B Include=`1;2;3` Exclude=`1;4`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList();
+
+            AssertProvenanceResult(expected, project, "4");
+        }
+
+        [Fact]
+        public void GetItemProvenanceOnlyStringLiteral()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`1;2;3`/>
+                    <B Include=`1;2;3` Exclude=`1`/>
+                    <C Include=`2;3` Exclude=`2`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1),
+                Tuple.Create("B", Operation.Exclude, Provenance.StringLiteral, 1)
+            };
+
+            AssertProvenanceResult(expected, project, "1");
+        }
+
+        [Fact]
+        public void GetItemProvenanceShouldNotReportMatchesInExcludesIfNoIncludeMatchesExist()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`1,2,3` Exclude=`4`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList();
+
+            AssertProvenanceResult(expected, project, "4");
+        }
+
+        [Fact]
+        public void GetItemProvenanceOnlyGlob()
+        {
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`*.foo`/>
+                    <B Include=`1.foo;2.foo` Exclude=`*.foo`/>
+                    <C Include=`2` Exclude=`*.bar`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
+                Tuple.Create("B", Operation.Exclude, Provenance.Glob, 1)
+            };
+
+            AssertProvenanceResult(expected, project, "2.foo");
+        }
+
+        [Fact]
+        public void GetItemProvenanceShouldHandleComplexGlobExclusion()
+        {
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`**\*.cs` Exclude=`**\bin\**`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Exclude, Provenance.Glob, 1)
+            };
+
+            AssertProvenanceResult(expected, project, @"bin\1.cs");
+        }
+
+        [Fact]
+        public void GetItemProvenanceShouldHandleComplexGlobMismatch()
+        {
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`**\*.cs` Exclude=`**\bin\**`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList();
+
+            AssertProvenanceResult(expected, project, @"bin\1.foo");
+        }
+
+        [Fact]
+        public void GetItemProvenanceGlobAndLiteral()
+        {
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`*.foo;1.foo;1.foo`/>
+                    <B Include=`1;2;1.foo` Exclude=`*.foo;1.foo;*.foo;1.foo;2.foo`/>
+                    <C Include=`2;3` Exclude=`2`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Include, Provenance.Glob | Provenance.StringLiteral, 3),
+                Tuple.Create("B", Operation.Exclude, Provenance.Glob | Provenance.StringLiteral, 4)
+            };
+
+            AssertProvenanceResult(expected, project, "1.foo");
+        }
+
+        [Fact]
+        public void GetItemProvenanceByItemType()
+        {
+            var project = 
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`*.foo;1.foo`/>
+                    <B Include=`*.foo;1.foo`/>
+                    <B Include=`1;2;1.foo` Exclude=`*.foo;1.foo`/>
+                    <C Include=`2;3` Exclude=`2`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("B", Operation.Include, Provenance.Glob | Provenance.StringLiteral, 2),
+                Tuple.Create("B", Operation.Exclude, Provenance.Glob | Provenance.StringLiteral, 2)
+            };
+
+            AssertProvenanceResult(expected, project, "1.foo", "B");
+        }
+
+        [Fact]
+        public void GetItemProvenanceByProjectItem()
+        {
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`*.foo;1.foo`/>
+                    <B Include=`1;2;3;*.foo` Exclude=`*.foo;1.foo`/>
+                    <B Include=`*.foo;1.foo`/>
+                    <C Include=`2;3` Exclude=`2`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("B", Operation.Exclude, Provenance.Glob | Provenance.StringLiteral, 2),
+                Tuple.Create("B", Operation.Include, Provenance.Glob | Provenance.StringLiteral, 2)
+            };
+
+            AssertProvenanceResult(expected, project, "1.foo", 1);
+        }
+
+        [Fact]
+        public void GetItemProvenanceWhenExcludeHasIndirectReferences()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <B Include=`1;2;3`/>
+                    <A Include=`1;2;3` Exclude=`$(P);@(B)`/>
+                  </ItemGroup>
+
+                  <PropertyGroup>
+                    <P>1;2;3;@(B)</P>  
+                  </PropertyGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("B", Operation.Include, Provenance.StringLiteral, 1),
+                Tuple.Create("A", Operation.Exclude, Provenance.Inconclusive | Provenance.StringLiteral, 3)
+            };
+
+            AssertProvenanceResult(expected, project, "1");
+        }
+
+        [Fact]
+        public void GetItemProvenanceWhenIncludeHasIndirectReferences()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <B Include=`1;2;3`/>
+                    <A Include=`$(P);@(B)`/>
+                    <C Include=`@(A)`/>
+                  </ItemGroup>
+
+                  <PropertyGroup>
+                    <P>1;2;3;@(B)</P>  
+                  </PropertyGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("B", Operation.Include, Provenance.StringLiteral, 1),
+                Tuple.Create("A", Operation.Include, Provenance.Inconclusive | Provenance.StringLiteral, 3),
+                Tuple.Create("C", Operation.Include, Provenance.Inconclusive, 3)
+            };
+
+            AssertProvenanceResult(expected, project, "1");
+        }
+
+        [Fact]
+        public void GetItemProvenanceWhenIncludeHasIndirectItemReferencesAndOnlyGlobsExistDirectly()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <B Include=`1;2;3`/>
+                    <A Include=`*;$(P);@(B)`/>
+                  </ItemGroup>
+
+                  <PropertyGroup>
+                    <P>@(B)</P>  
+                  </PropertyGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("B", Operation.Include, Provenance.StringLiteral, 1),
+                Tuple.Create("A", Operation.Include, Provenance.Inconclusive | Provenance.Glob, 3)
+            };
+
+            AssertProvenanceResult(expected, project, "1");
+        }
+
+        [Fact]
+        public void GetItemProvenanceShouldRespectItemConditions()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`1` Condition=`1 == 0`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList();
+
+            AssertProvenanceResult(expected, project, "1");
+        }
+
+        [Fact]
+        public void GetItemProvenanceShouldRespectItemGroupConditions()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup Condition=`1 == 0`>
+                    <A Include=`1`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList();
+
+            AssertProvenanceResult(expected, project, "1");
+        }
+
+        [Fact]
+        public void GetItemProvenanceShouldNotLookIntoTargets()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <Target Name=`Build`>
+                      <ItemGroup>
+                        <A Include=`1`/>
+                      </ItemGroup>
+                  </Target>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList();
+
+            AssertProvenanceResult(expected, project, "1");
+        }
+
+        [Fact]
+        public void GetItemProvenanceMatchesLiteralsWithNonCanonicPaths()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`1.foo;.\1.foo;.\.\1.foo`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 3)
+            };
+
+            AssertProvenanceResult(expected, project, "1.foo");
+            AssertProvenanceResult(expected, project, @".\1.foo");
+        }
+
+        [Fact]
+        public void GetItemProvenanceShouldMatchStringsWithIllegalPathCharacters()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`|:/\?*`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList();
+
+            AssertProvenanceResult(expected, project, @"?:/*\|");
+        }
+
+        [Fact]
+        public void GetItemProvenanceShouldWorkWithStringsExceedingMaxPath()
+        {
+            var longString = new string('a', 1000);
+
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`" + longString +  @"`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList();
+
+            AssertProvenanceResult(expected, project, longString + "a");
+        }
+
+        // todo: on xplat, split this to windows and non-windows test
+        [Fact]
+        public void GetItemProvenancePathMatchingShouldBeCaseInsensitive()
+        {
+            var project =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`a`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1)
+            };
+
+            AssertProvenanceResult(expected, project, "A");
+        }
+
+        private static void AssertProvenanceResult(ProvenanceResultTupleList expected, string project, string itemValue)
+        {
+            var provenanceResult = ObjectModelHelpers.CreateInMemoryProject(project).GetItemProvenance(itemValue);
+            AssertProvenanceResult(expected, provenanceResult);
+        }
+
+        private static void AssertProvenanceResult(ProvenanceResultTupleList expected, string project, string itemValue, string itemType)
+        {
+            var provenanceResult = ObjectModelHelpers.CreateInMemoryProject(project).GetItemProvenance(itemValue, itemType);
+            AssertProvenanceResult(expected, provenanceResult);
+        }
+
+        private static void AssertProvenanceResult(ProvenanceResultTupleList expected, string project, string itemValue, int position)
+        {
+            var p = ObjectModelHelpers.CreateInMemoryProject(project);
+            var item = p.Items.Where(i => i.EvaluatedInclude.Equals(itemValue)).ElementAt(position);
+
+            var provenanceResult = p.GetItemProvenance(item);
+            AssertProvenanceResult(expected, provenanceResult);
+        }
+
+        private static void AssertProvenanceResult(ProvenanceResultTupleList expected, List<ProvenanceResult> actual)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+
+            for (var i = 0; i < expected.Count; i++)
+            {
+                var expectedProvenance = expected[i];
+                var actualProvenance = actual[i];
+
+                Assert.Equal(expectedProvenance.Item1, actualProvenance.ItemElement.ItemType);
+                Assert.Equal(expectedProvenance.Item2, actualProvenance.Operation);
+                Assert.Equal(expectedProvenance.Item3, actualProvenance.Provenance);
+                Assert.Equal(expectedProvenance.Item4, actualProvenance.Occurrences);
+            }
+        }
+
         /// <summary>
         /// Creates a simple ProjectRootElement object.
         /// (When ProjectRootElement supports editing, we need not load from a string here.)


### PR DESCRIPTION
Addresses #732 

This implementation:
- is performed after evaluation => lacks flow accuracy of inter-item references
- appends `Provenance.Inconclusive` to the result when the match is inside an indirect property / item reference
- does not expand any globs

Since the expander / evaluator do not keep a trace of what happened, this implementation expands the string twice and diffs the results to understand what happened and to give accurate occurrence results.

Also, this implementation is a temporary one. It will get refactored when it has to consider Update and Remove. And there's a chance it will get removed and re-implemented on top of lazy evaluation to gain flow accuracy. And then re-implemented again if / when we have scanners, parsers, and interpreters over the itemspec context-sensitive mini-language.