### PR TITLE
Merge Xaml task changes back to master

### DIFF
--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -35,8 +35,12 @@
           <codeBase version="15.1.0.0" href="..\Microsoft.Build.Utilities.Core.dll"/>
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.1.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
         </dependentAssembly>
       </assemblyBinding>
     </runtime>

--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -34,6 +34,10 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
           <codeBase version="15.1.0.0" href="..\Microsoft.Build.Utilities.Core.dll"/>
         </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.1.0.0" />
+        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -31,8 +31,12 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.1.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
         </dependentAssembly>
       </assemblyBinding>
     </runtime>

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -30,6 +30,10 @@
           <assemblyIdentity name="Microsoft.Build.Utilities.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
         </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.1.0.0" />
+        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->

--- a/src/XMakeTasks/Microsoft.Xaml.targets
+++ b/src/XMakeTasks/Microsoft.Xaml.targets
@@ -13,7 +13,7 @@
         the .NET Framework directory and thus will no longer be the right answer. Override it to point
         to the correct .NET Framework location. --> 
    <PropertyGroup>
-      <XamlBuildTaskPath Condition="'$(XamlBuildTaskPath)' == ''">$(MSBuildToolsPath)</XamlBuildTaskPath>
+      <XamlBuildTaskPath Condition="'$(XamlBuildTaskPath)' == ''">$(MSBuildThisFileDirectory)</XamlBuildTaskPath>
    </PropertyGroup>
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.Xaml.targets" />

--- a/src/XMakeTasks/Microsoft.Xaml.targets
+++ b/src/XMakeTasks/Microsoft.Xaml.targets
@@ -13,7 +13,7 @@
         the .NET Framework directory and thus will no longer be the right answer. Override it to point
         to the correct .NET Framework location. --> 
    <PropertyGroup>
-      <XamlBuildTaskPath Condition="'$(XamlBuildTaskPath)' == ''">$(MSBuildFrameworkToolsPath)</XamlBuildTaskPath>
+      <XamlBuildTaskPath Condition="'$(XamlBuildTaskPath)' == ''">$(MSBuildToolsPath)</XamlBuildTaskPath>
    </PropertyGroup>
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.Xaml.targets" />


### PR DESCRIPTION
#856 was needed for Visual Studio "15" Preview 4, but we've taken changes into `master` that we don't want to ship quite yet. I cherry-picked the changes to a newly created stabilization branch. This just merges those back into master so future history spelunking is easier.