### PR TITLE
Set codeBase for MSBuild assemblies in x64 MSBuild

### DIFF
--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PlatformSpecificBuild>true</PlatformSpecificBuild>
@@ -12,6 +12,12 @@
     <AssemblyName>MSBuild</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationManifest>MSBuild.exe.manifest</ApplicationManifest>
+
+    <AppConfig>app.config</AppConfig>
+    <!-- Temporary solution for
+         https://github.com/Microsoft/msbuild/issues/834 Long term
+         two files should be generated from a single source. -->
+    <AppConfig Condition="'$(Platform)' == 'x64'">app.amd64.config</AppConfig>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
@@ -187,6 +193,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="app.amd64.config">
       <SubType>Designer</SubType>
     </None>
     <None Include="MSBuild.exe.manifest" />

--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+  <configuration>
+    <configSections>
+      <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    </configSections>
+    <startup useLegacyV2RuntimeActivationPolicy="true">
+      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+    <runtime>
+      <DisableFXClosureWalk enabled="true" />
+      <generatePublisherEvidence enabled="false" />
+      <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Framework.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Tasks.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Tasks.Core.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Utilities.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Utilities.Core.dll"/>
+        </dependentAssembly>
+      </assemblyBinding>
+    </runtime>
+    <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
+    <msbuildToolsets default="15.0">
+      <toolset toolsVersion="15.0">
+        <property name="MSBuildRootWorkaround704" value="$([MSBuild]::GetCurrentExecutableDirectory())" />
+        <!-- See https://github.com/Microsoft/msbuild/issues/704 -->
+        <property name="MSBuildToolsPath" value="$(MSBuildRootWorkaround704)" />
+        <property name="MSBuildToolsPath32" value="$(MSBuildToolsPath)" />
+        <property name="MSBuildToolsPath64" value="$(MSBuildToolsPath)\amd64" />
+        <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1@InstallationFolder)" />
+        <property name="MSBuildRuntimeVersion" value="4.0.30319" />
+        <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsPath64" value="$(SystemRoot)\Microsoft.NET\Framework64\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
+        <property name="SDK35ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86@InstallationFolder)" />
+        <property name="SDK40ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools-x86@InstallationFolder)" />
+        <property name="WindowsSDK80Path" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
+        <property name="VsInstallRoot" value="$([MSBuild]::GetVsInstallRoot())" />
+        <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
+        <property name="MSBuildExtensionsPath" value="$(VsInstallRoot)\MSBuild" />
+        <property name="MSBuildExtensionsPath32" value="$(VsInstallRoot)\MSBuild" />
+
+        <!-- VC Specific Paths -->
+        <property name="VCTargetsPath" value="$(VsInstallRoot)\Common7\IDE\VC\VCTargets\" />
+        <property name="VCTargetsPath14" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath14)','$(MSBuildProgramFiles32)\MSBuild\Microsoft.Cpp\v4.0\V140\'))" />
+        <property name="VCTargetsPath12" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath12)','$(MSBuildProgramFiles32)\MSBuild\Microsoft.Cpp\v4.0\V120\'))" />
+        <property name="VCTargetsPath11" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath11)','$(MSBuildProgramFiles32)\MSBuild\Microsoft.Cpp\v4.0\V110\'))" />
+        <property name="VCTargetsPath10" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$(MSBuildProgramFiles32)\MSBuild\Microsoft.Cpp\v4.0\'))" />
+        <property name="AndroidTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\Android\V150\" />
+        <property name="iOSTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\iOS\V150\" />
+        <projectImportSearchPaths>
+          <searchPaths os="windows">
+            <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
+          </searchPaths>
+        </projectImportSearchPaths>
+      </toolset>
+    </msbuildToolsets>
+  </configuration>


### PR DESCRIPTION
Initial fix for #834. Setting `codeBase` to ensure that all MSBuild
assemblies get loaded from the same location (in the MSBuild bin folder)
even if they're loaded from the amd64 MSBuild.exe.

This isn't a great solution--the app.config files should be generated from a common
source, because they should be identical except for the codeBase. Also, we
probably shouldn't even ship copies of the assemblies into the amd64
folder if they'll never be used. But this is an urgent bug so I'm
providing a quick workaround to be followed up with a long-term fix.