### PR TITLE
Avoid node reuse during desktop-hosted builds

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -19,7 +19,7 @@ set MSBUILD_ARGS=%MSBUILD_ARGS% /fileloggerparameters:Verbosity=diag;LogFile="%M
 
 :: Check for a runtime host. If not defined, do not use a host
 if not defined RUNTIME_HOST (
-	set BUILD_COMMAND="%MSBUILD_CUSTOM_PATH%" %MSBUILD_ARGS%
+	set BUILD_COMMAND="%MSBUILD_CUSTOM_PATH%" /nodeReuse:false %MSBUILD_ARGS%
 
     :: Check prerequisites for full framework build
  	if not "%VisualStudioVersion%" == "14.0" (


### PR DESCRIPTION
If msbuild is invoked with the (default) `/nodeReuse:true` argument,
worker nodes hang around for a period of time after the build is complete
to see if more work will be incoming. This is normally a nice
startup-time-reducing perf optimization. But in our own build, it means
that many newly-created MSBuild assemblies are opened and uneditable,
failing builds and causing cleans to fail.

Changing the Windows build script to just always pass `/nodeReuse:false`.