### PR TITLE
Bump up System.Collections.Immutable

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -34,7 +34,7 @@
 
     <!-- Package version / directories -->
     <BuildToolsVersion>1.0.25-prerelease-00199</BuildToolsVersion>
-    <CompilerToolsVersion>1.0.0</CompilerToolsVersion>
+    <CompilerToolsVersion>2.0.0-beta3</CompilerToolsVersion>
     <XunitVersion>2.1.0</XunitVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
     <GitVersioningVersion>1.4.30</GitVersioningVersion>

--- a/setup/files.swr
+++ b/setup/files.swr
@@ -15,6 +15,7 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)MSBuildTaskHost.exe vs.file.ngen=yes
   file source=$(X86BinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngen=yes
+  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
   file source=$(X86BinPath)Microsoft.Common.targets
@@ -132,6 +133,7 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngen=yes
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngen=yes
+  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
   file source=$(X86BinPath)Microsoft.Common.targets

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00199" />
-  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.Net.Compilers" version="2.0.0-beta3" targetFramework="net451" userInstalled="true" />
   <package id="xunit.runner.console" version="2.1.0" />
   <package id="MicroBuild.Core" version="0.2.0" />
   <package id="Nerdbank.GitVersioning" version="1.4.30" />

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.Tpl.Dataflow": "4.5.24",
-    "System.Collections.Immutable": "1.1.36"
+    "System.Collections.Immutable": "1.2.0"
   },
   "frameworks": {
     "net46": { }


### PR DESCRIPTION
We had added a dependency to System.Collections.Immutable which got overwritten by the VS build, thus breaking MSBuild. This PR bumps up collections.immutable and csc.