### PR TITLE
Disable a failing unit test

### DIFF
--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -2891,7 +2891,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// A whole bunch error check tests
         /// </summary>
-        [Fact]
+        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/916")]
         public void Medley()
         {
             // Make absolutely sure that the static method cache hasn't been polluted by the other tests.  


### PR DESCRIPTION
Related to issue #916.

When I run Microsoft.Build.UnitTests.Evaluation.Expander_Tests.Medley (from
Microsoft.Build.Engine.UnitTests.dll) by itself, the test passes. When I run all
tests in the assembly, however, it fails with this message:

> FAILURE: Expected '$([Microsoft.VisualBasic.FileIO.FileSystem]::CurrentDirectory)'
>   to not parse or not be evaluated but it evaluated to
>   'E:\Projects\msbuild\bin\x86\Windows_NT\Debug'
> Expected: True
> Actual:   False
> Stack Trace:
>   src\XMakeBuildEngine\UnitTests\Evaluation\Expander_Tests.cs(3141,0): at
>     Microsoft.Build.UnitTests.Evaluation.Expander_Tests.Medley()

Specifically, the test seems to fail if I also run the
PropertyStaticFunctionAllEnabled method in the same class first. That's the only
other test in the assembly that refers to the
Microsoft.VisualBasic.FileIO.FileSystem type.