### PR TITLE
Add satellite assemblies to FilesToSign

### DIFF
--- a/src/UpdateLocalizedResources.targets
+++ b/src/UpdateLocalizedResources.targets
@@ -98,4 +98,19 @@
     </ItemGroup>
   </Target>
 
+  <!-- Target SignFiles from MicroBuild.Plugins.Signing.targets signs @(FilesToSign) -->
+  <Target Name="AddSatelliteAssembliesToFilesToSignItem"
+          Condition="('$(SignType)' == 'real' OR '$(SignType)' == 'test')"
+          BeforeTargets="@(SignFilesDependsOn);SignFiles"
+          AfterTargets="CreateSatelliteAssemblies"
+          >
+
+    <ItemGroup>
+      <FilesToSign Include="@(IntermediateSatelliteAssembliesWithTargetPath -> '$(OutputPath)%(Culture)\%(FileName)%(Extension)')">
+        <Authenticode>Microsoft</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+
+  </Target>
+
 </Project>


### PR DESCRIPTION
SignFiles target needs it.

The SignFiles output finally looks alright:

```
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\Microsoft.Build.Utilities.Core.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\cs\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\de\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\es\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\fr\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\it\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\ja\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\ko\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\pl\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\pt\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\ru\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\tr\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\zh-Hans\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\zh-Hant\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
  Submitting C:\projects\msbuild_2\bin\x86\Windows_NT\Debug\en\Microsoft.Build.Utilities.Core.resources.dll for Test signing (TaskId:222)
```