### PR TITLE
Add StrongName metadata to FilesToSign item

### DIFF
--- a/src/UpdateLocalizedResources.targets
+++ b/src/UpdateLocalizedResources.targets
@@ -108,6 +108,7 @@
     <ItemGroup>
       <FilesToSign Include="@(IntermediateSatelliteAssembliesWithTargetPath -> '$(OutputPath)%(Culture)\%(FileName)%(Extension)')">
         <Authenticode>Microsoft</Authenticode>
+        <StrongName>StrongName</StrongName>
       </FilesToSign>
     </ItemGroup>
 


### PR DESCRIPTION
Something is causing the satellite assemblies to not be signed.
Trying this out as a potential solution