### PR TITLE
Update .nuspec for CoreXT package

### DIFF
--- a/setup/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
+++ b/setup/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>VS.ExternalAPIs.MSBuild.$architecture$</id>
-    <summary>CoreXT package for the VS build.</summary>
-    <description>CoreXT package for the VS build.</description>
+    <id>VS.ExternalAPIs.MSBuild</id>
+    <summary>CoreXT package containing MSBuild binaries for the VS build.</summary>
+    <description>CoreXT package containing MSBuild binaries for the VS build. Produced from the MSBuild $branchname$ branch.</description>
     <authors>MSBuild</authors>
     <version>0.0</version>
   </metadata>


### PR DESCRIPTION
Update the .nuspec file for the CoreXT package. It turns out we don't need the
architecture (x86, x64, etc.) burned into the name, so drop that. However, we
do want the branch name burned into the description. There may be times when
two different branches are producing packages with very similar version numbers,
and we'll want a reasonably easy way to figure out where they came from.