### PR TITLE
Port cross-plat ProcessExtensions from CLI

### DIFF
--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -200,6 +200,9 @@
     <Compile Include="ToolTask.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="ProcessExtensions.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <!-- FileTracker Managed Libraries -->
     <Compile Include="TrackedDependencies\CanonicalTrackedInputFiles.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Utilities/ProcessExtensions.cs
+++ b/src/Utilities/ProcessExtensions.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Utilities
+{
+    internal static class ProcessExtensions
+    {
+        public static void KillTree(this Process process, int timeout)
+        {
+            if (NativeMethodsShared.IsWindows)
+            {
+                try
+                {
+                    // issue the kill command
+                    NativeMethodsShared.KillTree(process.Id);
+                }
+                catch (InvalidOperationException)
+                {
+                    // The process already exited, which is fine,
+                    // just continue.
+                }
+            }
+            else
+            {
+                var children = new HashSet<int>();
+                GetAllChildIdsUnix(process.Id, children);
+                foreach (var childId in children)
+                {
+                    KillProcessUnix(childId);
+                }
+
+                KillProcessUnix(process.Id);
+            }
+
+            // wait until the process finishes exiting/getting killed. 
+            // We don't want to wait forever here because the task is already supposed to be dieing, we just want to give it long enough
+            // to try and flush what it can and stop. If it cannot do that in a reasonable time frame then we will just ignore it.
+            process.WaitForExit(timeout);
+        }
+
+        private static void GetAllChildIdsUnix(int parentId, ISet<int> children)
+        {
+            string stdout;
+            var exitCode = RunProcessAndWaitForExit(
+                "pgrep",
+                $"-P {parentId}",
+                out stdout);
+
+            if (exitCode == 0 && !string.IsNullOrEmpty(stdout))
+            {
+                using (var reader = new StringReader(stdout))
+                {
+                    while (true)
+                    {
+                        var text = reader.ReadLine();
+                        if (text == null)
+                        {
+                            return;
+                        }
+
+                        int id;
+                        if (int.TryParse(text, out id))
+                        {
+                            children.Add(id);
+                            // Recursively get the children
+                            GetAllChildIdsUnix(id, children);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void KillProcessUnix(int processId)
+        {
+            string stdout;
+            RunProcessAndWaitForExit(
+                "kill",
+                $"-TERM {processId}",
+                out stdout);
+        }
+
+        private static int RunProcessAndWaitForExit(string fileName, string arguments, out string stdout)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            };
+
+            var process = Process.Start(startInfo);
+
+            stdout = null;
+            if (process.WaitForExit(30))
+            {
+                stdout = process.StandardOutput.ReadToEnd();
+            }
+            else
+            {
+                process.Kill();
+            }
+
+            return process.ExitCode;
+        }
+    }
+}

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1091,20 +1091,6 @@ namespace Microsoft.Build.Utilities
                     LogShared.LogWarningWithCodeFromResources("Shared.KillingProcessByCancellation", proc.ProcessName);
                 }
 
-                try
-                {
-                    // issue the kill command
-                    NativeMethodsShared.KillTree(proc.Id);
-                }
-                catch (InvalidOperationException)
-                {
-                    // The process already exited, which is fine,
-                    // just continue.
-                }
-
-                // wait until the process finishes exiting/getting killed. 
-                // We don't want to wait forever here because the task is already supposed to be dieing, we just want to give it long enough
-                // to try and flush what it can and stop. If it cannot do that in a reasonable time frame then we will just ignore it.
                 int timeout = 5000;
                 string timeoutFromEnvironment = Environment.GetEnvironmentVariable("MSBUILDTOOLTASKCANCELPROCESSWAITTIMEOUT");
                 if (timeoutFromEnvironment != null)
@@ -1116,7 +1102,7 @@ namespace Microsoft.Build.Utilities
                     }
                 }
 
-                proc.WaitForExit(timeout);
+                proc.KillTree(timeout);
             }
         }
 


### PR DESCRIPTION
Current implementation of KillTree was tied to Windows Kernel32.dll P/Invocation.

This ports the Unix implementation of same from dotnet/cli repo:
https://github.com/dotnet/cli/blob/04f40f9/test/Microsoft.DotNet.Tools.Tests.Utilities/ProcessExtensions.cs
(not sure if there is a better way to consume it as a package instead of copy-pasta :spaghetti:?)

Fix #434
Fix #757