### PR TITLE
Disable multiprocess build (work around #874)

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -11,7 +11,7 @@ if not defined MSBUILD_CUSTOM_PATH (
 )
 
 if not defined MSBUILD_ARGS (
-    set MSBUILD_ARGS="%~dp0build.proj" /m /verbosity:minimal %*
+    set MSBUILD_ARGS="%~dp0build.proj" /verbosity:minimal %*
 )
 
 :: Add a the file logger with diagnostic verbosity to the msbuild args

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -191,7 +191,7 @@ case $host in
         RUNTIME_HOST="$TOOLS_DIR/dotnetcli/dotnet"
         RUNTIME_HOST_ARGS=""
         MSBUILD_EXE="$TOOLS_DIR/MSBuild.exe"
-        EXTRA_ARGS="$EXTRA_ARGS /m"
+        EXTRA_ARGS="$EXTRA_ARGS"
         ;;
 
     Mono)


### PR DESCRIPTION
It's not entirely clear why yet, but when MSBuild tries to spawn another
node, it emits

```
The specified deps.json [O:\msbuild\bin\Bootstrap\MSBuild.deps.json] does
not exist
```

And hangs. Disabling to get clean CI builds while debugging.