### PR TITLE
Create a package for use by the Visual Studio build

### DIFF
--- a/setup/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
+++ b/setup/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>VS.ExternalAPIs.MSBuild.$architecture$</id>
+    <summary>CoreXT package for the VS build.</summary>
+    <description>CoreXT package for the VS build.</description>
+    <authors>MSBuild</authors>
+    <version>0.0</version>
+  </metadata>
+  <files>
+    <file src="Microsoft.Build.dll" target="lib\net46" />
+    <file src="Microsoft.Build.Framework.dll" target="lib\net46" />
+    <file src="Microsoft.Build.Tasks.Core.dll" target="lib\net46" />
+    <file src="Microsoft.Build.Utilities.Core.dll" target="lib\net46" />
+  </files>
+</package>


### PR DESCRIPTION
Add a .nuspec file that captures the set of binaries we need to make available to the Visual Studio build. Our VSTS build process will be updated to create the NuGet package and upload it to the appropriate store.

A few things to note:

1. The package will be created and published by the official build; we don't need to add any further projects, scripts, etc. to the source tree.
2. As the official build runs for both x86 and x64, we're going to end up with two copies of the package. To differentiate them, they will have different IDs: VS.ExternalAPIs.MSBuild.**x86** and VS.ExternalAPIs.MSBuild.**x64**. At the moment, the contents will be identical, so we anticipate that only the x86 version will actually be used.
3. The version number will be specified when running the `nuget pack` command; hence the .nuspec file just uses 0.0 as a placeholder.