### PR TITLE
Allow MSBUILDDEBUGONSTART=2 for .NET Core

### DIFF
--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -482,18 +482,18 @@ namespace Microsoft.Build.CommandLine
             // with our OM and modify and save them. They'll never do this for Microsoft.*.targets, though,
             // and those form the great majority of our unnecessary memory use.
             Environment.SetEnvironmentVariable("MSBuildLoadMicrosoftTargetsReadOnly", "true");
+            switch (Environment.GetEnvironmentVariable("MSBUILDDEBUGONSTART"))
+            {
 #if FEATURE_DEBUG_LAUNCH
-            string debugFlag = Environment.GetEnvironmentVariable("MSBUILDDEBUGONSTART");
-            if (debugFlag == "1")
-            {
-                Debugger.Launch();
-            }
-            else if (debugFlag == "2")
-            {
-                // Sometimes easier to attach rather than deal with JIT prompt
-                Console.ReadLine();
-            }
+                case "1":
+                    Debugger.Launch();
+                    break;
 #endif
+                case "2":
+                    // Sometimes easier to attach rather than deal with JIT prompt
+                    Console.ReadLine();
+                    break;
+            }
 
 #if FEATURE_GET_COMMANDLINE
             ErrorUtilities.VerifyThrowArgumentLength(commandLine, "commandLine");


### PR DESCRIPTION
This was disabled when removing calls to `Debugger.Launch`, but in mode 2
`MSBUILDDEBUGONSTART` doesn't actually need that API and is .NET Core
friendly.