### PR TITLE
Fix NuGet package versions

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -65,7 +65,7 @@ echo.
 echo ** Rebuilding MSBuild with downloaded binaries
 
 set MSBUILDLOGPATH=%~dp0msbuild_bootstrap_build.log
-call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%BUILD_CONFIGURATION%
+call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%BUILD_CONFIGURATION% /p:"SkipBuildPackages=true"
 
 if %ERRORLEVEL% NEQ 0 (
     echo.

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -31,9 +31,21 @@
 
   <PropertyGroup>
     <SkipVersionGeneration>true</SkipVersionGeneration>
+    <BaseVersion>0.1.0-preview</BaseVersion>
     <BuildNumberMajor>$(RevisionNumber)</BuildNumberMajor>
     <BuildNumberMinor>$([System.DateTime]::Now.ToString(`yMMdd`))</BuildNumberMinor>
+
+    <!-- The version for msbuild nuget packages. Used by packages.targets:AddNuGetPackageVersionMetadataToNuspecs -->
+    <PackageVersion>$(BaseVersion)-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
+
+    <!-- Turn off the automated package generation in packages.targets:AddNuGetPackageVersionMetadataToNuspecs and use the above PackageVersion-->
+    <DoNotGeneratePackageVersion>true</DoNotGeneratePackageVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Used by packages.targets:BuildPackages to inject properties into the nuspec-->
+    <NuspecProperties Include="version=$(PackageVersion)"/>
+  </ItemGroup>
 
   <Import Project="$(ToolsDir)packages.targets" Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'" />
 

--- a/src/nuget/Microsoft.Build.Framework.nuspec
+++ b/src/nuget/Microsoft.Build.Framework.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.Build.Framework</id>
-    <version>0.1.0-preview</version>
+    <version>$version$</version>
     <title>MSBuild APIs</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.Build.Targets.nuspec
+++ b/src/nuget/Microsoft.Build.Targets.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.Build.Targets</id>
-    <version>0.1.0-preview</version>
+    <version>$version$</version>
     <title>MSBuild APIs</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -17,10 +17,10 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">
-        <dependency id="Microsoft.Build.Framework" />
-        <dependency id="Microsoft.Build" />
-        <dependency id="Microsoft.Build.Utilities.Core" />
-        <dependency id="Microsoft.Build.Tasks.Core" />
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
+        <dependency id="Microsoft.Build" version="$version$" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="$version$" />
+        <dependency id="Microsoft.Build.Tasks.Core" version="$version$" />
         <dependency id="MSBuild" />
       </group>
     </dependencies>

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.Build.Tasks.Core</id>
-    <version>0.1.0-preview</version>
+    <version>$version$</version>
     <title>MSBuild APIs</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -17,7 +17,7 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">
-        <dependency id="Microsoft.Build.Framework" />
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Collections.Concurrent" version="4.0.12" />

--- a/src/nuget/Microsoft.Build.Utilities.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Utilities.Core.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.Build.Utilities.Core</id>
-    <version>0.1.0-preview</version>
+    <version>$version$</version>
     <title>MSBuild APIs</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -17,7 +17,7 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">
-        <dependency id="Microsoft.Build.Framework" />
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Collections.Concurrent" version="4.0.12" />

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.Build</id>
-    <version>0.1.0-preview</version>
+    <version>$version$</version>
     <title>MSBuild APIs</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -17,7 +17,7 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">
-        <dependency id="Microsoft.Build.Framework" />
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
         <dependency id="System.AppContext" version="4.1.0" />
         <dependency id="System.Collections" version="4.0.11" />


### PR DESCRIPTION
* Update NUSPEC so that the version is coming from build properties
* Update NUSPEC so that dependency version is coming from build properties
* Don't build packages during the first build

Fixes #528, related to #692 