### PR TITLE
Open AssemblyFolder.config with minimal rights

### DIFF
--- a/src/Shared/AssemblyFolders/Serialization/AssemblyFolderCollection.cs
+++ b/src/Shared/AssemblyFolders/Serialization/AssemblyFolderCollection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Shared.AssemblyFoldersFromConfig
         /// <returns>New deserialized collection instance.</returns>
         internal static AssemblyFolderCollection Load(string filePath)
         {
-            using (FileStream fs = new FileStream(filePath, FileMode.Open))
+            using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (XmlDictionaryReader reader = XmlDictionaryReader.CreateTextReader(fs, new XmlDictionaryReaderQuotas()))
             {
                 DataContractSerializer serializer = new DataContractSerializer(typeof(AssemblyFolderCollection));


### PR DESCRIPTION
In the VS scenario, unelevated builds failed with

```
C:\Program Files (x86)\Microsoft Visual Studio 15.0\MSBuild\15.0\bin\Microsoft.Common.CurrentVersion.targets(1825,5): error MSB4018: The "ResolveAssemblyReference" task failed unexpectedly. [c:\branch\qa\vc\ide\tests\endtoend\EndToEnd.csproj]
C:\Program Files (x86)\Microsoft Visual Studio 15.0\MSBuild\15.0\bin\Microsoft.Common.CurrentVersion.targets(1825,5): error MSB4018: System.UnauthorizedAccessException: Access to the path 'C:\Program Files (x86)\Microsoft Visual Studio 15.0\MSBuild\15.0\bin\AssemblyFolders.config' is denied.
```

The installed VS path is ACLed so that files in it aren't writable by normal processes, but the default access request from the FileStream constructor is `FileAccess.ReadWrite`. `FileShare.Read` is the default, but I'm erring on the side of being explicit.