### PR TITLE
Stub cibuild.cmd to enable multi-runtime CI builds

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,0 +1,5 @@
+@echo off
+
+echo cibuild.cmd invoked from the xplat branch--calling RebuildWithLocalMSBuild.cmd
+
+RebuildWithLocalMSBuild.cmd


### PR DESCRIPTION
Checking this into xplat so that cf10c8a9 has a cibuild.cmd script to
target in the xplat branch. As-is, it always builds for .NET Core, even if
asked to build for desktop. A follow-up, full-featured cibuild.cmd will be
capable of building both desktop and Core.