### PR TITLE
Directory item metadata should be relative

### DIFF
--- a/src/Utilities/UnitTests/TaskItem_Tests.cs
+++ b/src/Utilities/UnitTests/TaskItem_Tests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Build.UnitTests
             TaskItem from = new TaskItem();
             from.ItemSpec = NativeMethodsShared.IsWindows ? @"c:\subdir\Monkey.txt" : "/subdir/Monkey.txt";
             Assert.Equal(
-                NativeMethodsShared.IsWindows ? @"subdir\" : "/subdir/",
+                NativeMethodsShared.IsWindows ? @"subdir\" : "subdir/",
                 from.GetMetadata(FileUtilities.ItemSpecModifiers.Directory));
         }
 

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             Assert.Equal(@"bar", item.GetMetadataValue("Filename"));
             Assert.Equal(@".baz", item.GetMetadataValue("Extension"));
             Assert.Equal(NativeMethodsShared.IsWindows ? @"c:\foo\" : "/foo/", item.GetMetadataValue("RelativeDir"));
-            Assert.Equal(NativeMethodsShared.IsWindows ? @"foo\" : "/foo/", item.GetMetadataValue("Directory"));
+            Assert.Equal(NativeMethodsShared.IsWindows ? @"foo\" : "foo/", item.GetMetadataValue("Directory"));
             Assert.Equal(String.Empty, item.GetMetadataValue("RecursiveDir"));
             Assert.Equal(
                 NativeMethodsShared.IsWindows ? @"c:\foo\bar.baz" : "/foo/bar.baz",

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -32,6 +32,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     public class Project_Tests : IDisposable
     {
         /// <summary>
+        /// Number of characters in a rooted path's prefix.
+        /// </summary>
+        /// <remarks>
+        /// The prefix is "c:\" on Windows, "/" on other OSes.
+        /// </remarks>
+        private readonly int RootPrefixLength = NativeMethodsShared.IsWindows ? 3 : 1;
+
+        /// <summary>
         /// Clear out the global project collection
         /// </summary>
         public Project_Tests()
@@ -705,24 +713,12 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 Project project = new Project(xml);
                 ProjectInstance projectInstance = new ProjectInstance(xml);
 
-                if (NativeMethodsShared.IsWindows)
-                {
-                    Assert.Equal(
-                        Path.Combine(Path.GetTempPath().Substring(3) /* remove c:\ */, @"obj\i386\"),
+                Assert.Equal(
+                        Path.Combine(Path.GetTempPath(), "obj", "i386").Substring(RootPrefixLength) + Path.DirectorySeparatorChar,
                         project.GetItems("BuiltProjectOutputGroupKeyOutput").First().EvaluatedInclude);
-                    Assert.Equal(
-                        Path.Combine(Path.GetTempPath().Substring(3) /* remove c:\ */, @"obj\i386\"),
+                Assert.Equal(
+                        Path.Combine(Path.GetTempPath(), "obj", "i386").Substring(RootPrefixLength) + Path.DirectorySeparatorChar,
                         projectInstance.GetItems("BuiltProjectOutputGroupKeyOutput").First().EvaluatedInclude);
-                }
-                else
-                {
-                    Assert.Equal(
-                        Path.Combine(Path.GetTempPath(), @"obj/i386/"),
-                        project.GetItems("BuiltProjectOutputGroupKeyOutput").First().EvaluatedInclude);
-                    Assert.Equal(
-                        Path.Combine(Path.GetTempPath(), @"obj/i386/"),
-                        projectInstance.GetItems("BuiltProjectOutputGroupKeyOutput").First().EvaluatedInclude);
-                }
             }
             finally
             {
@@ -756,24 +752,12 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 Project project = new Project(xml);
                 ProjectInstance projectInstance = new ProjectInstance(xml);
 
-                if (NativeMethodsShared.IsWindows)
-                {
-                    Assert.Equal(
-                        Path.Combine(Path.GetTempPath().Substring(3) /* remove c:\ */, @"obj\i386\"),
+                Assert.Equal(
+                        Path.Combine(Path.GetTempPath(), "obj", "i386").Substring(RootPrefixLength) + Path.DirectorySeparatorChar,
                         project.GetItems("BuiltProjectOutputGroupKeyOutput").First().EvaluatedInclude);
-                    Assert.Equal(
-                        Path.Combine(Path.GetTempPath().Substring(3) /* remove c:\ */, @"obj\i386\"),
+                Assert.Equal(
+                        Path.Combine(Path.GetTempPath(), "obj", "i386").Substring(RootPrefixLength) + Path.DirectorySeparatorChar,
                         projectInstance.GetItems("BuiltProjectOutputGroupKeyOutput").First().EvaluatedInclude);
-                }
-                else
-                {
-                    Assert.Equal(
-                        Path.Combine(Path.GetTempPath(), @"obj/i386/"),
-                        project.GetItems("BuiltProjectOutputGroupKeyOutput").First().EvaluatedInclude);
-                    Assert.Equal(
-                        Path.Combine(Path.GetTempPath(), @"obj/i386/"),
-                        projectInstance.GetItems("BuiltProjectOutputGroupKeyOutput").First().EvaluatedInclude);
-                }
             }
             finally
             {


### PR DESCRIPTION
Fixes #813

On Windows, `%(Directory)` strips the drive letter-colon-backslash
prefix from full paths. For unixy paths, the same meaning isn't exactly
clear, but there's a known root (`/`) that could be stripped
equivalently.

After this change, the correct metadata reference to get full directory
is `%(RootDir)%(Directory)` on Windows (as it always has been) and on
other OSes (as Mono's xbuild has been doing, and as seems most
consistent).