### PR TITLE
Update stale references to Roslyn targets

### DIFF
--- a/src/Utilities/UnitTests/project.json
+++ b/src/Utilities/UnitTests/project.json
@@ -17,7 +17,7 @@
         "System.Console": "4.0.0",
         "System.Diagnostics.Process": "4.1.0",
         "Microsoft.Win32.Primitives":  "4.0.1",
-        "Microsoft.Net.Compilers.Targets.NetCore": "0.1.4-dev",
+        "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
         "Microsoft.NETCore.TestHost": "1.0.0",
         "System.Xml.XmlDocument": "4.0.1",

--- a/src/XMakeBuildEngine/UnitTests/project.json
+++ b/src/XMakeBuildEngine/UnitTests/project.json
@@ -28,7 +28,7 @@
         "System.Xml.XPath.XmlDocument": "4.0.1",
         "Microsoft.Win32.Primitives": "4.0.1",
         "Microsoft.Net.Compilers.NetCore": "2.0.0-beta3",
-        "Microsoft.Net.Compilers.Targets.NetCore": "0.1.4-dev",
+        "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
         "Microsoft.NETCore.TestHost": "1.0.0",
         "System.Reflection.Metadata": "1.3.0"


### PR DESCRIPTION
These were updated in the runtime package list (so our final output was
ok), but not in these consumers.