### PR TITLE
Enable multi-runtime builds in CI infrastructure

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,0 +1,5 @@
+@echo off
+
+echo cibuild.cmd invoked from the master branch--calling RebuildWithLocalMSBuild.cmd
+
+RebuildWithLocalMSBuild.cmd /p:LocalizedBuild=true

--- a/netci.groovy
+++ b/netci.groovy
@@ -7,71 +7,79 @@ def project = GithubProject
 // Generate the builds for branches: xplat, master and PRs (which aren't branch specific)
 ['*/master', '*/xplat', 'pr'].each { branch ->
     ['Windows_NT', 'OSX', 'Ubuntu'].each {osName ->
-        def isPR = false
-        def newJobName = ''
-        def skipTestsWhenResultsNotFound = true
+        def runtimes = ['CoreCLR']
 
-        if (branch == 'pr') {
-            isPR = true
-            newJobName = Utilities.getFullJobName(project, "_${osName}", isPR)
-        } else {
-            newJobName = Utilities.getFullJobName(project, "innerloop_${branch.substring(2)}_${osName}", isPR)
+        if (osName == 'Windows_NT') {
+            runtimes.add('Desktop')
         }
 
-        // Create a new job with the specified name.  The brace opens a new closure
-        // and calls made within that closure apply to the newly created job.
-        def newJob = job(newJobName) {
-            description('')
-        }
-        
-        // Define job.
-        switch(osName) {
-            case 'Windows_NT':
-                newJob.with{
-                    steps{
-                        batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" && RebuildWithLocalMSBuild.cmd /p:LocalizedBuild=true")
+        // TODO: Mono
+
+        runtimes.each { runtime ->
+            def isPR = false
+            def newJobName = ''
+            def skipTestsWhenResultsNotFound = true
+
+            if (branch == 'pr') {
+                isPR = true
+                newJobName = Utilities.getFullJobName(project, "_${osName}_${runtime}", isPR)
+            } else {
+                newJobName = Utilities.getFullJobName(project, "innerloop_${branch.substring(2)}_${osName}_${runtime}", isPR)
+            }
+
+            // Create a new job with the specified name.  The brace opens a new closure
+            // and calls made within that closure apply to the newly created job.
+            def newJob = job(newJobName) {
+                description('')
+            }
+
+            // Define job.
+            switch(osName) {
+                case 'Windows_NT':
+                    newJob.with{
+                        steps{
+                            batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" && cibuild.cmd --target ${runtime}")
+                        }
+
+                        skipTestsWhenResultsNotFound = false
                     }
 
-                    skipTestsWhenResultsNotFound = false
-                }
-
-                break;
-            case 'OSX':
-                newJob.with{
-                    steps{
-                        shell("./cibuild.sh --scope Test")
+                    break;
+                case 'OSX':
+                    newJob.with{
+                        steps{
+                            shell("./cibuild.sh --scope Test --target ${runtime}")
+                        }
                     }
-                }
 
-                break;
-            case 'Ubuntu':
-
-                // Do not run tests on Ubuntu. We don't yet have a green test baseline.
-                newJob.with{
-                    steps{
-                        shell("./cibuild.sh --scope Compile")
+                    break;
+                case 'Ubuntu':
+                    // Do not run tests on Ubuntu. We don't yet have a green test baseline.
+                    newJob.with{
+                        steps{
+                            shell("./cibuild.sh --scope Compile --target ${runtime}")
+                        }
                     }
-                }
 
-                break;
-        }
+                    break;
+            }
 
-        // Add xunit result archiving. Skip if no results found.
-        Utilities.addXUnitDotNETResults(newJob, 'bin/**/*_TestResults.xml', skipTestsWhenResultsNotFound)
-        Utilities.setMachineAffinity(newJob, osName, 'latest-or-auto')
-        Utilities.standardJobSetup(newJob, project, isPR, branch)
-        // Add archiving of logs (even if the build failed)
-        Utilities.addArchival(newJob,
-                              'msbuild*.log,**/Microsoft.*.UnitTests.dll_*', /* filesToArchive */
-                              '', /* filesToExclude */
-                              false, /* doNotFailIfNothingArchived */
-                              false, /* archiveOnlyIfSuccessful */)
-        // Add trigger
-        if (isPR) {
-            Utilities.addGithubPRTrigger(newJob, "${osName} Build")
-        } else {
-            Utilities.addGithubPushTrigger(newJob)
+            // Add xunit result archiving. Skip if no results found.
+            Utilities.addXUnitDotNETResults(newJob, 'bin/**/*_TestResults.xml', skipTestsWhenResultsNotFound)
+            Utilities.setMachineAffinity(newJob, osName, 'latest-or-auto')
+            Utilities.standardJobSetup(newJob, project, isPR, branch)
+            // Add archiving of logs (even if the build failed)
+            Utilities.addArchival(newJob,
+                                  'msbuild*.log,**/Microsoft.*.UnitTests.dll_*', /* filesToArchive */
+                                  '', /* filesToExclude */
+                                  false, /* doNotFailIfNothingArchived */
+                                  false, /* archiveOnlyIfSuccessful */)
+            // Add trigger
+            if (isPR) {
+                Utilities.addGithubPRTrigger(newJob, "${osName} Build for ${runtime}")
+            } else {
+                Utilities.addGithubPushTrigger(newJob)
+            }
         }
     }
-    
 }


### PR DESCRIPTION
Needed for #342.

This adds another dimension to the CI build definitions, so we can start
building both the .NET Core and Desktop framework versions of MSBuild out
of the xplat branch.

Since `netci.groovy` only creates jobs, it can't know what branch is being
targeted for a PR-validation job. So the validation script must exist
everywhere. Since master doesn't build for .NET Core, I'm adding a stub
cibuild.cmd that's just a shim for the existing CI build script. Builds in
master will trigger two full-framework builds, with one labeled "CoreCLR".
This should be a temporary situation since the branches should be unified
soon.