### PR TITLE
Update app.config for C++ target default properties

### DIFF
--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -55,12 +55,13 @@
         <property name="MSBuildExtensionsPath32" value="$(VsInstallRoot)\MSBuild" />
 
         <!-- VC Specific Paths -->
-        <property name="VCTargetsPath" value="$(VsInstallRoot)\Common7\IDE\VC\VCTargets" />
-        <property name="VCTargetsPath14" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath14)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V140\'))" />
-        <property name="VCTargetsPath12" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath12)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V120\'))" />
-        <property name="VCTargetsPath11" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath11)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V110\'))" />
-        <property name="VCTargetsPath10" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\'))" />
-
+        <property name="VCTargetsPath" value="$(VsInstallRoot)\Common7\IDE\VC\VCTargets\" />
+        <property name="VCTargetsPath14" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath14)','$(MSBuildProgramFiles32)\MSBuild\Microsoft.Cpp\v4.0\V140\'))" />
+        <property name="VCTargetsPath12" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath12)','$(MSBuildProgramFiles32)\MSBuild\Microsoft.Cpp\v4.0\V120\'))" />
+        <property name="VCTargetsPath11" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath11)','$(MSBuildProgramFiles32)\MSBuild\Microsoft.Cpp\v4.0\V110\'))" />
+        <property name="VCTargetsPath10" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$(MSBuildProgramFiles32)\MSBuild\Microsoft.Cpp\v4.0\'))" />
+        <property name="AndroidTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\Android\V150\" />
+        <property name="iOSTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\iOS\V150\" />
         <projectImportSearchPaths>
           <searchPaths os="windows">
             <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>


### PR DESCRIPTION
 - Add trailing '\' on VCTargetsPath
 - Add AdroidTargetsPath and iOSTargetsPath per C++ team. This matches
   values that were previously set by optional installed components.