### PR TITLE
Introduce cibuild.cmd

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -140,6 +140,6 @@ exit /b 1
 :error
 echo.
 echo ---------------------------------------
-echo - RebuildWithLocalMSBuild.cmd FAILED. -
+echo - cibuild.cmd FAILED. -
 echo ---------------------------------------
 exit /b 1

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -6,7 +6,7 @@ if "%1"=="" goto doneParsingArguments
 if /i "%1"=="--scope" set SCOPE=%2&& shift && shift && goto parseArguments
 if /i "%1"=="--target" set TARGET=%2&& shift && shift && goto parseArguments
 if /i "%1"=="--host" set HOST=%2&& shift && shift && goto parseArguments
-if /i "%1"=="--skip-bootstrap" set BOOTSTRAP_ONLY=true&& shift && goto parseArguments
+if /i "%1"=="--bootstrap-only" set BOOTSTRAP_ONLY=true&& shift && goto parseArguments
 
 :: Unknown parameters
 goto :usage
@@ -134,7 +134,7 @@ echo Options
 echo   --scope ^<scope^>                Scope of the build ^(Compile / Test^)
 echo   --target ^<target^>              CoreCLR or Desktop ^(default: Desktop^)
 echo   --host ^<host^>                  CoreCLR or Desktop ^(default: Desktop^)
-echo   --skip-bootstrap               Do not rebuild msbuild with local binaries
+echo   --bootstrap-only               Do not rebuild msbuild with local binaries
 exit /b 1
 
 :error

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -48,14 +48,11 @@ if not defined HOST (
 )
 
 set RUNTIME_HOST=
-set HOST_SPECIFIED=
 if /i "%HOST%"=="CoreCLR" (
     set RUNTIME_HOST=%~dp0Tools\CoreRun.exe
     set MSBUILD_CUSTOM_PATH=%~dp0Tools\MSBuild.exe
-    set HOST_SPECIFIED=true
 ) else if /i "%HOST%"=="Desktop" (
     set RUNTIME_HOST=
-    set HOST_SPECIFIED=true
 ) else (
     echo Unsupported host detected: %HOST%. Aborting.
     goto :error

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -11,8 +11,6 @@ if /i "%1"=="--skip-bootstrap" set BOOTSTRAP_ONLY=true&& shift && goto parseArgu
 :: Unknown parameters
 goto :usage
 
-set CONFIGURATION=Debug-NetCore
-
 :doneParsingArguments
 
 if "%SCOPE%"=="Compile" (
@@ -28,11 +26,11 @@ if not defined TARGET (
     set TARGET=Desktop
 )
 
-set CONFIGURATION=
+set BUILD_CONFIGURATION=
 if "%TARGET%"=="CoreCLR" (
-    set CONFIGURATION=Debug-NetCore
+    set BUILD_CONFIGURATION=Debug-NetCore
 ) else if "%TARGET%"=="Desktop" (
-    set CONFIGURATION=Debug
+    set BUILD_CONFIGURATION=Debug
 ) else (
     echo Unsupported target detected: %TARGET%. Aborting.
     goto :error
@@ -70,7 +68,7 @@ echo.
 echo ** Rebuilding MSBuild with downloaded binaries
 
 set MSBUILDLOGPATH=%~dp0msbuild_bootstrap_build.log
-call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%CONFIGURATION%
+call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%BUILD_CONFIGURATION%
 
 if %ERRORLEVEL% NEQ 0 (
     echo.
@@ -89,7 +87,7 @@ echo ** Moving bootstrapped MSBuild to the bootstrap folder
 taskkill /F /IM vbcscompiler.exe
 
 set MSBUILDLOGPATH=%~dp0msbuild_move_bootstrap.log
-set MSBUILD_ARGS=/verbosity:minimal BootStrapMSbuild.proj /p:Configuration=%CONFIGURATION%
+set MSBUILD_ARGS=/verbosity:minimal BootStrapMSbuild.proj /p:Configuration=%BUILD_CONFIGURATION%
 
 call "%~dp0build.cmd"
 if %ERRORLEVEL% NEQ 0 (
@@ -110,7 +108,7 @@ if "%TARGET%"=="CoreCLR" (
 )
 
 if "%TARGET%"=="CoreCLR" (
-    set MSBUILD_CUSTOM_PATH="%dp0bin\Bootstrap\MSBuild.exe"
+    set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\MSBuild.exe"
 ) else (
     set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\15.0\Bin\MSBuild.exe"
 )
@@ -118,7 +116,7 @@ if "%TARGET%"=="CoreCLR" (
 echo.
 echo ** Rebuilding MSBuild with locally built binaries
 
-call "%~dp0build.cmd" /t:RebuildAndTest /p:Configuration=%CONFIGURATION%
+call "%~dp0build.cmd" /t:RebuildAndTest /p:Configuration=%BUILD_CONFIGURATION%
 
 if %ERRORLEVEL% NEQ 0 (
     echo.

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,5 +1,140 @@
-@echo off
+@if not defined _echo echo off
+setlocal
 
-echo cibuild.cmd invoked from the xplat branch--calling RebuildWithLocalMSBuild.cmd
+:parseArguments
+if "%1"=="" goto doneParsingArguments
+if /i "%1"=="--scope" set SCOPE=%2&& shift && shift && goto parseArguments
+if /i "%1"=="--target" set TARGET=%2&& shift && shift && goto parseArguments
+if /i "%1"=="--host" set HOST=%2&& shift && shift && goto parseArguments
+if /i "%1"=="--skip-bootstrap" set BOOTSTRAP_ONLY=true&& shift && goto parseArguments
 
-RebuildWithLocalMSBuild.cmd
+:: Unknown parameters
+goto :usage
+
+set CONFIGURATION=Debug-NetCore
+
+:doneParsingArguments
+
+if "%SCOPE%"=="Compile" (
+    set TARGET_ARG=Build
+) else (
+    set TARGET_ARG=BuildAndTest
+)
+
+:: Assign target configuration
+set CONFIGURATION=
+if "%TARGET%"=="CoreCLR" (
+    set CONFIGURATION=Debug-NetCore
+)
+if "%TARGET%"=="Desktop" (
+    set CONFIGURATION=Debug
+)
+
+if not defined CONFIGURATION (
+    echo Unsupported target detected: %TARGET%. Configuring as if for Desktop
+    set CONFIGURATION=Debug
+)
+
+:: Assign runtime host
+set RUNTIME_HOST=
+set HOST_SPECIFIED=
+if "%HOST%"=="CoreCLR" (
+    set RUNTIME_HOST=%~dp0Tools\CoreRun.exe
+    set MSBUILD_CUSTOM_PATH=%~dp0Tools\MSBuild.exe
+    set HOST_SPECIFIED=true
+)
+if "%HOST%"=="Desktop" (
+    set RUNTIME_HOST=
+    set HOST_SPECIFIED=true
+)
+
+if not defined HOST_SPECIFIED (
+    echo Unsupported host detected: %HOST%. Configuring as if for Desktop
+    set RUNTIME_HOST=
+)
+
+:: Restore build tools
+call %~dp0init-tools.cmd
+
+echo.
+echo ** Rebuilding MSBuild with downloaded binaries
+
+set MSBUILDLOGPATH=%~dp0msbuild_bootstrap_build.log
+call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%CONFIGURATION%
+
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo Bootstrap build failed with errorlevel %ERRORLEVEL% 1>&2
+    goto :error
+)
+echo on
+if "%BOOTSTRAP_ONLY%"=="true" goto :success
+
+:: Move initial build to bootstrap directory
+
+echo.
+echo ** Moving bootstrapped MSBuild to the bootstrap folder
+
+:: Kill Roslyn, which may have handles open to files we want
+taskkill /F /IM vbcscompiler.exe
+
+set MSBUILDLOGPATH=%~dp0msbuild_move_bootstrap.log
+set MSBUILD_ARGS=/verbosity:minimal BootStrapMSbuild.proj /p:Configuration=%CONFIGURATION%
+
+call "%~dp0build.cmd"
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo Failed to create bootstrap folder with errorlevel %ERRORLEVEL% 1>&2
+    goto :error
+)
+set MSBUILD_ARGS=
+
+:: Rebuild with bootstrapped msbuild
+set MSBUILDLOGPATH=%~dp0msbuild_local_build.log
+
+:: Only CoreCLR requires an override--it should use the host
+:: downloaded as part of its NuGet package references, rather
+:: than the possibly-stale one from Tools.
+if "%TARGET%"=="CoreCLR" (
+    set RUNTIME_HOST="%~dp0bin\Bootstrap\CoreRun.exe"
+)
+
+if "%TARGET%"=="CoreCLR" (
+    set MSBUILD_CUSTOM_PATH="%dp0bin\Bootstrap\MSBuild.exe"
+) else (
+    set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\15.0\Bin\MSBuild.exe"
+)
+
+echo.
+echo ** Rebuilding MSBuild with locally built binaries
+
+call "%~dp0build.cmd" /t:RebuildAndTest /p:Configuration=%CONFIGURATION%
+
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo Local build failed with error level %ERRORLEVEL% 1>&2
+    goto :error
+)
+
+:success
+echo.
+echo ++++++++++++++++
+echo + SUCCESS  :-) +
+echo ++++++++++++++++
+echo.
+exit /b 0
+
+:usage
+echo Options
+echo   --scope ^<scope^>                Scope of the build ^(Compile / Test^)
+echo   --target ^<target^>              CoreCLR or Desktop ^(default: Desktop^)
+echo   --host ^<host^>                  CoreCLR or Desktop ^(default: Desktop^)
+echo   --skip-bootstrap               Do not rebuild msbuild with local binaries
+exit /b 1
+
+:error
+echo.
+echo ---------------------------------------
+echo - RebuildWithLocalMSBuild.cmd FAILED. -
+echo ---------------------------------------
+exit /b 1

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -22,35 +22,45 @@ if "%SCOPE%"=="Compile" (
 )
 
 :: Assign target configuration
+
+:: Default to full-framework build
+if not defined TARGET (
+    set TARGET=Desktop
+)
+
 set CONFIGURATION=
 if "%TARGET%"=="CoreCLR" (
     set CONFIGURATION=Debug-NetCore
-)
-if "%TARGET%"=="Desktop" (
+) else if "%TARGET%"=="Desktop" (
     set CONFIGURATION=Debug
-)
-
-if not defined CONFIGURATION (
-    echo Unsupported target detected: %TARGET%. Configuring as if for Desktop
-    set CONFIGURATION=Debug
+) else (
+    echo Unsupported target detected: %TARGET%. Aborting.
+    goto :error
 )
 
 :: Assign runtime host
+
+:: By default match host to target
+if not defined HOST (
+    if "%TARGET%"=="CoreCLR" (
+        set HOST=CoreCLR
+    ) else (
+        set HOST=Desktop
+    )
+)
+
 set RUNTIME_HOST=
 set HOST_SPECIFIED=
 if "%HOST%"=="CoreCLR" (
     set RUNTIME_HOST=%~dp0Tools\CoreRun.exe
     set MSBUILD_CUSTOM_PATH=%~dp0Tools\MSBuild.exe
     set HOST_SPECIFIED=true
-)
-if "%HOST%"=="Desktop" (
+) else if "%HOST%"=="Desktop" (
     set RUNTIME_HOST=
     set HOST_SPECIFIED=true
-)
-
-if not defined HOST_SPECIFIED (
-    echo Unsupported host detected: %HOST%. Configuring as if for Desktop
-    set RUNTIME_HOST=
+) else (
+    echo Unsupported host detected: %HOST%. Aborting.
+    goto :error
 )
 
 :: Restore build tools

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -27,9 +27,9 @@ if not defined TARGET (
 )
 
 set BUILD_CONFIGURATION=
-if "%TARGET%"=="CoreCLR" (
+if /i "%TARGET%"=="CoreCLR" (
     set BUILD_CONFIGURATION=Debug-NetCore
-) else if "%TARGET%"=="Desktop" (
+) else if /i "%TARGET%"=="Desktop" (
     set BUILD_CONFIGURATION=Debug
 ) else (
     echo Unsupported target detected: %TARGET%. Aborting.
@@ -40,7 +40,7 @@ if "%TARGET%"=="CoreCLR" (
 
 :: By default match host to target
 if not defined HOST (
-    if "%TARGET%"=="CoreCLR" (
+    if /i "%TARGET%"=="CoreCLR" (
         set HOST=CoreCLR
     ) else (
         set HOST=Desktop
@@ -49,11 +49,11 @@ if not defined HOST (
 
 set RUNTIME_HOST=
 set HOST_SPECIFIED=
-if "%HOST%"=="CoreCLR" (
+if /i "%HOST%"=="CoreCLR" (
     set RUNTIME_HOST=%~dp0Tools\CoreRun.exe
     set MSBUILD_CUSTOM_PATH=%~dp0Tools\MSBuild.exe
     set HOST_SPECIFIED=true
-) else if "%HOST%"=="Desktop" (
+) else if /i "%HOST%"=="Desktop" (
     set RUNTIME_HOST=
     set HOST_SPECIFIED=true
 ) else (
@@ -103,11 +103,11 @@ set MSBUILDLOGPATH=%~dp0msbuild_local_build.log
 :: Only CoreCLR requires an override--it should use the host
 :: downloaded as part of its NuGet package references, rather
 :: than the possibly-stale one from Tools.
-if "%TARGET%"=="CoreCLR" (
+if /i "%TARGET%"=="CoreCLR" (
     set RUNTIME_HOST="%~dp0bin\Bootstrap\CoreRun.exe"
 )
 
-if "%TARGET%"=="CoreCLR" (
+if /i "%TARGET%"=="CoreCLR" (
     set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\MSBuild.exe"
 ) else (
     set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\15.0\Bin\MSBuild.exe"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -8,7 +8,7 @@ usage()
     echo "  --scope <scope>                Scope of the build (Compile / Test)"
     echo "  --target <target>              CoreCLR or Mono (default: CoreCLR)"
     echo "  --host <host>                  CoreCLR or Mono (default: CoreCLR)"
-    echo "  --skip-bootstrap               Do not rebuild msbuild with local binaries"
+    echo "  --bootstrap-only               Do not rebuild msbuild with local binaries"
 }
 
 restoreBuildTools(){
@@ -69,7 +69,7 @@ setMonoDir(){
     fi
 }
 
-SKIP_BOOTSTRAP=false
+BOOTSTRAP_ONLY=false
 
 # Paths
 THIS_SCRIPT_PATH="`dirname \"$0\"`"
@@ -118,8 +118,8 @@ do
         shift 2
         ;;
 
-        --skip-bootstrap)
-        SKIP_BOOTSTRAP=true
+        --bootstrap-only)
+        BOOTSTRAP_ONLY=true
         shift 1
         ;;
 
@@ -218,7 +218,7 @@ echo
 echo "** Rebuilding MSBuild with downloaded binaries"
 runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_EXE" "$BUILD_MSBUILD_ARGS" "$BOOTSTRAP_BUILD_LOG_PATH"
 
-if [[ $SKIP_BOOTSTRAP = true ]]; then
+if [[ $BOOTSTRAP_ONLY = true ]]; then
     exit $?
 fi
 

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -202,7 +202,7 @@ setHome
 restoreBuildTools
 
 echo
-echo "** Rebuilding MSBuild with binaries from BuildTools"
+echo "** Rebuilding MSBuild with downloaded binaries"
 runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_EXE" "$BUILD_MSBUILD_ARGS" "$BOOTSTRAP_BUILD_LOG_PATH"
 
 if [[ $SKIP_BOOTSTRAP = true ]]; then

--- a/targets/BootStrapFullFrameworkMSBuild.proj
+++ b/targets/BootStrapFullFrameworkMSBuild.proj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" InitialTargets="CheckForBootstrap" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="dir.props" />
+  <Import Project="../dir.props" />
 
   <ItemGroup>
     <InstalledVersionedExtensions Include="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\**\*.targets" />
@@ -19,14 +19,14 @@
 
     <InstalledNuGetFiles Include="$(MSBuildExtensionsPath)\Microsoft\NuGet\*" />
 
-    <FreshlyBuiltBinaries Include="$(OutputPath)*.dll" />
-    <FreshlyBuiltBinaries Include="$(OutputPath)*.exe" />
-    <FreshlyBuiltBinaries Include="$(OutputPath)*.pdb" />
-    <FreshlyBuiltBinaries Include="$(OutputPath)*.exe.config" />
+    <FreshlyBuiltBinaries Include="$(DeploymentDir)*.dll" />
+    <FreshlyBuiltBinaries Include="$(DeploymentDir)*.exe" />
+    <FreshlyBuiltBinaries Include="$(DeploymentDir)*.pdb" />
+    <FreshlyBuiltBinaries Include="$(DeploymentDir)*.exe.config" />
 
-    <FreshlyBuiltProjects Include="$(OutputPath)*props" />
-    <FreshlyBuiltProjects Include="$(OutputPath)*targets" />
-    <FreshlyBuiltProjects Include="$(OutputPath)*tasks" />
+    <FreshlyBuiltProjects Include="$(DeploymentDir)*props" />
+    <FreshlyBuiltProjects Include="$(DeploymentDir)*targets" />
+    <FreshlyBuiltProjects Include="$(DeploymentDir)*tasks" />
   </ItemGroup>
 
   <Target Name="Build">


### PR DESCRIPTION
📝 My plan is to get this in, set up a failing CI build, and then make it pass. I have that mostly working on my machine, so now it's time to see if Jenkins agrees with me.

This is a port of cibuild.sh, because RebuildWithLocalMSBuild didn't
support arguments and cibuild.sh is a better name. The code was initially
copied from RebuildWithLocalMSBuild.cmd.

Needed for #342.