### PR TITLE
Archive test results

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -62,7 +62,7 @@ def project = GithubProject
         Utilities.standardJobSetup(newJob, project, isPR, branch)
         // Add archiving of logs (even if the build failed)
         Utilities.addArchival(newJob,
-                              'msbuild*.log', /* filesToArchive */
+                              'msbuild*.log,Microsoft.*.UnitTests.dll_*', /* filesToArchive */
                               '', /* filesToExclude */
                               false, /* doNotFailIfNothingArchived */
                               false, /* archiveOnlyIfSuccessful */)


### PR DESCRIPTION
When tests fail in random, puzzling ways, it is probably helpful to have the xml outputs and the test 
stdout

[This comment](https://github.com/dotnet/dotnet-ci/blob/master/jobs/generation/Utilities.groovy#L852) suggests we can separate globs by commas, so that's what I did. Hopefully it works. If not, I'll manually create an ArchivalSettings object

(PR created in response to this CI failure: http://dotnet-ci.cloudapp.net/job/Microsoft_msbuild/job/_Windows_NT_prtest/644/)