### PR TITLE
Only override deps and runtimeconfig if they exist

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -11,7 +11,7 @@ if not defined MSBUILD_CUSTOM_PATH (
 )
 
 if not defined MSBUILD_ARGS (
-    set MSBUILD_ARGS="%~dp0build.proj" /verbosity:minimal %*
+    set MSBUILD_ARGS="%~dp0build.proj" /m /verbosity:minimal %*
 )
 
 :: Add a the file logger with diagnostic verbosity to the msbuild args

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -191,7 +191,7 @@ case $host in
         RUNTIME_HOST="$TOOLS_DIR/dotnetcli/dotnet"
         RUNTIME_HOST_ARGS=""
         MSBUILD_EXE="$TOOLS_DIR/MSBuild.exe"
-        EXTRA_ARGS="$EXTRA_ARGS"
+        EXTRA_ARGS="$EXTRA_ARGS /m"
         ;;
 
     Mono)

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -12,7 +12,6 @@ using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Diagnostics;
-using System.Reflection;
 using System.Threading;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
@@ -494,33 +493,7 @@ namespace Microsoft.Build.BackEnd
             // Run the child process with the same host as the currently-running process.
             string pathToHost;
             using (Process currentProcess = Process.GetCurrentProcess()) pathToHost = currentProcess.MainModule.FileName;
-
-            string dotnetConfigArguments = string.Empty;
-
-            // We can't assume that just because we're running on .NET Core the host is dotnet.
-            // In our selfhost build, we're still using corerun.
-            // TODO: once we stop using and supporting corerun, this should be unconditional.
-            if (pathToHost.Contains("dotnet"))
-            {
-                // MSBuild may have been invoked with custom dependency and runtime information,
-                // and our child process should be run the same way.
-
-                // Get current `--depsfile` value
-                var appDomainType = typeof(object).GetTypeInfo().Assembly?.GetType("System.AppDomain");
-                var currentDomain = appDomainType?.GetProperty("CurrentDomain")?.GetValue(null);
-                var deps = (string)appDomainType?.GetMethod("GetData")?.Invoke(currentDomain, new object[] {"APP_CONTEXT_DEPS_FILES"});
-                var depsFile = deps.Split(';')[0];
-
-                // The current `--runtimeconfig` isn't programmatically available.
-                // Until it is, we'll optimize for the known case, where we're called
-                // from `dotnet build3`, using `dotnet.deps.json` and `dotnet.runtimeconfig.json`
-                var runtimeConfigFile = depsFile.Replace(".deps.json", ".runtimeconfig.json");
-
-                dotnetConfigArguments = $"exec --depsfile {depsFile} --runtimeconfig {runtimeConfigFile}";
-            }
-
-            commandLineArgs =
-                $"{dotnetConfigArguments} \"{msbuildLocation}\" {commandLineArgs}";
+            commandLineArgs = "\"" + msbuildLocation + "\" " + commandLineArgs;
 
             ProcessStartInfo processStartInfo = new ProcessStartInfo();
             processStartInfo.FileName = pathToHost;


### PR DESCRIPTION
cd53996d introduced some tricks to ensure that, when we're invoked by
`dotnet build3`, a worker node can get spawned correctly. Unfortunately,
the technique that worked in that situation gave bad information in the
MSBuild selfhost build post-bootstrap, after 51f6d76 switched us to use
dotnet.exe instead of corerun.