### PR TITLE
Projects for creating NuGet packages for MSBuild 14.0 binaries

### DIFF
--- a/build/LegacyPackages/14.0/.gitignore
+++ b/build/LegacyPackages/14.0/.gitignore
@@ -1,0 +1,2 @@
+﻿# Ignore anything placed in the lib folder since it's just copied from the build locally
+lib/

--- a/build/LegacyPackages/14.0/Microsoft.Build.Conversion.Core/Microsoft.Build.Conversion.Core.nuspec
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Conversion.Core/Microsoft.Build.Conversion.Core.nuspec
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$id$</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <iconUrl>$iconUrl$</iconUrl>
+    <description>This package contains the $id$ assembly which contains logic for converting projects.  NOTE: This assembly is deprecated.</description>
+    <tags>MSBuild</tags>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="net45">
+        <dependency id="Microsoft.Build" version="[$version$]" />
+        <dependency id="Microsoft.Build.Engine" version="[$version$]" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="lib\net45\$id$.dll" target="lib\net45\$id$.dll" />
+  </files>
+</package>

--- a/build/LegacyPackages/14.0/Microsoft.Build.Engine/Microsoft.Build.Engine.nuspec
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Engine/Microsoft.Build.Engine.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$id$</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <iconUrl>$iconUrl$</iconUrl>
+    <description>This package contains the $id$ assembly which contains the legacy compatibility shim for the MSBuild engine.  NOTE: This assembly is deprecated.</description>
+    <tags>MSBuild</tags>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="net45">
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Xml" targetFramework="net45" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="lib\net45\$id$.dll" target="lib\net45\$id$.dll" />
+  </files>
+</package>

--- a/build/LegacyPackages/14.0/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -1,0 +1,709 @@
+namespace Microsoft.Build.Framework
+{
+    public delegate void AnyEventHandler(object sender, Microsoft.Build.Framework.BuildEventArgs e);
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct BuildEngineResult
+    {
+        public BuildEngineResult(bool result, System.Collections.Generic.List<System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.ITaskItem[]>> targetOutputsPerProject) { throw null;}
+        public bool Result { get { throw null; } }
+        public System.Collections.Generic.IList<System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.ITaskItem[]>> TargetOutputsPerProject { get { throw null; } }
+    }
+    public partial class BuildErrorEventArgs : Microsoft.Build.Framework.LazyFormattedBuildEventArgs
+    {
+        protected BuildErrorEventArgs() { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public string Code { get { throw null; } }
+        public int ColumnNumber { get { throw null; } }
+        public int EndColumnNumber { get { throw null; } }
+        public int EndLineNumber { get { throw null; } }
+        public string File { get { throw null; } }
+        public int LineNumber { get { throw null; } }
+        public string ProjectFile { get { throw null; } set { } }
+        public string Subcategory { get { throw null; } }
+    }
+    public delegate void BuildErrorEventHandler(object sender, Microsoft.Build.Framework.BuildErrorEventArgs e);
+    public abstract partial class BuildEventArgs : System.EventArgs
+    {
+        protected BuildEventArgs() { }
+        protected BuildEventArgs(string message, string helpKeyword, string senderName) { }
+        protected BuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+        public Microsoft.Build.Framework.BuildEventContext BuildEventContext { get { throw null; } set { } }
+        public string HelpKeyword { get { throw null; } }
+        public virtual string Message { get { throw null; } protected set { } }
+        public string SenderName { get { throw null; } }
+        public int ThreadId { get { throw null; } }
+        public System.DateTime Timestamp { get { throw null; } }
+    }
+    public partial class BuildEventContext
+    {
+        public const int InvalidNodeId = -2;
+        public const int InvalidProjectContextId = -2;
+        public const int InvalidProjectInstanceId = -1;
+        public const int InvalidSubmissionId = -1;
+        public const int InvalidTargetId = -1;
+        public const int InvalidTaskId = -1;
+        public BuildEventContext(int nodeId, int targetId, int projectContextId, int taskId) { }
+        public BuildEventContext(int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+        public BuildEventContext(int submissionId, int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+        public long BuildRequestId { get { throw null; } }
+        public static Microsoft.Build.Framework.BuildEventContext Invalid { get { throw null; } }
+        public int NodeId { get { throw null; } }
+        public int ProjectContextId { get { throw null; } }
+        public int ProjectInstanceId { get { throw null; } }
+        public int SubmissionId { get { throw null; } }
+        public int TargetId { get { throw null; } }
+        public int TaskId { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Microsoft.Build.Framework.BuildEventContext left, Microsoft.Build.Framework.BuildEventContext right) { throw null; }
+        public static bool operator !=(Microsoft.Build.Framework.BuildEventContext left, Microsoft.Build.Framework.BuildEventContext right) { throw null; }
+    }
+    public partial class BuildFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        protected BuildFinishedEventArgs() { }
+        public BuildFinishedEventArgs(string message, string helpKeyword, bool succeeded) { }
+        public BuildFinishedEventArgs(string message, string helpKeyword, bool succeeded, System.DateTime eventTimestamp) { }
+        public BuildFinishedEventArgs(string message, string helpKeyword, bool succeeded, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public bool Succeeded { get { throw null; } }
+    }
+    public delegate void BuildFinishedEventHandler(object sender, Microsoft.Build.Framework.BuildFinishedEventArgs e);
+    public partial class BuildMessageEventArgs : Microsoft.Build.Framework.LazyFormattedBuildEventArgs
+    {
+        protected BuildMessageEventArgs() { }
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, Microsoft.Build.Framework.MessageImportance importance) { }
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, Microsoft.Build.Framework.MessageImportance importance, System.DateTime eventTimestamp) { }
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, Microsoft.Build.Framework.MessageImportance importance, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, Microsoft.Build.Framework.MessageImportance importance) { }
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, Microsoft.Build.Framework.MessageImportance importance, System.DateTime eventTimestamp) { }
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, Microsoft.Build.Framework.MessageImportance importance, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public string Code { get { throw null; } }
+        public int ColumnNumber { get { throw null; } }
+        public int EndColumnNumber { get { throw null; } }
+        public int EndLineNumber { get { throw null; } }
+        public string File { get { throw null; } }
+        public Microsoft.Build.Framework.MessageImportance Importance { get { throw null; } }
+        public int LineNumber { get { throw null; } }
+        public string ProjectFile { get { throw null; } set { } }
+        public string Subcategory { get { throw null; } }
+    }
+    public delegate void BuildMessageEventHandler(object sender, Microsoft.Build.Framework.BuildMessageEventArgs e);
+    public partial class BuildStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        protected BuildStartedEventArgs() { }
+        public BuildStartedEventArgs(string message, string helpKeyword) { }
+        public BuildStartedEventArgs(string message, string helpKeyword, System.Collections.Generic.IDictionary<string, string> environmentOfBuild) { }
+        public BuildStartedEventArgs(string message, string helpKeyword, System.DateTime eventTimestamp) { }
+        public BuildStartedEventArgs(string message, string helpKeyword, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public System.Collections.Generic.IDictionary<string, string> BuildEnvironment { get { throw null; } }
+    }
+    public delegate void BuildStartedEventHandler(object sender, Microsoft.Build.Framework.BuildStartedEventArgs e);
+    public abstract partial class BuildStatusEventArgs : Microsoft.Build.Framework.LazyFormattedBuildEventArgs
+    {
+        protected BuildStatusEventArgs() { }
+        protected BuildStatusEventArgs(string message, string helpKeyword, string senderName) { }
+        protected BuildStatusEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+        protected BuildStatusEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+    }
+    public delegate void BuildStatusEventHandler(object sender, Microsoft.Build.Framework.BuildStatusEventArgs e);
+    public partial class BuildWarningEventArgs : Microsoft.Build.Framework.LazyFormattedBuildEventArgs
+    {
+        protected BuildWarningEventArgs() { }
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public string Code { get { throw null; } }
+        public int ColumnNumber { get { throw null; } }
+        public int EndColumnNumber { get { throw null; } }
+        public int EndLineNumber { get { throw null; } }
+        public string File { get { throw null; } }
+        public int LineNumber { get { throw null; } }
+        public string ProjectFile { get { throw null; } set { } }
+        public string Subcategory { get { throw null; } }
+    }
+    public delegate void BuildWarningEventHandler(object sender, Microsoft.Build.Framework.BuildWarningEventArgs e);
+    public partial class CriticalBuildMessageEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        protected CriticalBuildMessageEventArgs() { }
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+    }
+    public abstract partial class CustomBuildEventArgs : Microsoft.Build.Framework.LazyFormattedBuildEventArgs
+    {
+        protected CustomBuildEventArgs() { }
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName) { }
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+    }
+    public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
+    public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
+    {
+        protected ExternalProjectFinishedEventArgs() { }
+        public ExternalProjectFinishedEventArgs(string message, string helpKeyword, string senderName, string projectFile, bool succeeded) { }
+        public ExternalProjectFinishedEventArgs(string message, string helpKeyword, string senderName, string projectFile, bool succeeded, System.DateTime eventTimestamp) { }
+        public string ProjectFile { get { throw null; } }
+        public bool Succeeded { get { throw null; } }
+    }
+    public partial class ExternalProjectStartedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
+    {
+        protected ExternalProjectStartedEventArgs() { }
+        public ExternalProjectStartedEventArgs(string message, string helpKeyword, string senderName, string projectFile, string targetNames) { }
+        public ExternalProjectStartedEventArgs(string message, string helpKeyword, string senderName, string projectFile, string targetNames, System.DateTime eventTimestamp) { }
+        public string ProjectFile { get { throw null; } }
+        public string TargetNames { get { throw null; } }
+    }
+    public partial interface IBuildEngine
+    {
+        int ColumnNumberOfTaskNode { get; }
+        bool ContinueOnError { get; }
+        int LineNumberOfTaskNode { get; }
+        string ProjectFileOfTaskNode { get; }
+        bool BuildProjectFile(string projectFileName, string[] targetNames, System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs);
+        void LogCustomEvent(Microsoft.Build.Framework.CustomBuildEventArgs e);
+        void LogErrorEvent(Microsoft.Build.Framework.BuildErrorEventArgs e);
+        void LogMessageEvent(Microsoft.Build.Framework.BuildMessageEventArgs e);
+        void LogWarningEvent(Microsoft.Build.Framework.BuildWarningEventArgs e);
+    }
+    public partial interface IBuildEngine2 : Microsoft.Build.Framework.IBuildEngine
+    {
+        bool IsRunningMultipleNodes { get; }
+        bool BuildProjectFile(string projectFileName, string[] targetNames, System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs, string toolsVersion);
+        bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, System.Collections.IDictionary[] globalProperties, System.Collections.IDictionary[] targetOutputsPerProject, string[] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion);
+    }
+    public partial interface IBuildEngine3 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2
+    {
+        Microsoft.Build.Framework.BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, System.Collections.IDictionary[] globalProperties, System.Collections.Generic.IList<string>[] removeGlobalProperties, string[] toolsVersion, bool returnTargetOutputs);
+        void Reacquire();
+        void Yield();
+    }
+    public partial interface IBuildEngine4 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3
+    {
+        object GetRegisteredTaskObject(object key, Microsoft.Build.Framework.RegisteredTaskObjectLifetime lifetime);
+        void RegisterTaskObject(object key, object obj, Microsoft.Build.Framework.RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection);
+        object UnregisterTaskObject(object key, Microsoft.Build.Framework.RegisteredTaskObjectLifetime lifetime);
+    }
+    public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
+    {
+        void Cancel();
+    }
+    public partial interface IEventRedirector
+    {
+        void ForwardEvent(Microsoft.Build.Framework.BuildEventArgs buildEvent);
+    }
+    public partial interface IEventSource
+    {
+        event Microsoft.Build.Framework.AnyEventHandler AnyEventRaised;
+        event Microsoft.Build.Framework.BuildFinishedEventHandler BuildFinished;
+        event Microsoft.Build.Framework.BuildStartedEventHandler BuildStarted;
+        event Microsoft.Build.Framework.CustomBuildEventHandler CustomEventRaised;
+        event Microsoft.Build.Framework.BuildErrorEventHandler ErrorRaised;
+        event Microsoft.Build.Framework.BuildMessageEventHandler MessageRaised;
+        event Microsoft.Build.Framework.ProjectFinishedEventHandler ProjectFinished;
+        event Microsoft.Build.Framework.ProjectStartedEventHandler ProjectStarted;
+        event Microsoft.Build.Framework.BuildStatusEventHandler StatusEventRaised;
+        event Microsoft.Build.Framework.TargetFinishedEventHandler TargetFinished;
+        event Microsoft.Build.Framework.TargetStartedEventHandler TargetStarted;
+        event Microsoft.Build.Framework.TaskFinishedEventHandler TaskFinished;
+        event Microsoft.Build.Framework.TaskStartedEventHandler TaskStarted;
+        event Microsoft.Build.Framework.BuildWarningEventHandler WarningRaised;
+    }
+    public partial interface IForwardingLogger : Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
+    {
+        Microsoft.Build.Framework.IEventRedirector BuildEventRedirector { get; set; }
+        int NodeId { get; set; }
+    }
+    public partial interface IGeneratedTask : Microsoft.Build.Framework.ITask
+    {
+        object GetPropertyValue(Microsoft.Build.Framework.TaskPropertyInfo property);
+        void SetPropertyValue(Microsoft.Build.Framework.TaskPropertyInfo property, object value);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public partial interface ILogger
+    {
+        string Parameters { get; set; }
+        Microsoft.Build.Framework.LoggerVerbosity Verbosity { get; set; }
+        void Initialize(Microsoft.Build.Framework.IEventSource eventSource);
+        void Shutdown();
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public partial interface INodeLogger : Microsoft.Build.Framework.ILogger
+    {
+        void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount);
+    }
+    public partial interface ITask
+    {
+        Microsoft.Build.Framework.IBuildEngine BuildEngine { get; set; }
+        Microsoft.Build.Framework.ITaskHost HostObject { get; set; }
+        bool Execute();
+    }
+    public partial interface ITaskFactory
+    {
+        string FactoryName { get; }
+        System.Type TaskType { get; }
+        void CleanupTask(Microsoft.Build.Framework.ITask task);
+        Microsoft.Build.Framework.ITask CreateTask(Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost);
+        Microsoft.Build.Framework.TaskPropertyInfo[] GetTaskParameters();
+        bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.TaskPropertyInfo> parameterGroup, string taskBody, Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost);
+    }
+    public partial interface ITaskFactory2 : Microsoft.Build.Framework.ITaskFactory
+    {
+        Microsoft.Build.Framework.ITask CreateTask(Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost, System.Collections.Generic.IDictionary<string, string> taskIdentityParameters);
+        bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, string> factoryIdentityParameters, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.TaskPropertyInfo> parameterGroup, string taskBody, Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("9049A481-D0E9-414f-8F92-D4F67A0359A6")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface ITaskHost
+    {
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("8661674F-2148-4F71-A92A-49875511C528")]
+    public partial interface ITaskItem
+    {
+        string ItemSpec { get; set; }
+        int MetadataCount { get; }
+        System.Collections.ICollection MetadataNames { get; }
+        System.Collections.IDictionary CloneCustomMetadata();
+        void CopyMetadataTo(Microsoft.Build.Framework.ITaskItem destinationItem);
+        string GetMetadata(string metadataName);
+        void RemoveMetadata(string metadataName);
+        void SetMetadata(string metadataName, string metadataValue);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("ac6d5a59-f877-461b-88e3-b2f06fce0cb9")]
+    public partial interface ITaskItem2 : Microsoft.Build.Framework.ITaskItem
+    {
+        string EvaluatedIncludeEscaped { get; set; }
+        System.Collections.IDictionary CloneCustomMetadataEscaped();
+        string GetMetadataValueEscaped(string metadataName);
+        void SetMetadataValueLiteral(string metadataName, string metadataValue);
+    }
+    public partial class LazyFormattedBuildEventArgs : Microsoft.Build.Framework.BuildEventArgs
+    {
+        protected LazyFormattedBuildEventArgs() { }
+        public LazyFormattedBuildEventArgs(string message, string helpKeyword, string senderName) { }
+        public LazyFormattedBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+        public override string Message { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=false, Inherited=true)]
+    public sealed partial class LoadInSeparateAppDomainAttribute : System.Attribute
+    {
+        public LoadInSeparateAppDomainAttribute() { }
+    }
+    public partial class LoggerException : System.Exception
+    {
+        public LoggerException() { }
+        protected LoggerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public LoggerException(string message) { }
+        public LoggerException(string message, System.Exception innerException) { }
+        public LoggerException(string message, System.Exception innerException, string errorCode, string helpKeyword) { }
+        public string ErrorCode { get { throw null; } }
+        public string HelpKeyword { get { throw null; } }
+        [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    public enum LoggerVerbosity
+    {
+        Detailed = 3,
+        Diagnostic = 4,
+        Minimal = 1,
+        Normal = 2,
+        Quiet = 0,
+    }
+    public enum MessageImportance
+    {
+        High = 0,
+        Low = 2,
+        Normal = 1,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
+    public sealed partial class OutputAttribute : System.Attribute
+    {
+        public OutputAttribute() { }
+    }
+    public partial class ProjectFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        protected ProjectFinishedEventArgs() { }
+        public ProjectFinishedEventArgs(string message, string helpKeyword, string projectFile, bool succeeded) { }
+        public ProjectFinishedEventArgs(string message, string helpKeyword, string projectFile, bool succeeded, System.DateTime eventTimestamp) { }
+        public string ProjectFile { get { throw null; } }
+        public bool Succeeded { get { throw null; } }
+    }
+    public delegate void ProjectFinishedEventHandler(object sender, Microsoft.Build.Framework.ProjectFinishedEventArgs e);
+    public partial class ProjectStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        public const int InvalidProjectId = -1;
+        protected ProjectStartedEventArgs() { }
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, Microsoft.Build.Framework.BuildEventContext parentBuildEventContext) { }
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, Microsoft.Build.Framework.BuildEventContext parentBuildEventContext, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, Microsoft.Build.Framework.BuildEventContext parentBuildEventContext, System.DateTime eventTimestamp) { }
+        public ProjectStartedEventArgs(string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items) { }
+        public ProjectStartedEventArgs(string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, System.DateTime eventTimestamp) { }
+        public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } }
+        public System.Collections.IEnumerable Items { get { throw null; } }
+        public Microsoft.Build.Framework.BuildEventContext ParentProjectBuildEventContext { get { throw null; } }
+        public string ProjectFile { get { throw null; } }
+        public int ProjectId { get { throw null; } }
+        public System.Collections.IEnumerable Properties { get { throw null; } }
+        public string TargetNames { get { throw null; } }
+        public string ToolsVersion { get { throw null; } }
+    }
+    public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
+    public enum RegisteredTaskObjectLifetime
+    {
+        AppDomain = 1,
+        Build = 0,
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
+    public sealed partial class RequiredAttribute : System.Attribute
+    {
+        public RequiredAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=false, Inherited=false)]
+    public sealed partial class RequiredRuntimeAttribute : System.Attribute
+    {
+        public RequiredRuntimeAttribute(string runtimeVersion) { }
+        public string RuntimeVersion { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=false, Inherited=false)]
+    public sealed partial class RunInMTAAttribute : System.Attribute
+    {
+        public RunInMTAAttribute() { }
+    }
+    [System.AttributeUsageAttribute((System.AttributeTargets)(4), AllowMultiple=false, Inherited=false)]
+    public sealed partial class RunInSTAAttribute : System.Attribute
+    {
+        public RunInSTAAttribute() { }
+    }
+    public partial class TargetFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        protected TargetFinishedEventArgs() { }
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded) { }
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded, System.Collections.IEnumerable targetOutputs) { }
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded, System.DateTime eventTimestamp, System.Collections.IEnumerable targetOutputs) { }
+        public string ProjectFile { get { throw null; } }
+        public bool Succeeded { get { throw null; } }
+        public string TargetFile { get { throw null; } }
+        public string TargetName { get { throw null; } }
+        public System.Collections.IEnumerable TargetOutputs { get { throw null; } set { } }
+    }
+    public delegate void TargetFinishedEventHandler(object sender, Microsoft.Build.Framework.TargetFinishedEventArgs e);
+    public partial class TargetStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        protected TargetStartedEventArgs() { }
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile) { }
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, string parentTarget, System.DateTime eventTimestamp) { }
+        public string ParentTarget { get { throw null; } }
+        public string ProjectFile { get { throw null; } }
+        public string TargetFile { get { throw null; } }
+        public string TargetName { get { throw null; } }
+    }
+    public delegate void TargetStartedEventHandler(object sender, Microsoft.Build.Framework.TargetStartedEventArgs e);
+    public partial class TaskCommandLineEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        protected TaskCommandLineEventArgs() { }
+        public TaskCommandLineEventArgs(string commandLine, string taskName, Microsoft.Build.Framework.MessageImportance importance) { }
+        public TaskCommandLineEventArgs(string commandLine, string taskName, Microsoft.Build.Framework.MessageImportance importance, System.DateTime eventTimestamp) { }
+        public string CommandLine { get { throw null; } }
+        public string TaskName { get { throw null; } }
+    }
+    public partial class TaskFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        protected TaskFinishedEventArgs() { }
+        public TaskFinishedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, bool succeeded) { }
+        public TaskFinishedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, bool succeeded, System.DateTime eventTimestamp) { }
+        public string ProjectFile { get { throw null; } }
+        public bool Succeeded { get { throw null; } }
+        public string TaskFile { get { throw null; } }
+        public string TaskName { get { throw null; } }
+    }
+    public delegate void TaskFinishedEventHandler(object sender, Microsoft.Build.Framework.TaskFinishedEventArgs e);
+    public partial class TaskPropertyInfo
+    {
+        public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool Output { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Type PropertyType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool Required { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
+    public partial class TaskStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        protected TaskStartedEventArgs() { }
+        public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName) { }
+        public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, System.DateTime eventTimestamp) { }
+        public string ProjectFile { get { throw null; } }
+        public string TaskFile { get { throw null; } }
+        public string TaskName { get { throw null; } }
+    }
+    public delegate void TaskStartedEventHandler(object sender, Microsoft.Build.Framework.TaskStartedEventArgs e);
+}
+namespace Microsoft.Build.Framework.XamlTypes
+{
+    public sealed partial class Argument : System.ComponentModel.ISupportInitialize
+    {
+        public Argument() { }
+        public bool IsRequired { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Property { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Separator { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void BeginInit() { }
+        public void EndInit() { }
+    }
+    [System.Windows.Markup.ContentPropertyAttribute("Arguments")]
+    public abstract partial class BaseProperty : System.ComponentModel.ISupportInitialize
+    {
+        protected BaseProperty() { }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.Argument> Arguments { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Category { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.XamlTypes.Rule ContainingRule { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Framework.XamlTypes.DataSource DataSource { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string Default { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string DisplayName { get { throw null; } set { } }
+        [System.ComponentModel.LocalizableAttribute(false)]
+        public string F1Keyword { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int HelpContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(false)]
+        public string HelpFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(false)]
+        public string HelpUrl { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool IncludeInCommandLine { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool IsRequired { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.NameValuePair> Metadata { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool MultipleValuesAllowed { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool ReadOnly { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Separator { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Subcategory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Switch { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string SwitchPrefix { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.ValueEditor> ValueEditors { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool Visible { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public virtual void BeginInit() { }
+        public virtual void EndInit() { }
+    }
+    public sealed partial class BoolProperty : Microsoft.Build.Framework.XamlTypes.BaseProperty
+    {
+        public BoolProperty() { }
+        public string ReverseSwitch { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public sealed partial class Category : Microsoft.Build.Framework.XamlTypes.CategorySchema, System.ComponentModel.ISupportInitialize
+    {
+        public Category() { }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string DisplayName { get { throw null; } set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string HelpString { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Subtype { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void BeginInit() { }
+        public void EndInit() { }
+    }
+    public abstract partial class CategorySchema
+    {
+        protected CategorySchema() { }
+    }
+    [System.Windows.Markup.ContentPropertyAttribute("Metadata")]
+    public sealed partial class ContentType : Microsoft.Build.Framework.XamlTypes.IProjectSchemaNode, System.ComponentModel.ISupportInitialize
+    {
+        public ContentType() { }
+        public bool DefaultContentTypeForItemType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string DisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ObsoleteAttribute("Unused.  Use ItemType property instead.", true)]
+        public string ItemGroupName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string ItemType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.NameValuePair> Metadata { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void BeginInit() { }
+        public void EndInit() { }
+        public string GetMetadata(string metadataName) { throw null; }
+        public System.Collections.Generic.IEnumerable<object> GetSchemaObjects(System.Type type) { throw null; }
+        public System.Collections.Generic.IEnumerable<System.Type> GetSchemaObjectTypes() { throw null; }
+    }
+    public sealed partial class DataSource : System.ComponentModel.ISupportInitialize
+    {
+        public DataSource() { }
+        public bool HasConfigurationCondition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string ItemType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Label { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string MSBuildTarget { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string PersistedName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Persistence { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.XamlTypes.DefaultValueSourceLocation SourceOfDefaultValue { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string SourceType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void BeginInit() { }
+        public void EndInit() { }
+    }
+    public enum DefaultValueSourceLocation
+    {
+        AfterContext = 1,
+        BeforeContext = 0,
+    }
+    public sealed partial class DynamicEnumProperty : Microsoft.Build.Framework.XamlTypes.BaseProperty
+    {
+        public DynamicEnumProperty() { }
+        public string EnumProvider { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.NameValuePair> ProviderSettings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    [System.Windows.Markup.ContentPropertyAttribute("AdmissibleValues")]
+    public sealed partial class EnumProperty : Microsoft.Build.Framework.XamlTypes.BaseProperty
+    {
+        public EnumProperty() { }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.EnumValue> AdmissibleValues { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override void EndInit() { }
+    }
+    [System.Windows.Markup.ContentPropertyAttribute("Arguments")]
+    public sealed partial class EnumValue
+    {
+        public EnumValue() { }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.Argument> Arguments { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string DisplayName { get { throw null; } set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string HelpString { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool IsDefault { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.NameValuePair> Metadata { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Switch { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string SwitchPrefix { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public sealed partial class FileExtension : Microsoft.Build.Framework.XamlTypes.IProjectSchemaNode
+    {
+        public FileExtension() { }
+        public string ContentType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.IEnumerable<object> GetSchemaObjects(System.Type type) { throw null; }
+        public System.Collections.Generic.IEnumerable<System.Type> GetSchemaObjectTypes() { throw null; }
+    }
+    public sealed partial class IntProperty : Microsoft.Build.Framework.XamlTypes.BaseProperty
+    {
+        public IntProperty() { }
+        public System.Nullable<int> MaxValue { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Nullable<int> MinValue { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override void EndInit() { }
+    }
+    public partial interface IProjectSchemaNode
+    {
+        System.Collections.Generic.IEnumerable<object> GetSchemaObjects(System.Type type);
+        System.Collections.Generic.IEnumerable<System.Type> GetSchemaObjectTypes();
+    }
+    public sealed partial class ItemType : Microsoft.Build.Framework.XamlTypes.IProjectSchemaNode, System.ComponentModel.ISupportInitialize
+    {
+        public ItemType() { }
+        public string DefaultContentType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string DisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool UpToDateCheckInput { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void BeginInit() { }
+        public void EndInit() { }
+        public System.Collections.Generic.IEnumerable<object> GetSchemaObjects(System.Type type) { throw null; }
+        public System.Collections.Generic.IEnumerable<System.Type> GetSchemaObjectTypes() { throw null; }
+    }
+    public partial class NameValuePair
+    {
+        public NameValuePair() { }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    [System.Windows.Markup.ContentPropertyAttribute("Nodes")]
+    public sealed partial class ProjectSchemaDefinitions : Microsoft.Build.Framework.XamlTypes.IProjectSchemaNode
+    {
+        public ProjectSchemaDefinitions() { }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.IProjectSchemaNode> Nodes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.IEnumerable<object> GetSchemaObjects(System.Type type) { throw null; }
+        public System.Collections.Generic.IEnumerable<System.Type> GetSchemaObjectTypes() { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Rule: {Name}")]
+    [System.Windows.Markup.ContentPropertyAttribute("Properties")]
+    public sealed partial class Rule : Microsoft.Build.Framework.XamlTypes.RuleSchema, Microsoft.Build.Framework.XamlTypes.IProjectSchemaNode, System.ComponentModel.ISupportInitialize
+    {
+        public Rule() { }
+        public string AdditionalInputs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.Category> Categories { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string CommandLine { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.XamlTypes.DataSource DataSource { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string DisplayName { get { throw null; } set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.Category> EvaluatedCategories { get { throw null; } }
+        public string ExecutionDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string FileExtension { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string HelpString { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.Dictionary<string, object> Metadata { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int Order { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Outputs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.XamlTypes.RuleOverrideMode OverrideMode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string PageTemplate { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.BaseProperty> Properties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool PropertyPagesHidden { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Separator { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool ShowOnlyRuleProperties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SupportsFileBatching { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string SwitchPrefix { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string ToolName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void BeginInit() { }
+        public void EndInit() { }
+        public System.Collections.Specialized.OrderedDictionary GetPropertiesByCategory() { throw null; }
+        public System.Collections.Generic.IList<Microsoft.Build.Framework.XamlTypes.BaseProperty> GetPropertiesInCategory(string categoryName) { throw null; }
+        public Microsoft.Build.Framework.XamlTypes.BaseProperty GetProperty(string propertyName) { throw null; }
+        public System.Collections.Generic.IEnumerable<object> GetSchemaObjects(System.Type type) { throw null; }
+        public System.Collections.Generic.IEnumerable<System.Type> GetSchemaObjectTypes() { throw null; }
+    }
+    [System.Windows.Markup.ContentPropertyAttribute("Rules")]
+    public sealed partial class RuleBag : Microsoft.Build.Framework.XamlTypes.IProjectSchemaNode, System.ComponentModel.ISupportInitialize
+    {
+        public RuleBag() { }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.Rule> Rules { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void BeginInit() { }
+        public void EndInit() { }
+        public System.Collections.Generic.IEnumerable<object> GetSchemaObjects(System.Type type) { throw null; }
+        public System.Collections.Generic.IEnumerable<System.Type> GetSchemaObjectTypes() { throw null; }
+    }
+    public enum RuleOverrideMode
+    {
+        Extend = 1,
+        Replace = 0,
+    }
+    public abstract partial class RuleSchema
+    {
+        protected RuleSchema() { }
+    }
+    public sealed partial class StringListProperty : Microsoft.Build.Framework.XamlTypes.BaseProperty
+    {
+        public StringListProperty() { }
+        public string CommandLineValueSeparator { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string RendererValueSeparator { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Subtype { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public sealed partial class StringProperty : Microsoft.Build.Framework.XamlTypes.BaseProperty
+    {
+        public StringProperty() { }
+        public string Subtype { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    [System.Windows.Markup.ContentPropertyAttribute("Metadata")]
+    public sealed partial class ValueEditor : System.ComponentModel.ISupportInitialize
+    {
+        public ValueEditor() { }
+        [System.ComponentModel.LocalizableAttribute(true)]
+        public string DisplayName { get { throw null; } set { } }
+        public string EditorType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.List<Microsoft.Build.Framework.XamlTypes.NameValuePair> Metadata { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void BeginInit() { }
+        public void EndInit() { }
+    }
+}

--- a/build/LegacyPackages/14.0/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -295,14 +295,18 @@ namespace Microsoft.Build.Framework
     public partial class LoggerException : System.Exception
     {
         public LoggerException() { }
+#if !NETSTANDARD
         protected LoggerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#endif
         public LoggerException(string message) { }
         public LoggerException(string message, System.Exception innerException) { }
         public LoggerException(string message, System.Exception innerException, string errorCode, string helpKeyword) { }
         public string ErrorCode { get { throw null; } }
         public string HelpKeyword { get { throw null; } }
+#if !NETSTANDARD
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#endif
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public enum LoggerVerbosity
@@ -440,6 +444,7 @@ namespace Microsoft.Build.Framework
     }
     public delegate void TaskStartedEventHandler(object sender, Microsoft.Build.Framework.TaskStartedEventArgs e);
 }
+#if !NETSTANDARD
 namespace Microsoft.Build.Framework.XamlTypes
 {
     public sealed partial class Argument : System.ComponentModel.ISupportInitialize
@@ -707,3 +712,4 @@ namespace Microsoft.Build.Framework.XamlTypes
         public void EndInit() { }
     }
 }
+#endif

--- a/build/LegacyPackages/14.0/Microsoft.Build.Framework/Microsoft.Build.Framework.nuspec
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Framework/Microsoft.Build.Framework.nuspec
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$id$</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <iconUrl>$iconUrl$</iconUrl>
+    <description>This package contains the $id$ assembly which is a common assembly used by other MSBuild assemblies.</description>
+    <tags>MSBuild</tags>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="lib\net45\$id$.dll" target="lib\net45\$id$.dll" />
+    <file src="bin\$configuration$\net45\$id$.dll" target="ref\net45\$id$.dll" />
+    <file src="bin\$configuration$\netstandard1.3\$id$.dll" target="ref\netstandard1.3\$id$.dll" />
+  </files>
+</package>

--- a/build/LegacyPackages/14.0/Microsoft.Build.Framework/project.json
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Framework/project.json
@@ -1,0 +1,26 @@
+﻿{
+  "version":  "14.0.0.0",
+  "buildOptions": {
+    "keyFile": "../../../../Tools/MSFT.snk",
+    "publicSign": true
+  },
+  "frameworks": {
+    "net45": {
+      "frameworkAssemblies": {
+        "System.Xaml": {
+          "type": "build"
+        }
+      }
+    },
+    "netstandard1.3": {
+      "buildOptions": {
+        "define": [ "NETSTANDARD" ]
+      },
+      "dependencies": {
+        "System.Collections": "4.0.11",
+        "System.Runtime": "4.1.0",
+        "System.Runtime.InteropServices": "4.1.0"
+      }
+    }
+  }
+}

--- a/build/LegacyPackages/14.0/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1,0 +1,2510 @@
+namespace Microsoft.Build.Tasks
+{
+    public partial class AL : Microsoft.Build.Tasks.ToolTaskExtension
+    {
+        public AL() { }
+        public string AlgorithmId { get { throw null; } set { } }
+        public string BaseAddress { get { throw null; } set { } }
+        public string CompanyName { get { throw null; } set { } }
+        public string Configuration { get { throw null; } set { } }
+        public string Copyright { get { throw null; } set { } }
+        public string Culture { get { throw null; } set { } }
+        public bool DelaySign { get { throw null; } set { } }
+        public string Description { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] EmbedResources { get { throw null; } set { } }
+        public string EvidenceFile { get { throw null; } set { } }
+        public string FileVersion { get { throw null; } set { } }
+        public string Flags { get { throw null; } set { } }
+        public bool GenerateFullPaths { get { throw null; } set { } }
+        public string KeyContainer { get { throw null; } set { } }
+        public string KeyFile { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] LinkResources { get { throw null; } set { } }
+        public string MainEntryPoint { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputAssembly { get { throw null; } set { } }
+        public string Platform { get { throw null; } set { } }
+        public bool Prefer32Bit { get { throw null; } set { } }
+        public string ProductName { get { throw null; } set { } }
+        public string ProductVersion { get { throw null; } set { } }
+        public string[] ResponseFiles { get { throw null; } set { } }
+        public string SdkToolsPath { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] SourceModules { get { throw null; } set { } }
+        public string TargetType { get { throw null; } set { } }
+        public string TemplateFile { get { throw null; } set { } }
+        public string Title { get { throw null; } set { } }
+        protected override string ToolName { get { throw null; } }
+        public string Trademark { get { throw null; } set { } }
+        public string Version { get { throw null; } set { } }
+        public string Win32Icon { get { throw null; } set { } }
+        public string Win32Resource { get { throw null; } set { } }
+        protected internal override void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        public override bool Execute() { throw null; }
+        protected override string GenerateFullPathToTool() { throw null; }
+    }
+    [Microsoft.Build.Framework.LoadInSeparateAppDomainAttribute]
+    public abstract partial class AppDomainIsolatedTaskExtension : Microsoft.Build.Utilities.AppDomainIsolatedTask
+    {
+        internal AppDomainIsolatedTaskExtension() { }
+        public new Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
+    }
+    public partial class AspNetCompiler : Microsoft.Build.Tasks.ToolTaskExtension
+    {
+        public AspNetCompiler() { }
+        public bool AllowPartiallyTrustedCallers { get { throw null; } set { } }
+        public bool Clean { get { throw null; } set { } }
+        public bool Debug { get { throw null; } set { } }
+        public bool DelaySign { get { throw null; } set { } }
+        public bool FixedNames { get { throw null; } set { } }
+        public bool Force { get { throw null; } set { } }
+        public string KeyContainer { get { throw null; } set { } }
+        public string KeyFile { get { throw null; } set { } }
+        public string MetabasePath { get { throw null; } set { } }
+        public string PhysicalPath { get { throw null; } set { } }
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+        public string TargetPath { get { throw null; } set { } }
+        protected override string ToolName { get { throw null; } }
+        public bool Updateable { get { throw null; } set { } }
+        public string VirtualPath { get { throw null; } set { } }
+        protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        public override bool Execute() { throw null; }
+        protected override string GenerateFullPathToTool() { throw null; }
+        protected override bool ValidateParameters() { throw null; }
+    }
+    public partial class AssignCulture : Microsoft.Build.Tasks.TaskExtension
+    {
+        public AssignCulture() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] AssignedFiles { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] AssignedFilesWithCulture { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] AssignedFilesWithNoCulture { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] CultureNeutralAssignedFiles { get { throw null; } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class AssignLinkMetadata : Microsoft.Build.Tasks.TaskExtension
+    {
+        public AssignLinkMetadata() { }
+        public Microsoft.Build.Framework.ITaskItem[] Items { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] OutputItems { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class AssignProjectConfiguration : Microsoft.Build.Tasks.ResolveProjectBase
+    {
+        public AssignProjectConfiguration() { }
+        public bool AddSyntheticProjectReferencesForSolutionDependencies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] AssignedProjects { get { throw null; } set { } }
+        public string CurrentProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string CurrentProjectConfiguration { get { throw null; } set { } }
+        public string CurrentProjectPlatform { get { throw null; } set { } }
+        public string DefaultToVcxPlatformMapping { get { throw null; } set { } }
+        public bool OnlyReferenceAndBuildProjectsEnabledInSolutionConfiguration { get { throw null; } set { } }
+        public string OutputType { get { throw null; } set { } }
+        public bool ResolveConfigurationPlatformUsingMappings { get { throw null; } set { } }
+        public bool ShouldUnsetParentConfigurationAndPlatform { get { throw null; } set { } }
+        public string SolutionConfigurationContents { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] UnassignedProjects { get { throw null; } set { } }
+        public string VcxToDefaultPlatformMapping { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class AssignTargetPath : Microsoft.Build.Tasks.TaskExtension
+    {
+        public AssignTargetPath() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] AssignedFiles { get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string RootFolder { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    [Microsoft.Build.Framework.RunInMTAAttribute]
+    public partial class CallTarget : Microsoft.Build.Tasks.TaskExtension
+    {
+        public CallTarget() { }
+        public bool RunEachTargetSeparately { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] TargetOutputs { get { throw null; } }
+        public string[] Targets { get { throw null; } set { } }
+        public bool UseResultsCache { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class CodeTaskFactory : Microsoft.Build.Framework.ITaskFactory
+    {
+        public CodeTaskFactory() { }
+        public string FactoryName { get { throw null; } }
+        public System.Type TaskType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public void CleanupTask(Microsoft.Build.Framework.ITask task) { }
+        public Microsoft.Build.Framework.ITask CreateTask(Microsoft.Build.Framework.IBuildEngine loggingHost) { throw null; }
+        public Microsoft.Build.Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.TaskPropertyInfo> taskParameters, string taskElementContents, Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
+    public partial class CombinePath : Microsoft.Build.Tasks.TaskExtension
+    {
+        public CombinePath() { }
+        public string BasePath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] CombinedPaths { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Paths { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class CommandLineBuilderExtension : Microsoft.Build.Utilities.CommandLineBuilder
+    {
+        public CommandLineBuilderExtension() { }
+        protected string GetQuotedText(string unquotedText) { throw null; }
+    }
+    public partial class ConvertToAbsolutePath : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ConvertToAbsolutePath() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] AbsolutePaths { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Paths { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class Copy : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
+    {
+        public Copy() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] CopiedFiles { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+        public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
+        public int Retries { get { throw null; } set { } }
+        public int RetryDelayMilliseconds { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SkipUnchangedFiles { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
+        public bool UseHardlinksIfPossible { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void Cancel() { }
+        public override bool Execute() { throw null; }
+    }
+    public partial class CreateCSharpManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
+    {
+        public CreateCSharpManifestResourceName() { }
+        protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
+        protected override bool IsSourceFile(string fileName) { throw null; }
+    }
+    public partial class CreateItem : Microsoft.Build.Tasks.TaskExtension
+    {
+        public CreateItem() { }
+        public string[] AdditionalMetadata { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Exclude { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Include { get { throw null; } set { } }
+        public bool PreserveExistingMetadata { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public abstract partial class CreateManifestResourceName : Microsoft.Build.Tasks.TaskExtension
+    {
+        protected System.Collections.Generic.Dictionary<string, Microsoft.Build.Framework.ITaskItem> itemSpecToTaskitem;
+        protected CreateManifestResourceName() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ManifestResourceNames { get { throw null; } }
+        public bool PrependCultureAsDirectory { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResourceFiles { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
+        public string RootNamespace { get { throw null; } set { } }
+        protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
+        public override bool Execute() { throw null; }
+        protected abstract bool IsSourceFile(string fileName);
+        public static string MakeValidEverettIdentifier(string name) { throw null; }
+    }
+    public partial class CreateProperty : Microsoft.Build.Tasks.TaskExtension
+    {
+        public CreateProperty() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string[] Value { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string[] ValueSetByTask { get { throw null; } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class CreateVisualBasicManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
+    {
+        public CreateVisualBasicManifestResourceName() { }
+        protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
+        protected override bool IsSourceFile(string fileName) { throw null; }
+    }
+    public sealed partial class Delete : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
+    {
+        public Delete() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] DeletedFiles { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public bool TreatErrorsAsWarnings { get { throw null; } set { } }
+        public void Cancel() { }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class Error : Microsoft.Build.Tasks.TaskExtension
+    {
+        public Error() { }
+        public string Code { get { throw null; } set { } }
+        public string File { get { throw null; } set { } }
+        public string HelpKeyword { get { throw null; } set { } }
+        public string Text { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class ErrorFromResources : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ErrorFromResources() { }
+        public string[] Arguments { get { throw null; } set { } }
+        public string Code { get { throw null; } set { } }
+        public string File { get { throw null; } set { } }
+        public string HelpKeyword { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string Resource { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class Exec : Microsoft.Build.Tasks.ToolTaskExtension
+    {
+        public Exec() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string Command { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ConsoleOutput { get { throw null; } }
+        public bool ConsoleToMSBuild { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string CustomErrorRegularExpression { get { throw null; } set { } }
+        public string CustomWarningRegularExpression { get { throw null; } set { } }
+        public bool IgnoreExitCode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool IgnoreStandardErrorWarningFormat { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Outputs { get { throw null; } set { } }
+        protected override System.Text.Encoding StandardErrorEncoding { get { throw null; } }
+        protected override Microsoft.Build.Framework.MessageImportance StandardErrorLoggingImportance { get { throw null; } }
+        protected override System.Text.Encoding StandardOutputEncoding { get { throw null; } }
+        protected override Microsoft.Build.Framework.MessageImportance StandardOutputLoggingImportance { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string StdErrEncoding { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string StdOutEncoding { get { throw null; } set { } }
+        protected override string ToolName { get { throw null; } }
+        public string UseUtf8Encoding { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string WorkingDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands) { throw null; }
+        protected override string GenerateFullPathToTool() { throw null; }
+        protected override string GetWorkingDirectory() { throw null; }
+        protected override bool HandleTaskExecutionErrors() { throw null; }
+        protected override void LogEventsFromTextOutput(string singleLine, Microsoft.Build.Framework.MessageImportance messageImportance) { }
+        protected override void LogPathToTool(string toolName, string pathToTool) { }
+        protected override void LogToolCommand(string message) { }
+        protected override bool ValidateParameters() { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct ExtractedClassName
+    {
+        public bool IsInsideConditionalBlock { get { throw null; } set { } }
+        public string Name { get { throw null; } set { } }
+    }
+    public partial class FindAppConfigFile : Microsoft.Build.Tasks.TaskExtension
+    {
+        public FindAppConfigFile() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem AppConfigFile { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] PrimaryList { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SecondaryList { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class FindInList : Microsoft.Build.Tasks.TaskExtension
+    {
+        public FindInList() { }
+        public bool CaseSensitive { get { throw null; } set { } }
+        public bool FindLastMatch { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem ItemFound { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string ItemSpecToFind { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] List { get { throw null; } set { } }
+        public bool MatchFileNameOnly { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class FindInvalidProjectReferences : Microsoft.Build.Tasks.TaskExtension
+    {
+        public FindInvalidProjectReferences() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] InvalidReferences { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] ProjectReferences { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPlatformIdentifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPlatformVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class FindUnderPath : Microsoft.Build.Tasks.TaskExtension
+    {
+        public FindUnderPath() { }
+        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] InPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] OutOfPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem Path { get { throw null; } set { } }
+        public bool UpdateToAbsolutePaths { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class FormatUrl : Microsoft.Build.Tasks.TaskExtension
+    {
+        public FormatUrl() { }
+        public string InputUrl { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string OutputUrl { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class FormatVersion : Microsoft.Build.Tasks.TaskExtension
+    {
+        public FormatVersion() { }
+        public string FormatType { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string OutputVersion { get { throw null; } set { } }
+        public int Revision { get { throw null; } set { } }
+        public string Version { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class GenerateApplicationManifest : Microsoft.Build.Tasks.GenerateManifestBase
+    {
+        public GenerateApplicationManifest() { }
+        public string ClrVersion { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem ConfigFile { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Dependencies { get { throw null; } set { } }
+        public string ErrorReportUrl { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] FileAssociations { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public bool HostInBrowser { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem IconFile { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] IsolatedComReferences { get { throw null; } set { } }
+        public string ManifestType { get { throw null; } set { } }
+        public string OSVersion { get { throw null; } set { } }
+        public string Product { get { throw null; } set { } }
+        public string Publisher { get { throw null; } set { } }
+        public bool RequiresMinimumFramework35SP1 { get { throw null; } set { } }
+        public string SuiteName { get { throw null; } set { } }
+        public string SupportUrl { get { throw null; } set { } }
+        public string TargetFrameworkProfile { get { throw null; } set { } }
+        public string TargetFrameworkSubset { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem TrustInfoFile { get { throw null; } set { } }
+        public bool UseApplicationTrust { get { throw null; } set { } }
+        protected override System.Type GetObjectType() { throw null; }
+        protected override bool OnManifestLoaded(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+        protected override bool OnManifestResolved(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+        protected internal override bool ValidateInputs() { throw null; }
+    }
+    public partial class GenerateBindingRedirects : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GenerateBindingRedirects() { }
+        public Microsoft.Build.Framework.ITaskItem AppConfigFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputAppConfigFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem[] SuggestedRedirects { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string TargetName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class GenerateBootstrapper : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GenerateBootstrapper() { }
+        public string ApplicationFile { get { throw null; } set { } }
+        public string ApplicationName { get { throw null; } set { } }
+        public bool ApplicationRequiresElevation { get { throw null; } set { } }
+        public string ApplicationUrl { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string[] BootstrapperComponentFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] BootstrapperItems { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string BootstrapperKeyFile { get { throw null; } set { } }
+        public string ComponentsLocation { get { throw null; } set { } }
+        public string ComponentsUrl { get { throw null; } set { } }
+        public bool CopyComponents { get { throw null; } set { } }
+        public string Culture { get { throw null; } set { } }
+        public string FallbackCulture { get { throw null; } set { } }
+        public string OutputPath { get { throw null; } set { } }
+        public string Path { get { throw null; } set { } }
+        public string SupportUrl { get { throw null; } set { } }
+        public bool Validate { get { throw null; } set { } }
+        public string VisualStudioVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class GenerateDeploymentManifest : Microsoft.Build.Tasks.GenerateManifestBase
+    {
+        public GenerateDeploymentManifest() { }
+        public bool CreateDesktopShortcut { get { throw null; } set { } }
+        public string DeploymentUrl { get { throw null; } set { } }
+        public bool DisallowUrlActivation { get { throw null; } set { } }
+        public string ErrorReportUrl { get { throw null; } set { } }
+        public bool Install { get { throw null; } set { } }
+        public bool MapFileExtensions { get { throw null; } set { } }
+        public string MinimumRequiredVersion { get { throw null; } set { } }
+        public string Product { get { throw null; } set { } }
+        public string Publisher { get { throw null; } set { } }
+        public string SuiteName { get { throw null; } set { } }
+        public string SupportUrl { get { throw null; } set { } }
+        public bool TrustUrlParameters { get { throw null; } set { } }
+        public bool UpdateEnabled { get { throw null; } set { } }
+        public int UpdateInterval { get { throw null; } set { } }
+        public string UpdateMode { get { throw null; } set { } }
+        public string UpdateUnit { get { throw null; } set { } }
+        protected override System.Type GetObjectType() { throw null; }
+        protected override bool OnManifestLoaded(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+        protected override bool OnManifestResolved(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+        protected internal override bool ValidateInputs() { throw null; }
+    }
+    public abstract partial class GenerateManifestBase : Microsoft.Build.Utilities.Task
+    {
+        protected GenerateManifestBase() { }
+        public string AssemblyName { get { throw null; } set { } }
+        public string AssemblyVersion { get { throw null; } set { } }
+        public string Description { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem InputManifest { get { throw null; } set { } }
+        public int MaxTargetPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputManifest { get { throw null; } set { } }
+        public string Platform { get { throw null; } set { } }
+        public string TargetCulture { get { throw null; } set { } }
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        protected internal Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference AddAssemblyFromItem(Microsoft.Build.Framework.ITaskItem item) { throw null; }
+        protected internal Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference AddAssemblyNameFromItem(Microsoft.Build.Framework.ITaskItem item, Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReferenceType referenceType) { throw null; }
+        protected internal Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference AddEntryPointFromItem(Microsoft.Build.Framework.ITaskItem item, Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReferenceType referenceType) { throw null; }
+        protected internal Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference AddFileFromItem(Microsoft.Build.Framework.ITaskItem item) { throw null; }
+        public override bool Execute() { throw null; }
+        protected internal Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference FindFileFromItem(Microsoft.Build.Framework.ITaskItem item) { throw null; }
+        protected abstract System.Type GetObjectType();
+        protected abstract bool OnManifestLoaded(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest);
+        protected abstract bool OnManifestResolved(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest);
+        protected internal virtual bool ValidateInputs() { throw null; }
+        protected internal virtual bool ValidateOutput() { throw null; }
+    }
+    [Microsoft.Build.Framework.RequiredRuntimeAttribute("v2.0")]
+    public sealed partial class GenerateResource : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GenerateResource() { }
+        public Microsoft.Build.Framework.ITaskItem[] AdditionalInputs { get { throw null; } set { } }
+        public string[] EnvironmentVariables { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ExcludedInputPaths { get { throw null; } set { } }
+        public bool ExecuteAsTool { get { throw null; } set { } }
+        public bool ExtractResWFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] FilesWritten { get { throw null; } }
+        public bool MinimalRebuildFromTracking { get { throw null; } set { } }
+        public bool NeverLockTypeAssemblies { get { throw null; } set { } }
+        public string OutputDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] OutputResources { get { throw null; } set { } }
+        public bool PublicClass { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] References { get { throw null; } set { } }
+        public string SdkToolsPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Sources { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem StateFile { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string StronglyTypedClassName { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string StronglyTypedFileName { get { throw null; } set { } }
+        public string StronglyTypedLanguage { get { throw null; } set { } }
+        public string StronglyTypedManifestPrefix { get { throw null; } set { } }
+        public string StronglyTypedNamespace { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TLogReadFiles { get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] TLogWriteFiles { get { throw null; } }
+        public string ToolArchitecture { get { throw null; } set { } }
+        public string TrackerFrameworkPath { get { throw null; } set { } }
+        public string TrackerLogDirectory { get { throw null; } set { } }
+        public string TrackerSdkPath { get { throw null; } set { } }
+        public bool TrackFileAccess { get { throw null; } set { } }
+        public bool UseSourcePath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class GenerateTrustInfo : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GenerateTrustInfo() { }
+        public Microsoft.Build.Framework.ITaskItem[] ApplicationDependencies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem BaseManifest { get { throw null; } set { } }
+        public string ExcludedPermissions { get { throw null; } set { } }
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+        public string TargetZone { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem TrustInfoFile { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class GetAssemblyIdentity : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GetAssemblyIdentity() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class GetFrameworkPath : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GetFrameworkPath() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion11Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion20Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion30Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion35Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion40Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion451Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion452Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion45Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion461Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion46Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string Path { get { throw null; } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class GetFrameworkSdkPath : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GetFrameworkSdkPath() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkSdkVersion20Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkSdkVersion35Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkSdkVersion40Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkSdkVersion451Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkSdkVersion45Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkSdkVersion461Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkSdkVersion46Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string Path { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class GetInstalledSDKLocations : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GetInstalledSDKLocations() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] InstalledSDKs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string[] SDKDirectoryRoots { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string[] SDKExtensionDirectoryRoots { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string SDKRegistryRoot { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class GetReferenceAssemblyPaths : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GetReferenceAssemblyPaths() { }
+        public bool BypassFrameworkInstallChecks { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string[] FullFrameworkReferenceAssemblyPaths { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string[] ReferenceAssemblyPaths { get { throw null; } }
+        public string RootPath { get { throw null; } set { } }
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string TargetFrameworkMonikerDisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class GetSDKReferenceFiles : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GetSDKReferenceFiles() { }
+        public string CacheFileFolderPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] CopyLocalFiles { get { throw null; } }
+        public bool LogCacheFileExceptions { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool LogRedistConflictBetweenSDKsAsWarning { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool LogRedistConflictWithinSDKAsWarning { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool LogRedistFilesList { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool LogReferenceConflictBetweenSDKsAsWarning { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool LogReferenceConflictWithinSDKAsWarning { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool LogReferencesList { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] RedistFiles { get { throw null; } }
+        public string[] ReferenceExtensions { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] References { get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedSDKReferences { get { throw null; } set { } }
+        public string TargetSDKIdentifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string TargetSDKVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
+    [System.Runtime.InteropServices.GuidAttribute("00020401-0000-0000-C000-000000000046")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface IFixedTypeInfo
+    {
+        void AddressOfMember(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, out System.IntPtr ppv);
+        void CreateInstance(object pUnkOuter, ref System.Guid riid, out object ppvObj);
+        void GetContainingTypeLib(out System.Runtime.InteropServices.ComTypes.ITypeLib ppTLB, out int pIndex);
+        void GetDllEntry(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, System.IntPtr pBstrDllName, System.IntPtr pBstrName, System.IntPtr pwOrdinal);
+        void GetDocumentation(int index, out string strName, out string strDocString, out int dwHelpContext, out string strHelpFile);
+        void GetFuncDesc(int index, out System.IntPtr ppFuncDesc);
+        void GetIDsOfNames(string[] rgszNames, int cNames, int[] pMemId);
+        void GetImplTypeFlags(int index, out System.Runtime.InteropServices.ComTypes.IMPLTYPEFLAGS pImplTypeFlags);
+        void GetMops(int memid, out string pBstrMops);
+        void GetNames(int memid, string[] rgBstrNames, int cMaxNames, out int pcNames);
+        void GetRefTypeInfo(System.IntPtr hRef, out Microsoft.Build.Tasks.IFixedTypeInfo ppTI);
+        void GetRefTypeOfImplType(int index, out System.IntPtr href);
+        void GetTypeAttr(out System.IntPtr ppTypeAttr);
+        void GetTypeComp(out System.Runtime.InteropServices.ComTypes.ITypeComp ppTComp);
+        void GetVarDesc(int index, out System.IntPtr ppVarDesc);
+        void Invoke(object pvInstance, int memid, short wFlags, ref System.Runtime.InteropServices.ComTypes.DISPPARAMS pDispParams, System.IntPtr pVarResult, System.IntPtr pExcepInfo, out int puArgErr);
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.PreserveSig)]void ReleaseFuncDesc(System.IntPtr pFuncDesc);
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.PreserveSig)]void ReleaseTypeAttr(System.IntPtr pTypeAttr);
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.PreserveSig)]void ReleaseVarDesc(System.IntPtr pVarDesc);
+    }
+    public partial class LC : Microsoft.Build.Tasks.ToolTaskExtension
+    {
+        public LC() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem LicenseTarget { get { throw null; } set { } }
+        public bool NoLogo { get { throw null; } set { } }
+        public string OutputDirectory { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputLicense { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ReferencedAssemblies { get { throw null; } set { } }
+        public string SdkToolsPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Sources { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetFrameworkVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        protected override string ToolName { get { throw null; } }
+        protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected internal override void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected override string GenerateFullPathToTool() { throw null; }
+        protected override bool ValidateParameters() { throw null; }
+    }
+    public partial class MakeDir : Microsoft.Build.Tasks.TaskExtension
+    {
+        public MakeDir() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Directories { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] DirectoriesCreated { get { throw null; } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class Message : Microsoft.Build.Tasks.TaskExtension
+    {
+        public Message() { }
+        public string Code { get { throw null; } set { } }
+        public string File { get { throw null; } set { } }
+        public string HelpKeyword { get { throw null; } set { } }
+        public string Importance { get { throw null; } set { } }
+        public bool IsCritical { get { throw null; } set { } }
+        public string Text { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class Move : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
+    {
+        public Move() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem DestinationFolder { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] MovedFiles { get { throw null; } }
+        public bool OverwriteReadOnlyFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SourceFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void Cancel() { }
+        public override bool Execute() { throw null; }
+    }
+    [Microsoft.Build.Framework.RunInMTAAttribute]
+    public partial class MSBuild : Microsoft.Build.Tasks.TaskExtension
+    {
+        public MSBuild() { }
+        public bool BuildInParallel { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Projects { get { throw null; } set { } }
+        public string[] Properties { get { throw null; } set { } }
+        public bool RebaseOutputs { get { throw null; } set { } }
+        public string RemoveProperties { get { throw null; } set { } }
+        public bool RunEachTargetSeparately { get { throw null; } set { } }
+        public string SkipNonexistentProjects { get { throw null; } set { } }
+        public bool StopOnFirstFailure { get { throw null; } set { } }
+        public string[] TargetAndPropertyListSeparators { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] TargetOutputs { get { throw null; } }
+        public string[] Targets { get { throw null; } set { } }
+        public string ToolsVersion { get { throw null; } set { } }
+        public bool UnloadProjectsOnCompletion { get { throw null; } set { } }
+        public bool UseResultsCache { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class ReadLinesFromFile : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ReadLinesFromFile() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem File { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Lines { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class RegisterAssembly : Microsoft.Build.Tasks.AppDomainIsolatedTaskExtension, System.Runtime.InteropServices.ITypeLibExporterNotifySink
+    {
+        public RegisterAssembly() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem AssemblyListFile { get { throw null; } set { } }
+        public bool CreateCodeBase { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+        public void ReportEvent(System.Runtime.InteropServices.ExporterEventKind kind, int code, string msg) { }
+        public object ResolveRef(System.Reflection.Assembly assemblyToResolve) { throw null; }
+    }
+    public partial class RemoveDir : Microsoft.Build.Tasks.TaskExtension
+    {
+        public RemoveDir() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Directories { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] RemovedDirectories { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class RemoveDuplicates : Microsoft.Build.Tasks.TaskExtension
+    {
+        public RemoveDuplicates() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Filtered { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Inputs { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class RequiresFramework35SP1Assembly : Microsoft.Build.Tasks.TaskExtension
+    {
+        public RequiresFramework35SP1Assembly() { }
+        public Microsoft.Build.Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+        public bool CreateDesktopShortcut { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem DeploymentManifestEntryPoint { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+        public string ErrorReportUrl { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ReferencedAssemblies { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public bool RequiresMinimumFramework35SP1 { get { throw null; } set { } }
+        public bool SigningManifests { get { throw null; } set { } }
+        public string SuiteName { get { throw null; } set { } }
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class ResolveAssemblyReference : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ResolveAssemblyReference() { }
+        public string[] AllowedAssemblyExtensions { get { throw null; } set { } }
+        public string[] AllowedRelatedFileExtensions { get { throw null; } set { } }
+        public string AppConfigFile { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
+        public bool AutoUnify { get { throw null; } set { } }
+        public string[] CandidateAssemblyFiles { get { throw null; } set { } }
+        public bool CopyLocalDependenciesWhenParentReferenceInGac { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] CopyLocalFiles { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string DependsOnSystemRuntime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool DoNotCopyLocalIfInGac { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] FilesWritten { get { throw null; } set { } }
+        public bool FindDependencies { get { throw null; } set { } }
+        public bool FindRelatedFiles { get { throw null; } set { } }
+        public bool FindSatellites { get { throw null; } set { } }
+        public bool FindSerializationAssemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] FullFrameworkAssemblyTables { get { throw null; } set { } }
+        public string[] FullFrameworkFolders { get { throw null; } set { } }
+        public string[] FullTargetFrameworkSubsetNames { get { throw null; } set { } }
+        public bool IgnoreDefaultInstalledAssemblySubsetTables { get { throw null; } set { } }
+        public bool IgnoreDefaultInstalledAssemblyTables { get { throw null; } set { } }
+        public bool IgnoreTargetFrameworkAttributeVersionMismatch { get { throw null; } set { } }
+        public bool IgnoreVersionForFrameworkReferences { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] InstalledAssemblySubsetTables { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] InstalledAssemblyTables { get { throw null; } set { } }
+        public string[] LatestTargetFrameworkDirectories { get { throw null; } set { } }
+        public string ProfileName { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] RelatedFiles { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedDependencyFiles { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedFiles { get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedSDKReferences { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SatelliteFiles { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ScatterFiles { get { throw null; } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string[] SearchPaths { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SerializationAssemblyFiles { get { throw null; } }
+        public bool Silent { get { throw null; } set { } }
+        public string StateFile { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SuggestedRedirects { get { throw null; } }
+        public bool SupportsBindingRedirectGeneration { get { throw null; } set { } }
+        public string TargetedRuntimeVersion { get { throw null; } set { } }
+        public string[] TargetFrameworkDirectories { get { throw null; } set { } }
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+        public string TargetFrameworkMonikerDisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string[] TargetFrameworkSubsets { get { throw null; } set { } }
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        public string TargetProcessorArchitecture { get { throw null; } set { } }
+        public bool UnresolveFrameworkAssembliesFromHigherFrameworks { get { throw null; } set { } }
+        public string WarnOrErrorOnTargetArchitectureMismatch { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class ResolveCodeAnalysisRuleSet : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ResolveCodeAnalysisRuleSet() { }
+        public string CodeAnalysisRuleSet { get { throw null; } set { } }
+        public string[] CodeAnalysisRuleSetDirectories { get { throw null; } set { } }
+        public string MSBuildProjectDirectory { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string ResolvedCodeAnalysisRuleSet { get { throw null; } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class ResolveComReference : Microsoft.Build.Tasks.AppDomainIsolatedTaskExtension
+    {
+        public ResolveComReference() { }
+        public bool DelaySign { get { throw null; } set { } }
+        public string[] EnvironmentVariables { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool ExecuteAsTool { get { throw null; } set { } }
+        public bool IncludeVersionInInteropName { get { throw null; } set { } }
+        public string KeyContainer { get { throw null; } set { } }
+        public string KeyFile { get { throw null; } set { } }
+        public bool NoClassMembers { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedAssemblyReferences { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedFiles { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedModules { get { throw null; } set { } }
+        public string SdkToolsPath { get { throw null; } set { } }
+        public bool Silent { get { throw null; } set { } }
+        public string StateFile { get { throw null; } set { } }
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        public string TargetProcessorArchitecture { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TypeLibNames { get { throw null; } set { } }
+        public string WrapperOutputDirectory { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class ResolveKeySource : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ResolveKeySource() { }
+        public int AutoClosePasswordPromptShow { get { throw null; } set { } }
+        public int AutoClosePasswordPromptTimeout { get { throw null; } set { } }
+        public string CertificateFile { get { throw null; } set { } }
+        public string CertificateThumbprint { get { throw null; } set { } }
+        public string KeyFile { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string ResolvedKeyContainer { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string ResolvedKeyFile { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string ResolvedThumbprint { get { throw null; } set { } }
+        public bool ShowImportDialogDespitePreviousFailures { get { throw null; } set { } }
+        public bool SuppressAutoClosePasswordPrompt { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class ResolveManifestFiles : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ResolveManifestFiles() { }
+        public Microsoft.Build.Framework.ITaskItem DeploymentManifestEntryPoint { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ExtraFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ManagedAssemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] NativeAssemblies { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] OutputAssemblies { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputDeploymentManifestEntryPoint { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] OutputFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] PublishFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] SatelliteAssemblies { get { throw null; } set { } }
+        public bool SigningManifests { get { throw null; } set { } }
+        public string TargetCulture { get { throw null; } set { } }
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class ResolveNativeReference : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ResolveNativeReference() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string[] AdditionalSearchPaths { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ContainedComComponents { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ContainedLooseEtcFiles { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ContainedLooseTlbFiles { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ContainedPrerequisiteAssemblies { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ContainedTypeLibraries { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ContainingReferenceFiles { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] NativeReferences { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class ResolveNonMSBuildProjectOutput : Microsoft.Build.Tasks.ResolveProjectBase
+    {
+        public ResolveNonMSBuildProjectOutput() { }
+        public string PreresolvedProjectOutputs { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedOutputPaths { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] UnresolvedProjectReferences { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public abstract partial class ResolveProjectBase : Microsoft.Build.Tasks.TaskExtension
+    {
+        protected ResolveProjectBase() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ProjectReferences { get { throw null; } set { } }
+        protected void AddSyntheticProjectReferences(string currentProjectAbsolutePath) { }
+        protected System.Xml.XmlElement GetProjectElement(Microsoft.Build.Framework.ITaskItem projectRef) { throw null; }
+        protected string GetProjectItem(Microsoft.Build.Framework.ITaskItem projectRef) { throw null; }
+    }
+    public partial class ResolveSDKReference : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ResolveSDKReference() { }
+        public Microsoft.Build.Framework.ITaskItem[] DisallowedSDKDependencies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] InstalledSDKs { get { throw null; } set { } }
+        public bool LogResolutionErrorsAsWarnings { get { throw null; } set { } }
+        public bool Prefer32Bit { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string ProjectName { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] References { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedSDKReferences { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] RuntimeReferenceOnlySDKDependencies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SDKReferences { get { throw null; } set { } }
+        public string TargetedSDKArchitecture { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string TargetedSDKConfiguration { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+        public bool WarnOnMissingPlatformVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class SGen : Microsoft.Build.Tasks.ToolTaskExtension
+    {
+        public SGen() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string BuildAssemblyName { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string BuildAssemblyPath { get { throw null; } set { } }
+        public bool DelaySign { get { throw null; } set { } }
+        public string KeyContainer { get { throw null; } set { } }
+        public string KeyFile { get { throw null; } set { } }
+        public string Platform { get { throw null; } set { } }
+        public string[] References { get { throw null; } set { } }
+        public string SdkToolsPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SerializationAssembly { get { throw null; } set { } }
+        public string SerializationAssemblyName { get { throw null; } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public bool ShouldGenerateSerializer { get { throw null; } set { } }
+        protected override string ToolName { get { throw null; } }
+        public string[] Types { get { throw null; } set { } }
+        public bool UseKeep { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public bool UseProxyTypes { get { throw null; } set { } }
+        protected override string GenerateCommandLineCommands() { throw null; }
+        protected override string GenerateFullPathToTool() { throw null; }
+        protected override bool SkipTaskExecution() { throw null; }
+        protected override bool ValidateParameters() { throw null; }
+    }
+    public sealed partial class SignFile : Microsoft.Build.Utilities.Task
+    {
+        public SignFile() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string CertificateThumbprint { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem SigningTarget { get { throw null; } set { } }
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        public string TimestampUrl { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public abstract partial class TaskExtension : Microsoft.Build.Utilities.Task
+    {
+        internal TaskExtension() { }
+        public new Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
+    }
+    public partial class TaskLoggingHelperExtension : Microsoft.Build.Utilities.TaskLoggingHelper
+    {
+        public TaskLoggingHelperExtension(Microsoft.Build.Framework.ITask taskInstance, System.Resources.ResourceManager primaryResources, System.Resources.ResourceManager sharedResources, string helpKeywordPrefix) : base (default(Microsoft.Build.Framework.ITask)) { }
+        public System.Resources.ResourceManager TaskSharedResources { get { throw null; } set { } }
+        public override string FormatResourceString(string resourceName, params object[] args) { throw null; }
+    }
+    public abstract partial class ToolTaskExtension : Microsoft.Build.Utilities.ToolTask
+    {
+        internal ToolTaskExtension() { }
+        protected internal System.Collections.Hashtable Bag { get { throw null; } }
+        protected override bool HasLoggedErrors { get { throw null; } }
+        public new Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
+        protected internal virtual void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected internal virtual void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected override string GenerateCommandLineCommands() { throw null; }
+        protected override string GenerateResponseFileCommands() { throw null; }
+        protected internal bool GetBoolParameterWithDefault(string parameterName, bool defaultValue) { throw null; }
+        protected internal int GetIntParameterWithDefault(string parameterName, int defaultValue) { throw null; }
+    }
+    public partial class Touch : Microsoft.Build.Tasks.TaskExtension
+    {
+        public Touch() { }
+        public bool AlwaysCreate { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
+        public bool ForceTouch { get { throw null; } set { } }
+        public string Time { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] TouchedFiles { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class UnregisterAssembly : Microsoft.Build.Tasks.AppDomainIsolatedTaskExtension
+    {
+        public UnregisterAssembly() { }
+        public Microsoft.Build.Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem AssemblyListFile { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class UpdateManifest : Microsoft.Build.Utilities.Task
+    {
+        public UpdateManifest() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem ApplicationManifest { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string ApplicationPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem InputManifest { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputManifest { get { throw null; } set { } }
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class Warning : Microsoft.Build.Tasks.TaskExtension
+    {
+        public Warning() { }
+        public string Code { get { throw null; } set { } }
+        public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string HelpKeyword { get { throw null; } set { } }
+        public string Text { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class WinMDExp : Microsoft.Build.Tasks.ToolTaskExtension
+    {
+        public WinMDExp() { }
+        public string AssemblyUnificationPolicy { get { throw null; } set { } }
+        public string DisabledWarnings { get { throw null; } set { } }
+        public string InputDocumentationFile { get { throw null; } set { } }
+        public string InputPDBFile { get { throw null; } set { } }
+        public string OutputDocumentationFile { get { throw null; } set { } }
+        public string OutputPDBFile { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string OutputWindowsMetadataFile { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] References { get { throw null; } set { } }
+        public string SdkToolsPath { get { throw null; } set { } }
+        protected override System.Text.Encoding StandardErrorEncoding { get { throw null; } }
+        protected override System.Text.Encoding StandardOutputEncoding { get { throw null; } }
+        protected override string ToolName { get { throw null; } }
+        public bool TreatWarningsAsErrors { get { throw null; } set { } }
+        public bool UTF8Output { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string WinMDModule { get { throw null; } set { } }
+        protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected override string GenerateFullPathToTool() { throw null; }
+        protected override bool SkipTaskExecution() { throw null; }
+        protected override bool ValidateParameters() { throw null; }
+    }
+    public partial class WriteCodeFragment : Microsoft.Build.Tasks.TaskExtension
+    {
+        public WriteCodeFragment() { }
+        public Microsoft.Build.Framework.ITaskItem[] AssemblyAttributes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string Language { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem OutputDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem OutputFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class WriteLinesToFile : Microsoft.Build.Tasks.TaskExtension
+    {
+        public WriteLinesToFile() { }
+        public string Encoding { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem File { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Lines { get { throw null; } set { } }
+        public bool Overwrite { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class XamlTaskFactory : Microsoft.Build.Framework.ITaskFactory
+    {
+        public XamlTaskFactory() { }
+        public string FactoryName { get { throw null; } }
+        public string TaskElementContents { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string TaskName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string TaskNamespace { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Type TaskType { get { throw null; } }
+        public void CleanupTask(Microsoft.Build.Framework.ITask task) { }
+        public Microsoft.Build.Framework.ITask CreateTask(Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+        public Microsoft.Build.Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.TaskPropertyInfo> taskParameters, string taskElementContents, Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
+    public partial class XmlPeek : Microsoft.Build.Tasks.TaskExtension
+    {
+        public XmlPeek() { }
+        public string Namespaces { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Result { get { throw null; } }
+        public string XmlContent { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class XmlPoke : Microsoft.Build.Tasks.TaskExtension
+    {
+        public XmlPoke() { }
+        public string Namespaces { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem Value { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class XslTransformation : Microsoft.Build.Tasks.TaskExtension
+    {
+        public XslTransformation() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] OutputPaths { get { throw null; } set { } }
+        public string Parameters { get { throw null; } set { } }
+        public bool UseTrustedSettings { get { throw null; } set { } }
+        public string XmlContent { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] XmlInputPaths { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem XslCompiledDllPath { get { throw null; } set { } }
+        public string XslContent { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem XslInputPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+}
+namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
+{
+    [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("1D9FE38A-0226-4b95-9C6B-6DFFA2236270")]
+    public partial class BootstrapperBuilder : Microsoft.Build.Tasks.Deployment.Bootstrapper.IBootstrapperBuilder
+    {
+        public BootstrapperBuilder() { }
+        public BootstrapperBuilder(string visualStudioVersion) { }
+        public string Path { get { throw null; } set { } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductCollection Products { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildResults Build(Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildSettings settings) { throw null; }
+        public string[] GetOutputFolders(string[] productCodes, string culture, string fallbackCulture, Microsoft.Build.Tasks.Deployment.Bootstrapper.ComponentsLocation componentsLocation) { throw null; }
+    }
+    public partial class BuildMessage : Microsoft.Build.Tasks.Deployment.Bootstrapper.IBuildMessage
+    {
+        internal BuildMessage() { }
+        public int HelpId { get { throw null; } }
+        public string HelpKeyword { get { throw null; } }
+        public string Message { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildMessageSeverity Severity { get { throw null; } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("936D32F9-1A68-4d5e-98EA-044AC9A1AADA")]
+    public enum BuildMessageSeverity
+    {
+        Error = 2,
+        Info = 0,
+        Warning = 1,
+    }
+    [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("FAD7BA7C-CA00-41e0-A5EF-2DA9A74E58E6")]
+    public partial class BuildResults : Microsoft.Build.Tasks.Deployment.Bootstrapper.IBuildResults
+    {
+        internal BuildResults() { }
+        public string[] ComponentFiles { get { throw null; } }
+        public string KeyFile { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildMessage[] Messages { get { throw null; } }
+        public bool Succeeded { get { throw null; } }
+    }
+    [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("5D13802C-C830-4b41-8E7A-F69D9DD6A095")]
+    public partial class BuildSettings : Microsoft.Build.Tasks.Deployment.Bootstrapper.IBuildSettings
+    {
+        public BuildSettings() { }
+        public string ApplicationFile { get { throw null; } set { } }
+        public string ApplicationName { get { throw null; } set { } }
+        public bool ApplicationRequiresElevation { get { throw null; } set { } }
+        public string ApplicationUrl { get { throw null; } set { } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.ComponentsLocation ComponentsLocation { get { throw null; } set { } }
+        public string ComponentsUrl { get { throw null; } set { } }
+        public bool CopyComponents { get { throw null; } set { } }
+        public int FallbackLCID { get { throw null; } set { } }
+        public int LCID { get { throw null; } set { } }
+        public string OutputPath { get { throw null; } set { } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductBuilderCollection ProductBuilders { get { throw null; } }
+        public string SupportUrl { get { throw null; } set { } }
+        public bool Validate { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("12F49949-7B60-49CD-B6A0-2B5E4A638AAF")]
+    public enum ComponentsLocation
+    {
+        Absolute = 2,
+        HomeSite = 0,
+        Relative = 1,
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("1D202366-5EEA-4379-9255-6F8CDB8587C9")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(0))]
+    public partial interface IBootstrapperBuilder
+    {
+        [System.Runtime.InteropServices.DispIdAttribute(1)]
+        string Path { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(4)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductCollection Products { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(5)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildResults Build(Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildSettings settings);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("E3C981EA-99E6-4f48-8955-1AAFDFB5ACE4")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(0))]
+    public partial interface IBuildMessage
+    {
+        [System.Runtime.InteropServices.DispIdAttribute(4)]
+        int HelpId { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(3)]
+        string HelpKeyword { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(2)]
+        string Message { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(1)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildMessageSeverity Severity { get; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("586B842C-D9C7-43b8-84E4-9CFC3AF9F13B")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(0))]
+    public partial interface IBuildResults
+    {
+        [System.Runtime.InteropServices.DispIdAttribute(3)]
+        string[] ComponentFiles { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(2)]
+        string KeyFile { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(4)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.BuildMessage[] Messages { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(1)]
+        bool Succeeded { get; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("87EEBC69-0948-4ce6-A2DE-819162B87CC6")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(0))]
+    public partial interface IBuildSettings
+    {
+        [System.Runtime.InteropServices.DispIdAttribute(2)]
+        string ApplicationFile { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(1)]
+        string ApplicationName { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(13)]
+        bool ApplicationRequiresElevation { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(3)]
+        string ApplicationUrl { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(11)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.ComponentsLocation ComponentsLocation { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(4)]
+        string ComponentsUrl { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(5)]
+        bool CopyComponents { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(7)]
+        int FallbackLCID { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(6)]
+        int LCID { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(8)]
+        string OutputPath { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(9)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductBuilderCollection ProductBuilders { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(12)]
+        string SupportUrl { get; set; }
+        [System.Runtime.InteropServices.DispIdAttribute(10)]
+        bool Validate { get; set; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("9E81BE3D-530F-4a10-8349-5D5947BA59AD")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(0))]
+    public partial interface IProduct
+    {
+        [System.Runtime.InteropServices.DispIdAttribute(4)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductCollection Includes { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(2)]
+        string Name { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(1)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductBuilder ProductBuilder { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(3)]
+        string ProductCode { get; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("0777432F-A60D-48b3-83DB-90326FE8C96E")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(0))]
+    public partial interface IProductBuilder
+    {
+        [System.Runtime.InteropServices.DispIdAttribute(1)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.Product Product { get; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("0D593FC0-E3F1-4dad-A674-7EA4D327F79B")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(0))]
+    public partial interface IProductBuilderCollection
+    {
+        [System.Runtime.InteropServices.DispIdAttribute(2)]
+        void Add(Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductBuilder builder);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("63F63663-8503-4875-814C-09168E595367")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(0))]
+    public partial interface IProductCollection
+    {
+        [System.Runtime.InteropServices.DispIdAttribute(1)]
+        int Count { get; }
+        [System.Runtime.InteropServices.DispIdAttribute(2)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.Product Item(int index);
+        [System.Runtime.InteropServices.DispIdAttribute(3)]
+        Microsoft.Build.Tasks.Deployment.Bootstrapper.Product Product(string productCode);
+    }
+    [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("532BF563-A85D-4088-8048-41F51AC5239F")]
+    public partial class Product : Microsoft.Build.Tasks.Deployment.Bootstrapper.IProduct
+    {
+        public Product() { }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductCollection Includes { get { throw null; } }
+        public string Name { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductBuilder ProductBuilder { get { throw null; } }
+        public string ProductCode { get { throw null; } }
+    }
+    public partial class ProductBuilder : Microsoft.Build.Tasks.Deployment.Bootstrapper.IProductBuilder
+    {
+        internal ProductBuilder() { }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.Product Product { get { throw null; } }
+    }
+    [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("D25C0741-99CA-49f7-9460-95E5F25EEF43")]
+    public partial class ProductBuilderCollection : Microsoft.Build.Tasks.Deployment.Bootstrapper.IProductBuilderCollection, System.Collections.IEnumerable
+    {
+        internal ProductBuilderCollection() { }
+        public void Add(Microsoft.Build.Tasks.Deployment.Bootstrapper.ProductBuilder builder) { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+    [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("EFFA164B-3E87-4195-88DB-8AC004DDFE2A")]
+    public partial class ProductCollection : Microsoft.Build.Tasks.Deployment.Bootstrapper.IProductCollection, System.Collections.IEnumerable
+    {
+        internal ProductCollection() { }
+        public int Count { get { throw null; } }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.Product Item(int index) { throw null; }
+        public Microsoft.Build.Tasks.Deployment.Bootstrapper.Product Product(string productCode) { throw null; }
+    }
+}
+namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
+{
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class ApplicationIdentity
+    {
+        public ApplicationIdentity(string url, Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity deployManifestIdentity, Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity applicationManifestIdentity) { }
+        public ApplicationIdentity(string url, string deployManifestPath, string applicationManifestPath) { }
+        public override string ToString() { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    [System.Xml.Serialization.XmlRootAttribute("ApplicationManifest")]
+    public sealed partial class ApplicationManifest : Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyManifest
+    {
+        public ApplicationManifest() { }
+        public ApplicationManifest(string targetFrameworkVersion) { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ConfigFile { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public override Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference EntryPoint { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ErrorReportUrl { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileAssociationCollection FileAssociations { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool HostInBrowser { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string IconFile { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool IsClickOnceManifest { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public int MaxTargetPath { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string OSDescription { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string OSSupportUrl { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string OSVersion { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Product { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Publisher { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string SuiteName { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string SupportUrl { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.TrustInfo TrustInfo { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool UseApplicationTrust { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("ConfigFile")]
+        public string XmlConfigFile { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlElementAttribute("EntryPointIdentity")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity XmlEntryPointIdentity { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("EntryPointParameters")]
+        public string XmlEntryPointParameters { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("EntryPointPath")]
+        public string XmlEntryPointPath { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("ErrorReportUrl")]
+        public string XmlErrorReportUrl { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlArrayAttribute("FileAssociations")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileAssociation[] XmlFileAssociations { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("HostInBrowser")]
+        public string XmlHostInBrowser { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("IconFile")]
+        public string XmlIconFile { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("IsClickOnceManifest")]
+        public string XmlIsClickOnceManifest { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("OSBuild")]
+        public string XmlOSBuild { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("OSDescription")]
+        public string XmlOSDescription { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("OSMajor")]
+        public string XmlOSMajor { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("OSMinor")]
+        public string XmlOSMinor { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("OSRevision")]
+        public string XmlOSRevision { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("OSSupportUrl")]
+        public string XmlOSSupportUrl { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Product")]
+        public string XmlProduct { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Publisher")]
+        public string XmlPublisher { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("SuiteName")]
+        public string XmlSuiteName { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("SupportUrl")]
+        public string XmlSupportUrl { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("UseApplicationTrust")]
+        public string XmlUseApplicationTrust { get { throw null; } set { } }
+        public override void Validate() { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    [System.Xml.Serialization.XmlRootAttribute("AssemblyIdentity")]
+    public sealed partial class AssemblyIdentity
+    {
+        public AssemblyIdentity() { }
+        public AssemblyIdentity(Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity identity) { }
+        public AssemblyIdentity(string name) { }
+        public AssemblyIdentity(string name, string version) { }
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture) { }
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture, string processorArchitecture) { }
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture, string processorArchitecture, string type) { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Culture { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool IsFrameworkAssembly { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool IsNeutralPlatform { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool IsStrongName { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Name { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ProcessorArchitecture { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string PublicKeyToken { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Type { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Version { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Culture")]
+        public string XmlCulture { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Name")]
+        public string XmlName { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("ProcessorArchitecture")]
+        public string XmlProcessorArchitecture { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("PublicKeyToken")]
+        public string XmlPublicKeyToken { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Type")]
+        public string XmlType { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Version")]
+        public string XmlVersion { get { throw null; } set { } }
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity FromAssemblyName(string assemblyName) { throw null; }
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity FromFile(string path) { throw null; }
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity FromManagedAssembly(string path) { throw null; }
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity FromManifest(string path) { throw null; }
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity FromNativeAssembly(string path) { throw null; }
+        public string GetFullName(Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity.FullNameFlags flags) { throw null; }
+        public bool IsInFramework(string frameworkIdentifier, string frameworkVersion) { throw null; }
+        public override string ToString() { throw null; }
+        [System.FlagsAttribute]
+        public enum FullNameFlags
+        {
+            All = 3,
+            Default = 0,
+            ProcessorArchitecture = 1,
+            Type = 2,
+        }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    [System.Xml.Serialization.XmlRootAttribute("AssemblyManifest")]
+    public partial class AssemblyManifest : Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest
+    {
+        public AssemblyManifest() { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.ProxyStub[] ExternalProxyStubs { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlArrayAttribute("ExternalProxyStubs")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.ProxyStub[] XmlExternalProxyStubs { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class AssemblyReference : Microsoft.Build.Tasks.Deployment.ManifestUtilities.BaseReference
+    {
+        public AssemblyReference() { }
+        public AssemblyReference(string path) { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity AssemblyIdentity { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool IsPrerequisite { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReferenceType ReferenceType { get { throw null; } set { } }
+        protected internal override string SortName { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlElementAttribute("AssemblyIdentity")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity XmlAssemblyIdentity { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("IsNative")]
+        public string XmlIsNative { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("IsPrerequisite")]
+        public string XmlIsPrerequisite { get { throw null; } set { } }
+        public override string ToString() { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class AssemblyReferenceCollection : System.Collections.IEnumerable
+    {
+        internal AssemblyReferenceCollection() { }
+        public int Count { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference this[int index] { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference Add(Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference assembly) { throw null; }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference Add(string path) { throw null; }
+        public void Clear() { }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference Find(Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity identity) { throw null; }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference Find(string name) { throw null; }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference FindTargetPath(string targetPath) { throw null; }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public void Remove(Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference assemblyReference) { }
+    }
+    public enum AssemblyReferenceType
+    {
+        ClickOnceManifest = 1,
+        ManagedAssembly = 2,
+        NativeAssembly = 3,
+        Unspecified = 0,
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public abstract partial class BaseReference
+    {
+        protected internal BaseReference() { }
+        protected internal BaseReference(string path) { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Group { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Hash { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool IsOptional { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ResolvedPath { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public long Size { get { throw null; } set { } }
+        protected internal abstract string SortName { get; }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string SourcePath { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string TargetPath { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Group")]
+        public string XmlGroup { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Hash")]
+        public string XmlHash { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("HashAlg")]
+        public string XmlHashAlgorithm { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("IsOptional")]
+        public string XmlIsOptional { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Path")]
+        public string XmlPath { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Size")]
+        public string XmlSize { get { throw null; } set { } }
+        public override string ToString() { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public partial class ComClass
+    {
+        public ComClass() { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ClsId { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Description { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ProgId { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ThreadingModel { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string TlbId { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Clsid")]
+        public string XmlClsId { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Description")]
+        public string XmlDescription { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Progid")]
+        public string XmlProgId { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("ThreadingModel")]
+        public string XmlThreadingModel { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Tlbid")]
+        public string XmlTlbId { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class CompatibleFramework
+    {
+        public CompatibleFramework() { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Profile { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string SupportedRuntime { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Version { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Profile")]
+        public string XmlProfile { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("SupportedRuntime")]
+        public string XmlSupportedRuntime { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Version")]
+        public string XmlVersion { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class CompatibleFrameworkCollection : System.Collections.IEnumerable
+    {
+        internal CompatibleFrameworkCollection() { }
+        public int Count { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.CompatibleFramework this[int index] { get { throw null; } }
+        public void Add(Microsoft.Build.Tasks.Deployment.ManifestUtilities.CompatibleFramework compatibleFramework) { }
+        public void Clear() { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    [System.Xml.Serialization.XmlRootAttribute("DeployManifest")]
+    public sealed partial class DeployManifest : Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest
+    {
+        public DeployManifest() { }
+        public DeployManifest(string targetFrameworkMoniker) { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.CompatibleFrameworkCollection CompatibleFrameworks { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool CreateDesktopShortcut { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string DeploymentUrl { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool DisallowUrlActivation { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public override Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference EntryPoint { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ErrorReportUrl { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool Install { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool MapFileExtensions { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string MinimumRequiredVersion { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Product { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Publisher { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string SuiteName { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string SupportUrl { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool TrustUrlParameters { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool UpdateEnabled { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public int UpdateInterval { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.UpdateMode UpdateMode { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.UpdateUnit UpdateUnit { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlArrayAttribute("CompatibleFrameworks")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.CompatibleFramework[] XmlCompatibleFrameworks { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("CreateDesktopShortcut")]
+        public string XmlCreateDesktopShortcut { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("DeploymentUrl")]
+        public string XmlDeploymentUrl { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("DisallowUrlActivation")]
+        public string XmlDisallowUrlActivation { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("ErrorReportUrl")]
+        public string XmlErrorReportUrl { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Install")]
+        public string XmlInstall { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("MapFileExtensions")]
+        public string XmlMapFileExtensions { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("MinimumRequiredVersion")]
+        public string XmlMinimumRequiredVersion { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Product")]
+        public string XmlProduct { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Publisher")]
+        public string XmlPublisher { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("SuiteName")]
+        public string XmlSuiteName { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("SupportUrl")]
+        public string XmlSupportUrl { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("TrustUrlParameters")]
+        public string XmlTrustUrlParameters { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("UpdateEnabled")]
+        public string XmlUpdateEnabled { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("UpdateInterval")]
+        public string XmlUpdateInterval { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("UpdateMode")]
+        public string XmlUpdateMode { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("UpdateUnit")]
+        public string XmlUpdateUnit { get { throw null; } set { } }
+        public override void Validate() { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class FileAssociation
+    {
+        public FileAssociation() { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string DefaultIcon { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Description { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Extension { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ProgId { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("DefaultIcon")]
+        public string XmlDefaultIcon { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Description")]
+        public string XmlDescription { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Extension")]
+        public string XmlExtension { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Progid")]
+        public string XmlProgId { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class FileAssociationCollection : System.Collections.IEnumerable
+    {
+        internal FileAssociationCollection() { }
+        public int Count { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileAssociation this[int index] { get { throw null; } }
+        public void Add(Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileAssociation fileAssociation) { }
+        public void Clear() { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class FileReference : Microsoft.Build.Tasks.Deployment.ManifestUtilities.BaseReference
+    {
+        public FileReference() { }
+        public FileReference(string path) { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.ComClass[] ComClasses { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool IsDataFile { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.ProxyStub[] ProxyStubs { get { throw null; } }
+        protected internal override string SortName { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.TypeLib[] TypeLibs { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlArrayAttribute("ComClasses")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.ComClass[] XmlComClasses { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlArrayAttribute("ProxyStubs")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.ProxyStub[] XmlProxyStubs { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlArrayAttribute("TypeLibs")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.TypeLib[] XmlTypeLibs { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("WriteableType")]
+        public string XmlWriteableType { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class FileReferenceCollection : System.Collections.IEnumerable
+    {
+        internal FileReferenceCollection() { }
+        public int Count { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference this[int index] { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference Add(Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference file) { throw null; }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference Add(string path) { throw null; }
+        public void Clear() { }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference FindTargetPath(string targetPath) { throw null; }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public void Remove(Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference file) { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public abstract partial class Manifest
+    {
+        protected internal Manifest() { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity AssemblyIdentity { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReferenceCollection AssemblyReferences { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Description { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public virtual Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference EntryPoint { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReferenceCollection FileReferences { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public System.IO.Stream InputStream { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.OutputMessageCollection OutputMessages { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool ReadOnly { get { throw null; } set { } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string SourcePath { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlElementAttribute("AssemblyIdentity")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyIdentity XmlAssemblyIdentity { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlArrayAttribute("AssemblyReferences")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.AssemblyReference[] XmlAssemblyReferences { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Description")]
+        public string XmlDescription { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlArrayAttribute("FileReferences")]
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.FileReference[] XmlFileReferences { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Schema")]
+        public string XmlSchema { get { throw null; } set { } }
+        public void ResolveFiles() { }
+        public void ResolveFiles(string[] searchPaths) { }
+        public override string ToString() { throw null; }
+        public void UpdateFileInfo() { }
+        public void UpdateFileInfo(string targetFrameworkVersion) { }
+        public virtual void Validate() { }
+        protected void ValidatePlatform() { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public static partial class ManifestReader
+    {
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest ReadManifest(System.IO.Stream input, bool preserveStream) { throw null; }
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest ReadManifest(string path, bool preserveStream) { throw null; }
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest ReadManifest(string manifestType, System.IO.Stream input, bool preserveStream) { throw null; }
+        public static Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest ReadManifest(string manifestType, string path, bool preserveStream) { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public static partial class ManifestWriter
+    {
+        public static void WriteManifest(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest) { }
+        public static void WriteManifest(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest, System.IO.Stream output) { }
+        public static void WriteManifest(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest, string path) { }
+        public static void WriteManifest(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest, string path, string targetframeWorkVersion) { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class OutputMessage
+    {
+        internal OutputMessage() { }
+        public string Name { get { throw null; } }
+        public string Text { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.OutputMessageType Type { get { throw null; } }
+        public string[] GetArguments() { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class OutputMessageCollection : System.Collections.IEnumerable
+    {
+        internal OutputMessageCollection() { }
+        public int ErrorCount { get { throw null; } }
+        public Microsoft.Build.Tasks.Deployment.ManifestUtilities.OutputMessage this[int index] { get { throw null; } }
+        public int WarningCount { get { throw null; } }
+        public void Clear() { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public enum OutputMessageType
+    {
+        Error = 2,
+        Info = 0,
+        Warning = 1,
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public partial class ProxyStub
+    {
+        public ProxyStub() { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string BaseInterface { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string IID { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Name { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string NumMethods { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string TlbId { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("BaseInterface")]
+        public string XmlBaseInterface { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Iid")]
+        public string XmlIID { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Name")]
+        public string XmlName { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("NumMethods")]
+        public string XmlNumMethods { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Tlbid")]
+        public string XmlTlbId { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public static partial class SecurityUtilities
+    {
+        public static System.Security.PermissionSet ComputeZonePermissionSet(string targetZone, System.Security.PermissionSet includedPermissionSet, string[] excludedPermissions) { throw null; }
+        public static System.Security.PermissionSet IdentityListToPermissionSet(string[] ids) { throw null; }
+        public static string[] PermissionSetToIdentityList(System.Security.PermissionSet permissionSet) { throw null; }
+        public static void SignFile(System.Security.Cryptography.X509Certificates.X509Certificate2 cert, System.Uri timestampUrl, string path) { }
+        public static void SignFile(string certPath, System.Security.SecureString certPassword, System.Uri timestampUrl, string path) { }
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path) { }
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion) { }
+        public static System.Security.PermissionSet XmlToPermissionSet(System.Xml.XmlElement element) { throw null; }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public sealed partial class TrustInfo
+    {
+        public TrustInfo() { }
+        public bool HasUnmanagedCodePermission { get { throw null; } }
+        public bool IsFullTrust { get { throw null; } set { } }
+        public System.Security.PermissionSet PermissionSet { get { throw null; } set { } }
+        public bool PreserveFullTrustPermissionSet { get { throw null; } set { } }
+        public string SameSiteAccess { get { throw null; } set { } }
+        public void Clear() { }
+        public void Read(System.IO.Stream input) { }
+        public void Read(string path) { }
+        public void ReadManifest(System.IO.Stream input) { }
+        public void ReadManifest(string path) { }
+        public override string ToString() { throw null; }
+        public void Write(System.IO.Stream output) { }
+        public void Write(string path) { }
+        public void WriteManifest(System.IO.Stream output) { }
+        public void WriteManifest(System.IO.Stream input, System.IO.Stream output) { }
+        public void WriteManifest(string path) { }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public partial class TypeLib
+    {
+        public TypeLib() { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Flags { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string HelpDirectory { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string ResourceId { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string TlbId { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Version { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Flags")]
+        public string XmlFlags { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("HelpDir")]
+        public string XmlHelpDirectory { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("ResourceId")]
+        public string XmlResourceId { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Tlbid")]
+        public string XmlTlbId { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Version")]
+        public string XmlVersion { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public enum UpdateMode
+    {
+        Background = 0,
+        Foreground = 1,
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public enum UpdateUnit
+    {
+        Days = 1,
+        Hours = 0,
+        Weeks = 2,
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(false)]
+    public partial class WindowClass
+    {
+        public WindowClass() { }
+        public WindowClass(string name, bool versioned) { }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public string Name { get { throw null; } }
+        [System.Xml.Serialization.XmlIgnoreAttribute]
+        public bool Versioned { get { throw null; } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Name")]
+        public string XmlName { get { throw null; } set { } }
+        [System.ComponentModel.BrowsableAttribute(false)]
+        [System.ComponentModel.EditorBrowsableAttribute((System.ComponentModel.EditorBrowsableState)(1))]
+        [System.Xml.Serialization.XmlAttributeAttribute("Versioned")]
+        public string XmlVersioned { get { throw null; } set { } }
+    }
+}
+namespace Microsoft.Build.Tasks.Hosting
+{
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("B5A95716-2053-4B70-9FBF-E4148EBA96BC")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface IAnalyzerHostObject
+    {
+        bool SetAdditionalFiles(Microsoft.Build.Framework.ITaskItem[] additionalFiles);
+        bool SetAnalyzers(Microsoft.Build.Framework.ITaskItem[] analyzers);
+        bool SetRuleSet(string ruleSetFile);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("8520CC4D-64DC-4855-BE3F-4C28CCE048EE")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface ICscHostObject : Microsoft.Build.Framework.ITaskHost
+    {
+        void BeginInitialization();
+        bool Compile();
+        bool EndInitialization(out string errorMessage, out int errorCode);
+        bool IsDesignTime();
+        bool IsUpToDate();
+        bool SetAdditionalLibPaths(string[] additionalLibPaths);
+        bool SetAddModules(string[] addModules);
+        bool SetAllowUnsafeBlocks(bool allowUnsafeBlocks);
+        bool SetBaseAddress(string baseAddress);
+        bool SetCheckForOverflowUnderflow(bool checkForOverflowUnderflow);
+        bool SetCodePage(int codePage);
+        bool SetDebugType(string debugType);
+        bool SetDefineConstants(string defineConstants);
+        bool SetDelaySign(bool delaySignExplicitlySet, bool delaySign);
+        bool SetDisabledWarnings(string disabledWarnings);
+        bool SetDocumentationFile(string documentationFile);
+        bool SetEmitDebugInformation(bool emitDebugInformation);
+        bool SetErrorReport(string errorReport);
+        bool SetFileAlignment(int fileAlignment);
+        bool SetGenerateFullPaths(bool generateFullPaths);
+        bool SetKeyContainer(string keyContainer);
+        bool SetKeyFile(string keyFile);
+        bool SetLangVersion(string langVersion);
+        bool SetLinkResources(Microsoft.Build.Framework.ITaskItem[] linkResources);
+        bool SetMainEntryPoint(string targetType, string mainEntryPoint);
+        bool SetModuleAssemblyName(string moduleAssemblyName);
+        bool SetNoConfig(bool noConfig);
+        bool SetNoStandardLib(bool noStandardLib);
+        bool SetOptimize(bool optimize);
+        bool SetOutputAssembly(string outputAssembly);
+        bool SetPdbFile(string pdbFile);
+        bool SetPlatform(string platform);
+        bool SetReferences(Microsoft.Build.Framework.ITaskItem[] references);
+        bool SetResources(Microsoft.Build.Framework.ITaskItem[] resources);
+        bool SetResponseFiles(Microsoft.Build.Framework.ITaskItem[] responseFiles);
+        bool SetSources(Microsoft.Build.Framework.ITaskItem[] sources);
+        bool SetTargetType(string targetType);
+        bool SetTreatWarningsAsErrors(bool treatWarningsAsErrors);
+        bool SetWarningLevel(int warningLevel);
+        bool SetWarningsAsErrors(string warningsAsErrors);
+        bool SetWarningsNotAsErrors(string warningsNotAsErrors);
+        bool SetWin32Icon(string win32Icon);
+        bool SetWin32Resource(string win32Resource);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("D6D4E228-259A-4076-B5D0-0627338BCC10")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface ICscHostObject2 : Microsoft.Build.Framework.ITaskHost, Microsoft.Build.Tasks.Hosting.ICscHostObject
+    {
+        bool SetWin32Manifest(string win32Manifest);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("F9353662-F1ED-4a23-A323-5F5047E85F5D")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface ICscHostObject3 : Microsoft.Build.Framework.ITaskHost, Microsoft.Build.Tasks.Hosting.ICscHostObject, Microsoft.Build.Tasks.Hosting.ICscHostObject2
+    {
+        bool SetApplicationConfiguration(string applicationConfiguration);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("0DDB496F-C93C-492C-87F1-90B6FDBAA833")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface ICscHostObject4 : Microsoft.Build.Framework.ITaskHost, Microsoft.Build.Tasks.Hosting.ICscHostObject, Microsoft.Build.Tasks.Hosting.ICscHostObject2, Microsoft.Build.Tasks.Hosting.ICscHostObject3
+    {
+        bool SetHighEntropyVA(bool highEntropyVA);
+        bool SetPlatformWith32BitPreference(string platformWith32BitPreference);
+        bool SetSubsystemVersion(string subsystemVersion);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("7D7AC3BE-253A-40e8-A3FF-357D0DA7C47A")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface IVbcHostObject : Microsoft.Build.Framework.ITaskHost
+    {
+        void BeginInitialization();
+        bool Compile();
+        void EndInitialization();
+        bool IsDesignTime();
+        bool IsUpToDate();
+        bool SetAdditionalLibPaths(string[] additionalLibPaths);
+        bool SetAddModules(string[] addModules);
+        bool SetBaseAddress(string targetType, string baseAddress);
+        bool SetCodePage(int codePage);
+        bool SetDebugType(bool emitDebugInformation, string debugType);
+        bool SetDefineConstants(string defineConstants);
+        bool SetDelaySign(bool delaySign);
+        bool SetDisabledWarnings(string disabledWarnings);
+        bool SetDocumentationFile(string documentationFile);
+        bool SetErrorReport(string errorReport);
+        bool SetFileAlignment(int fileAlignment);
+        bool SetGenerateDocumentation(bool generateDocumentation);
+        bool SetImports(Microsoft.Build.Framework.ITaskItem[] importsList);
+        bool SetKeyContainer(string keyContainer);
+        bool SetKeyFile(string keyFile);
+        bool SetLinkResources(Microsoft.Build.Framework.ITaskItem[] linkResources);
+        bool SetMainEntryPoint(string mainEntryPoint);
+        bool SetNoConfig(bool noConfig);
+        bool SetNoStandardLib(bool noStandardLib);
+        bool SetNoWarnings(bool noWarnings);
+        bool SetOptimize(bool optimize);
+        bool SetOptionCompare(string optionCompare);
+        bool SetOptionExplicit(bool optionExplicit);
+        bool SetOptionStrict(bool optionStrict);
+        bool SetOptionStrictType(string optionStrictType);
+        bool SetOutputAssembly(string outputAssembly);
+        bool SetPlatform(string platform);
+        bool SetReferences(Microsoft.Build.Framework.ITaskItem[] references);
+        bool SetRemoveIntegerChecks(bool removeIntegerChecks);
+        bool SetResources(Microsoft.Build.Framework.ITaskItem[] resources);
+        bool SetResponseFiles(Microsoft.Build.Framework.ITaskItem[] responseFiles);
+        bool SetRootNamespace(string rootNamespace);
+        bool SetSdkPath(string sdkPath);
+        bool SetSources(Microsoft.Build.Framework.ITaskItem[] sources);
+        bool SetTargetCompactFramework(bool targetCompactFramework);
+        bool SetTargetType(string targetType);
+        bool SetTreatWarningsAsErrors(bool treatWarningsAsErrors);
+        bool SetWarningsAsErrors(string warningsAsErrors);
+        bool SetWarningsNotAsErrors(string warningsNotAsErrors);
+        bool SetWin32Icon(string win32Icon);
+        bool SetWin32Resource(string win32Resource);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("f59afc84-d102-48b1-a090-1b90c79d3e09")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface IVbcHostObject2 : Microsoft.Build.Framework.ITaskHost, Microsoft.Build.Tasks.Hosting.IVbcHostObject
+    {
+        bool SetModuleAssemblyName(string moduleAssemblyName);
+        bool SetOptionInfer(bool optionInfer);
+        bool SetWin32Manifest(string win32Manifest);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("1186fe8f-8aba-48d6-8ce3-32ca42f53728")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface IVbcHostObject3 : Microsoft.Build.Framework.ITaskHost, Microsoft.Build.Tasks.Hosting.IVbcHostObject, Microsoft.Build.Tasks.Hosting.IVbcHostObject2
+    {
+        bool SetLanguageVersion(string languageVersion);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("2AE3233C-8AB3-48A0-9ED9-6E3545B3C566")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface IVbcHostObject4 : Microsoft.Build.Framework.ITaskHost, Microsoft.Build.Tasks.Hosting.IVbcHostObject, Microsoft.Build.Tasks.Hosting.IVbcHostObject2, Microsoft.Build.Tasks.Hosting.IVbcHostObject3
+    {
+        bool SetVBRuntime(string VBRuntime);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("5ACF41FF-6F2B-4623-8146-740C89212B21")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface IVbcHostObject5 : Microsoft.Build.Framework.ITaskHost, Microsoft.Build.Tasks.Hosting.IVbcHostObject, Microsoft.Build.Tasks.Hosting.IVbcHostObject2, Microsoft.Build.Tasks.Hosting.IVbcHostObject3, Microsoft.Build.Tasks.Hosting.IVbcHostObject4
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.PreserveSig)]int CompileAsync(out System.IntPtr buildSucceededEvent, out System.IntPtr buildFailedEvent);
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.PreserveSig)]int EndCompile(bool buildSuccess);
+        Microsoft.Build.Tasks.Hosting.IVbcHostObjectFreeThreaded GetFreeThreadedHostObject();
+        bool SetHighEntropyVA(bool highEntropyVA);
+        bool SetPlatformWith32BitPreference(string platformWith32BitPreference);
+        bool SetSubsystemVersion(string subsystemVersion);
+    }
+    [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+    [System.Runtime.InteropServices.GuidAttribute("ECCF972F-8C2D-4F51-9746-9288661DE2CB")]
+    [System.Runtime.InteropServices.InterfaceTypeAttribute((System.Runtime.InteropServices.ComInterfaceType)(1))]
+    public partial interface IVbcHostObjectFreeThreaded
+    {
+        bool Compile();
+    }
+}
+namespace Microsoft.Build.Tasks.Xaml
+{
+    public partial class CommandLineArgumentRelation : Microsoft.Build.Tasks.Xaml.PropertyRelation
+    {
+        public CommandLineArgumentRelation(string argument, string value, bool required, string separator) { }
+        public string Separator { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public partial class CommandLineGenerator
+    {
+        public CommandLineGenerator(Microsoft.Build.Framework.XamlTypes.Rule rule, System.Collections.Generic.Dictionary<string, object> parameterValues) { }
+        public string AdditionalOptions { get { throw null; } set { } }
+        public string AlwaysAppend { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string CommandLineTemplate { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string GenerateCommandLine() { throw null; }
+    }
+    public partial class CommandLineToolSwitch
+    {
+        public CommandLineToolSwitch() { }
+        public CommandLineToolSwitch(Microsoft.Build.Tasks.Xaml.CommandLineToolSwitchType toolType) { }
+        public bool AllowMultipleValues { get { throw null; } set { } }
+        public bool ArgumentRequired { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.ICollection<System.Tuple<string, bool>> Arguments { get { throw null; } set { } }
+        public bool BooleanValue { get { throw null; } set { } }
+        public string Description { get { throw null; } set { } }
+        public string DisplayName { get { throw null; } set { } }
+        public string FallbackArgumentParameter { get { throw null; } set { } }
+        public string FalseSuffix { get { throw null; } set { } }
+        public bool IncludeInCommandLine { get { throw null; } set { } }
+        public bool IsValid { get { throw null; } set { } }
+        public string Name { get { throw null; } set { } }
+        public int Number { get { throw null; } set { } }
+        public System.Collections.Generic.LinkedList<System.Collections.Generic.KeyValuePair<string, string>> Overrides { get { throw null; } }
+        public System.Collections.Generic.LinkedList<string> Parents { get { throw null; } }
+        public bool Required { get { throw null; } set { } }
+        public string ReverseSwitchValue { get { throw null; } set { } }
+        public bool Reversible { get { throw null; } set { } }
+        public string Separator { get { throw null; } set { } }
+        public string[] StringList { get { throw null; } set { } }
+        public string SwitchValue { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TaskItemArray { get { throw null; } set { } }
+        public string TrueSuffix { get { throw null; } set { } }
+        public Microsoft.Build.Tasks.Xaml.CommandLineToolSwitchType Type { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+    }
+    public enum CommandLineToolSwitchType
+    {
+        Boolean = 0,
+        Integer = 1,
+        ITaskItemArray = 4,
+        String = 2,
+        StringArray = 3,
+    }
+    public partial class PropertyRelation
+    {
+        public PropertyRelation() { }
+        public PropertyRelation(string argument, string value, bool required) { }
+        public string Argument { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool Required { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Value { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public abstract partial class XamlDataDrivenToolTask : Microsoft.Build.Utilities.ToolTask
+    {
+        protected XamlDataDrivenToolTask(string[] switchOrderList, System.Resources.ResourceManager taskResources) { }
+        public virtual string[] AcceptableNonZeroExitCodes { get { throw null; } set { } }
+        protected internal System.Collections.Generic.Dictionary<string, Microsoft.Build.Tasks.Xaml.CommandLineToolSwitch> ActiveToolSwitches { get { throw null; } }
+        public System.Collections.Generic.Dictionary<string, Microsoft.Build.Tasks.Xaml.CommandLineToolSwitch> ActiveToolSwitchesValues { get { throw null; } set { } }
+        public string AdditionalOptions { get { throw null; } set { } }
+        public string CommandLineTemplate { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        protected override System.Text.Encoding ResponseFileEncoding { get { throw null; } }
+        public void AddActiveSwitchToolValue(Microsoft.Build.Tasks.Xaml.CommandLineToolSwitch switchToAdd) { }
+        public string CreateSwitchValue(string propertyName, string baseSwitch, string separator, System.Tuple<string, bool>[] arguments) { throw null; }
+        public override bool Execute() { throw null; }
+        protected override string GenerateCommandLineCommands() { throw null; }
+        protected override string GenerateFullPathToTool() { throw null; }
+        protected override string GenerateResponseFileCommands() { throw null; }
+        protected override bool HandleTaskExecutionErrors() { throw null; }
+        public bool IsPropertySet(string propertyName) { throw null; }
+        public string ReadSwitchMap(string propertyName, string[][] switchMap, string value) { throw null; }
+        public int ReadSwitchMap2(string propertyName, System.Tuple<string, string, System.Tuple<string, bool>[]>[] switchMap, string value) { throw null; }
+        public void ReplaceToolSwitch(Microsoft.Build.Tasks.Xaml.CommandLineToolSwitch switchToAdd) { }
+        public bool ValidateInteger(string switchName, int min, int max, int value) { throw null; }
+        protected override bool ValidateParameters() { throw null; }
+    }
+}
+namespace System.Deployment.Internal.CodeSigning
+{
+    public sealed partial class RSAPKCS1SHA256SignatureDescription : System.Security.Cryptography.SignatureDescription
+    {
+        public RSAPKCS1SHA256SignatureDescription() { }
+        public override System.Security.Cryptography.AsymmetricSignatureDeformatter CreateDeformatter(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+        public override System.Security.Cryptography.AsymmetricSignatureFormatter CreateFormatter(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+    }
+}

--- a/build/LegacyPackages/14.0/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1,5 +1,6 @@
 namespace Microsoft.Build.Tasks
 {
+#if !NETSTANDARD
     public partial class AL : Microsoft.Build.Tasks.ToolTaskExtension
     {
         public AL() { }
@@ -46,7 +47,6 @@ namespace Microsoft.Build.Tasks
     public abstract partial class AppDomainIsolatedTaskExtension : Microsoft.Build.Utilities.AppDomainIsolatedTask
     {
         internal AppDomainIsolatedTaskExtension() { }
-        public new Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
     }
     public partial class AspNetCompiler : Microsoft.Build.Tasks.ToolTaskExtension
     {
@@ -71,6 +71,7 @@ namespace Microsoft.Build.Tasks
         protected override string GenerateFullPathToTool() { throw null; }
         protected override bool ValidateParameters() { throw null; }
     }
+#endif
     public partial class AssignCulture : Microsoft.Build.Tasks.TaskExtension
     {
         public AssignCulture() { }
@@ -135,6 +136,7 @@ namespace Microsoft.Build.Tasks
         public bool UseResultsCache { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public partial class CodeTaskFactory : Microsoft.Build.Framework.ITaskFactory
     {
         public CodeTaskFactory() { }
@@ -145,6 +147,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
         public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.TaskPropertyInfo> taskParameters, string taskElementContents, Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
     }
+#endif
     public partial class CombinePath : Microsoft.Build.Tasks.TaskExtension
     {
         public CombinePath() { }
@@ -334,6 +337,7 @@ namespace Microsoft.Build.Tasks
         public bool MatchFileNameOnly { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public partial class FindInvalidProjectReferences : Microsoft.Build.Tasks.TaskExtension
     {
         public FindInvalidProjectReferences() { }
@@ -346,6 +350,7 @@ namespace Microsoft.Build.Tasks
         public string TargetPlatformVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public partial class FindUnderPath : Microsoft.Build.Tasks.TaskExtension
     {
         public FindUnderPath() { }
@@ -359,6 +364,7 @@ namespace Microsoft.Build.Tasks
         public bool UpdateToAbsolutePaths { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public sealed partial class FormatUrl : Microsoft.Build.Tasks.TaskExtension
     {
         public FormatUrl() { }
@@ -367,6 +373,7 @@ namespace Microsoft.Build.Tasks
         public string OutputUrl { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public sealed partial class FormatVersion : Microsoft.Build.Tasks.TaskExtension
     {
         public FormatVersion() { }
@@ -377,6 +384,7 @@ namespace Microsoft.Build.Tasks
         public string Version { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public sealed partial class GenerateApplicationManifest : Microsoft.Build.Tasks.GenerateManifestBase
     {
         public GenerateApplicationManifest() { }
@@ -405,6 +413,7 @@ namespace Microsoft.Build.Tasks
         protected override bool OnManifestResolved(Microsoft.Build.Tasks.Deployment.ManifestUtilities.Manifest manifest) { throw null; }
         protected internal override bool ValidateInputs() { throw null; }
     }
+#endif
     public partial class GenerateBindingRedirects : Microsoft.Build.Tasks.TaskExtension
     {
         public GenerateBindingRedirects() { }
@@ -415,6 +424,7 @@ namespace Microsoft.Build.Tasks
         public string TargetName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public sealed partial class GenerateBootstrapper : Microsoft.Build.Tasks.TaskExtension
     {
         public GenerateBootstrapper() { }
@@ -490,6 +500,7 @@ namespace Microsoft.Build.Tasks
         protected internal virtual bool ValidateInputs() { throw null; }
         protected internal virtual bool ValidateOutput() { throw null; }
     }
+#endif
     [Microsoft.Build.Framework.RequiredRuntimeAttribute("v2.0")]
     public sealed partial class GenerateResource : Microsoft.Build.Tasks.TaskExtension
     {
@@ -530,6 +541,7 @@ namespace Microsoft.Build.Tasks
         public bool UseSourcePath { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public sealed partial class GenerateTrustInfo : Microsoft.Build.Tasks.TaskExtension
     {
         public GenerateTrustInfo() { }
@@ -552,6 +564,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public partial class GetFrameworkPath : Microsoft.Build.Tasks.TaskExtension
     {
         public GetFrameworkPath() { }
@@ -579,6 +592,7 @@ namespace Microsoft.Build.Tasks
         public string Path { get { throw null; } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public partial class GetFrameworkSdkPath : Microsoft.Build.Tasks.TaskExtension
     {
         public GetFrameworkSdkPath() { }
@@ -614,6 +628,7 @@ namespace Microsoft.Build.Tasks
         public string TargetPlatformVersion { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public partial class GetReferenceAssemblyPaths : Microsoft.Build.Tasks.TaskExtension
     {
         public GetReferenceAssemblyPaths() { }
@@ -628,6 +643,7 @@ namespace Microsoft.Build.Tasks
         public string TargetFrameworkMonikerDisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public partial class GetSDKReferenceFiles : Microsoft.Build.Tasks.TaskExtension
     {
         public GetSDKReferenceFiles() { }
@@ -696,6 +712,7 @@ namespace Microsoft.Build.Tasks
         protected override string GenerateFullPathToTool() { throw null; }
         protected override bool ValidateParameters() { throw null; }
     }
+#endif
     public partial class MakeDir : Microsoft.Build.Tasks.TaskExtension
     {
         public MakeDir() { }
@@ -761,6 +778,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] Lines { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public partial class RegisterAssembly : Microsoft.Build.Tasks.AppDomainIsolatedTaskExtension, System.Runtime.InteropServices.ITypeLibExporterNotifySink
     {
         public RegisterAssembly() { }
@@ -774,6 +792,7 @@ namespace Microsoft.Build.Tasks
         public void ReportEvent(System.Runtime.InteropServices.ExporterEventKind kind, int code, string msg) { }
         public object ResolveRef(System.Reflection.Assembly assemblyToResolve) { throw null; }
     }
+#endif
     public partial class RemoveDir : Microsoft.Build.Tasks.TaskExtension
     {
         public RemoveDir() { }
@@ -791,6 +810,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] Inputs { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public sealed partial class RequiresFramework35SP1Assembly : Microsoft.Build.Tasks.TaskExtension
     {
         public RequiresFramework35SP1Assembly() { }
@@ -808,6 +828,7 @@ namespace Microsoft.Build.Tasks
         public string TargetFrameworkVersion { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public partial class ResolveAssemblyReference : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveAssemblyReference() { }
@@ -882,6 +903,7 @@ namespace Microsoft.Build.Tasks
         public string ResolvedCodeAnalysisRuleSet { get { throw null; } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public sealed partial class ResolveComReference : Microsoft.Build.Tasks.AppDomainIsolatedTaskExtension
     {
         public ResolveComReference() { }
@@ -907,6 +929,7 @@ namespace Microsoft.Build.Tasks
         public string WrapperOutputDirectory { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public partial class ResolveKeySource : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveKeySource() { }
@@ -925,6 +948,7 @@ namespace Microsoft.Build.Tasks
         public bool SuppressAutoClosePasswordPrompt { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public sealed partial class ResolveManifestFiles : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveManifestFiles() { }
@@ -980,6 +1004,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] UnresolvedProjectReferences { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public abstract partial class ResolveProjectBase : Microsoft.Build.Tasks.TaskExtension
     {
         protected ResolveProjectBase() { }
@@ -989,6 +1014,7 @@ namespace Microsoft.Build.Tasks
         protected System.Xml.XmlElement GetProjectElement(Microsoft.Build.Framework.ITaskItem projectRef) { throw null; }
         protected string GetProjectItem(Microsoft.Build.Framework.ITaskItem projectRef) { throw null; }
     }
+#if !NETSTANDARD
     public partial class ResolveSDKReference : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveSDKReference() { }
@@ -1053,23 +1079,21 @@ namespace Microsoft.Build.Tasks
         public string TimestampUrl { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public abstract partial class TaskExtension : Microsoft.Build.Utilities.Task
     {
         internal TaskExtension() { }
-        public new Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
     }
     public partial class TaskLoggingHelperExtension : Microsoft.Build.Utilities.TaskLoggingHelper
     {
-        public TaskLoggingHelperExtension(Microsoft.Build.Framework.ITask taskInstance, System.Resources.ResourceManager primaryResources, System.Resources.ResourceManager sharedResources, string helpKeywordPrefix) : base (default(Microsoft.Build.Framework.ITask)) { }
+        public TaskLoggingHelperExtension(Microsoft.Build.Framework.ITask taskInstance, System.Resources.ResourceManager primaryResources, System.Resources.ResourceManager sharedResources, string helpKeywordPrefix) :base(taskInstance) { }
         public System.Resources.ResourceManager TaskSharedResources { get { throw null; } set { } }
         public override string FormatResourceString(string resourceName, params object[] args) { throw null; }
     }
     public abstract partial class ToolTaskExtension : Microsoft.Build.Utilities.ToolTask
     {
         internal ToolTaskExtension() { }
-        protected internal System.Collections.Hashtable Bag { get { throw null; } }
         protected override bool HasLoggedErrors { get { throw null; } }
-        public new Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
         protected internal virtual void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected internal virtual void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override string GenerateCommandLineCommands() { throw null; }
@@ -1089,6 +1113,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] TouchedFiles { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public partial class UnregisterAssembly : Microsoft.Build.Tasks.AppDomainIsolatedTaskExtension
     {
         public UnregisterAssembly() { }
@@ -1111,6 +1136,7 @@ namespace Microsoft.Build.Tasks
         public string TargetFrameworkVersion { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
     public sealed partial class Warning : Microsoft.Build.Tasks.TaskExtension
     {
         public Warning() { }
@@ -1120,6 +1146,7 @@ namespace Microsoft.Build.Tasks
         public string Text { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public partial class WinMDExp : Microsoft.Build.Tasks.ToolTaskExtension
     {
         public WinMDExp() { }
@@ -1146,6 +1173,7 @@ namespace Microsoft.Build.Tasks
         protected override bool SkipTaskExecution() { throw null; }
         protected override bool ValidateParameters() { throw null; }
     }
+#endif
     public partial class WriteCodeFragment : Microsoft.Build.Tasks.TaskExtension
     {
         public WriteCodeFragment() { }
@@ -1167,6 +1195,7 @@ namespace Microsoft.Build.Tasks
         public bool Overwrite { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#if !NETSTANDARD
     public partial class XamlTaskFactory : Microsoft.Build.Framework.ITaskFactory
     {
         public XamlTaskFactory() { }
@@ -1215,7 +1244,9 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem XslInputPath { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+#endif
 }
+#if !NETSTANDARD
 namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 {
     [System.Runtime.InteropServices.ClassInterfaceAttribute((System.Runtime.InteropServices.ClassInterfaceType)(0))]
@@ -2237,6 +2268,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         public string XmlVersioned { get { throw null; } set { } }
     }
 }
+#endif
 namespace Microsoft.Build.Tasks.Hosting
 {
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
@@ -2415,6 +2447,7 @@ namespace Microsoft.Build.Tasks.Hosting
         bool Compile();
     }
 }
+#if !NETSTANDARD
 namespace Microsoft.Build.Tasks.Xaml
 {
     public partial class CommandLineArgumentRelation : Microsoft.Build.Tasks.Xaml.PropertyRelation
@@ -2508,3 +2541,4 @@ namespace System.Deployment.Internal.CodeSigning
         public override System.Security.Cryptography.AsymmetricSignatureFormatter CreateFormatter(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
     }
 }
+#endif

--- a/build/LegacyPackages/14.0/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.nuspec
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$id$</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <iconUrl>$iconUrl$</iconUrl>
+    <description>This package contains the $id$ assembly which implements the commonly used tasks of MSBuild.</description>
+    <tags>MSBuild</tags>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
+        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
+      </group>
+      <group targetFramework="net45">
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="lib\net45\$id$.dll" target="lib\net45\$id$.dll" />
+    <file src="bin\$configuration$\net45\$id$.dll" target="ref\net45\$id$.dll" />
+    <file src="bin\$configuration$\netstandard1.3\$id$.dll" target="ref\netstandard1.3\$id$.dll" />
+  </files>
+</package>

--- a/build/LegacyPackages/14.0/Microsoft.Build.Tasks.Core/project.json
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Tasks.Core/project.json
@@ -1,0 +1,30 @@
+{
+  "version": "14.0.0.0",
+  "buildOptions": {
+    "keyFile": "../../../../Tools/MSFT.snk",
+    "publicSign": true
+  },
+  "dependencies": {
+    "Microsoft.Build.Framework": {
+      "target": "project"
+    },
+    "Microsoft.Build.Utilities.Core": {
+      "target": "project"
+    }
+  },
+  "frameworks": {
+    "net45": {
+      "frameworkAssemblies": {
+        "System.Xml": {}
+      }
+    },
+    "netstandard1.3": {
+      "buildOptions": {
+        "define": [ "NETSTANDARD" ]
+      },
+      "dependencies": {
+        "System.Xml.XmlDocument": "4.0.1"
+      }
+    }
+  }
+}

--- a/build/LegacyPackages/14.0/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -1,0 +1,559 @@
+namespace Microsoft.Build.Utilities
+{
+    [Microsoft.Build.Framework.LoadInSeparateAppDomainAttribute]
+    public abstract partial class AppDomainIsolatedTask : System.MarshalByRefObject, Microsoft.Build.Framework.ITask
+    {
+        protected AppDomainIsolatedTask() { }
+        protected AppDomainIsolatedTask(System.Resources.ResourceManager taskResources) { }
+        protected AppDomainIsolatedTask(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+        public Microsoft.Build.Framework.IBuildEngine BuildEngine { get { throw null; } set { } }
+        protected string HelpKeywordPrefix { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskHost HostObject { get { throw null; } set { } }
+        public Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
+        protected System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+        public abstract bool Execute();
+        [System.Security.SecurityCriticalAttribute]
+        public override object InitializeLifetimeService() { throw null; }
+    }
+    public partial class AssemblyFoldersExInfo
+    {
+        public AssemblyFoldersExInfo(Microsoft.Win32.RegistryHive hive, Microsoft.Win32.RegistryView view, string registryKey, string directoryPath, System.Version targetFrameworkVersion) { }
+        public string DirectoryPath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Win32.RegistryHive Hive { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Key { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Version TargetFrameworkVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Win32.RegistryView View { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
+    public partial class CanonicalTrackedInputFiles
+    {
+        public CanonicalTrackedInputFiles(Microsoft.Build.Framework.ITask ownerTask, Microsoft.Build.Framework.ITaskItem[] tlogFiles, Microsoft.Build.Framework.ITaskItem sourceFile, Microsoft.Build.Framework.ITaskItem[] excludedInputPaths, Microsoft.Build.Utilities.CanonicalTrackedOutputFiles outputs, bool useMinimalRebuildOptimization, bool maintainCompositeRootingMarkers) { }
+        public CanonicalTrackedInputFiles(Microsoft.Build.Framework.ITask ownerTask, Microsoft.Build.Framework.ITaskItem[] tlogFiles, Microsoft.Build.Framework.ITaskItem[] sourceFiles, Microsoft.Build.Framework.ITaskItem[] excludedInputPaths, Microsoft.Build.Framework.ITaskItem[] outputs, bool useMinimalRebuildOptimization, bool maintainCompositeRootingMarkers) { }
+        public CanonicalTrackedInputFiles(Microsoft.Build.Framework.ITask ownerTask, Microsoft.Build.Framework.ITaskItem[] tlogFiles, Microsoft.Build.Framework.ITaskItem[] sourceFiles, Microsoft.Build.Framework.ITaskItem[] excludedInputPaths, Microsoft.Build.Utilities.CanonicalTrackedOutputFiles outputs, bool useMinimalRebuildOptimization, bool maintainCompositeRootingMarkers) { }
+        public CanonicalTrackedInputFiles(Microsoft.Build.Framework.ITaskItem[] tlogFiles, Microsoft.Build.Framework.ITaskItem[] sourceFiles, Microsoft.Build.Framework.ITaskItem[] excludedInputPaths, Microsoft.Build.Utilities.CanonicalTrackedOutputFiles outputs, bool useMinimalRebuildOptimization, bool maintainCompositeRootingMarkers) { }
+        public CanonicalTrackedInputFiles(Microsoft.Build.Framework.ITaskItem[] tlogFiles, Microsoft.Build.Framework.ITaskItem[] sourceFiles, Microsoft.Build.Utilities.CanonicalTrackedOutputFiles outputs, bool useMinimalRebuildOptimization, bool maintainCompositeRootingMarkers) { }
+        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>> DependencyTable { get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] ComputeSourcesNeedingCompilation() { throw null; }
+        public Microsoft.Build.Framework.ITaskItem[] ComputeSourcesNeedingCompilation(bool searchForSubRootsInCompositeRootingMarkers) { throw null; }
+        public bool FileIsExcludedFromDependencyCheck(string fileName) { throw null; }
+        public void RemoveDependenciesFromEntryIfMissing(Microsoft.Build.Framework.ITaskItem source) { }
+        public void RemoveDependenciesFromEntryIfMissing(Microsoft.Build.Framework.ITaskItem source, Microsoft.Build.Framework.ITaskItem correspondingOutput) { }
+        public void RemoveDependenciesFromEntryIfMissing(Microsoft.Build.Framework.ITaskItem[] source) { }
+        public void RemoveDependenciesFromEntryIfMissing(Microsoft.Build.Framework.ITaskItem[] source, Microsoft.Build.Framework.ITaskItem[] correspondingOutputs) { }
+        public void RemoveDependencyFromEntry(Microsoft.Build.Framework.ITaskItem source, Microsoft.Build.Framework.ITaskItem dependencyToRemove) { }
+        public void RemoveDependencyFromEntry(Microsoft.Build.Framework.ITaskItem[] sources, Microsoft.Build.Framework.ITaskItem dependencyToRemove) { }
+        public void RemoveEntriesForSource(Microsoft.Build.Framework.ITaskItem source) { }
+        public void RemoveEntriesForSource(Microsoft.Build.Framework.ITaskItem[] source) { }
+        public void RemoveEntryForSourceRoot(string rootingMarker) { }
+        public void SaveTlog() { }
+        public void SaveTlog(Microsoft.Build.Utilities.DependencyFilter includeInTLog) { }
+    }
+    public partial class CanonicalTrackedOutputFiles
+    {
+        public CanonicalTrackedOutputFiles(Microsoft.Build.Framework.ITask ownerTask, Microsoft.Build.Framework.ITaskItem[] tlogFiles) { }
+        public CanonicalTrackedOutputFiles(Microsoft.Build.Framework.ITask ownerTask, Microsoft.Build.Framework.ITaskItem[] tlogFiles, bool constructOutputsFromTLogs) { }
+        public CanonicalTrackedOutputFiles(Microsoft.Build.Framework.ITaskItem[] tlogFiles) { }
+        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, System.DateTime>> DependencyTable { get { throw null; } }
+        public void AddComputedOutputForSourceRoot(string sourceKey, string computedOutput) { }
+        public void AddComputedOutputsForSourceRoot(string sourceKey, Microsoft.Build.Framework.ITaskItem[] computedOutputs) { }
+        public void AddComputedOutputsForSourceRoot(string sourceKey, string[] computedOutputs) { }
+        public Microsoft.Build.Framework.ITaskItem[] OutputsForNonCompositeSource(params Microsoft.Build.Framework.ITaskItem[] sources) { throw null; }
+        public Microsoft.Build.Framework.ITaskItem[] OutputsForSource(params Microsoft.Build.Framework.ITaskItem[] sources) { throw null; }
+        public Microsoft.Build.Framework.ITaskItem[] OutputsForSource(Microsoft.Build.Framework.ITaskItem[] sources, bool searchForSubRootsInCompositeRootingMarkers) { throw null; }
+        public void RemoveDependenciesFromEntryIfMissing(Microsoft.Build.Framework.ITaskItem source) { }
+        public void RemoveDependenciesFromEntryIfMissing(Microsoft.Build.Framework.ITaskItem source, Microsoft.Build.Framework.ITaskItem correspondingOutput) { }
+        public void RemoveDependenciesFromEntryIfMissing(Microsoft.Build.Framework.ITaskItem[] source) { }
+        public void RemoveDependenciesFromEntryIfMissing(Microsoft.Build.Framework.ITaskItem[] source, Microsoft.Build.Framework.ITaskItem[] correspondingOutputs) { }
+        public void RemoveDependencyFromEntry(Microsoft.Build.Framework.ITaskItem source, Microsoft.Build.Framework.ITaskItem dependencyToRemove) { }
+        public void RemoveDependencyFromEntry(Microsoft.Build.Framework.ITaskItem[] sources, Microsoft.Build.Framework.ITaskItem dependencyToRemove) { }
+        public void RemoveEntriesForSource(Microsoft.Build.Framework.ITaskItem source) { }
+        public void RemoveEntriesForSource(Microsoft.Build.Framework.ITaskItem source, Microsoft.Build.Framework.ITaskItem correspondingOutput) { }
+        public void RemoveEntriesForSource(Microsoft.Build.Framework.ITaskItem[] source) { }
+        public void RemoveEntriesForSource(Microsoft.Build.Framework.ITaskItem[] source, Microsoft.Build.Framework.ITaskItem[] correspondingOutputs) { }
+        public bool RemoveOutputForSourceRoot(string sourceRoot, string outputPathToRemove) { throw null; }
+        public string[] RemoveRootsWithSharedOutputs(Microsoft.Build.Framework.ITaskItem[] sources) { throw null; }
+        public void SaveTlog() { }
+        public void SaveTlog(Microsoft.Build.Utilities.DependencyFilter includeInTLog) { }
+    }
+    public partial class CommandLineBuilder
+    {
+        public CommandLineBuilder() { }
+        public CommandLineBuilder(bool quoteHyphensOnCommandLine) { }
+        protected System.Text.StringBuilder CommandLine { get { throw null; } }
+        public int Length { get { throw null; } }
+        public void AppendFileNameIfNotNull(Microsoft.Build.Framework.ITaskItem fileItem) { }
+        public void AppendFileNameIfNotNull(string fileName) { }
+        public void AppendFileNamesIfNotNull(Microsoft.Build.Framework.ITaskItem[] fileItems, string delimiter) { }
+        public void AppendFileNamesIfNotNull(string[] fileNames, string delimiter) { }
+        protected void AppendFileNameWithQuoting(string fileName) { }
+        protected void AppendQuotedTextToBuffer(System.Text.StringBuilder buffer, string unquotedTextToAppend) { }
+        protected void AppendSpaceIfNotEmpty() { }
+        public void AppendSwitch(string switchName) { }
+        public void AppendSwitchIfNotNull(string switchName, Microsoft.Build.Framework.ITaskItem parameter) { }
+        public void AppendSwitchIfNotNull(string switchName, Microsoft.Build.Framework.ITaskItem[] parameters, string delimiter) { }
+        public void AppendSwitchIfNotNull(string switchName, string parameter) { }
+        public void AppendSwitchIfNotNull(string switchName, string[] parameters, string delimiter) { }
+        public void AppendSwitchUnquotedIfNotNull(string switchName, Microsoft.Build.Framework.ITaskItem parameter) { }
+        public void AppendSwitchUnquotedIfNotNull(string switchName, Microsoft.Build.Framework.ITaskItem[] parameters, string delimiter) { }
+        public void AppendSwitchUnquotedIfNotNull(string switchName, string parameter) { }
+        public void AppendSwitchUnquotedIfNotNull(string switchName, string[] parameters, string delimiter) { }
+        public void AppendTextUnquoted(string textToAppend) { }
+        protected void AppendTextWithQuoting(string textToAppend) { }
+        protected virtual bool IsQuotingRequired(string parameter) { throw null; }
+        public override string ToString() { throw null; }
+        protected virtual void VerifyThrowNoEmbeddedDoubleQuotes(string switchName, string parameter) { }
+    }
+    public delegate bool DependencyFilter(string fullPath);
+    public enum DotNetFrameworkArchitecture
+    {
+        Bitness32 = 1,
+        Bitness64 = 2,
+        Current = 0,
+    }
+    public enum ExecutableType
+    {
+        Managed32Bit = 3,
+        Managed64Bit = 4,
+        ManagedIL = 2,
+        Native32Bit = 0,
+        Native64Bit = 1,
+        SameAsCurrentProcess = 5,
+    }
+    public static partial class FileTracker
+    {
+        public static string CreateRootingMarkerResponseFile(Microsoft.Build.Framework.ITaskItem[] sources) { throw null; }
+        public static string CreateRootingMarkerResponseFile(string rootMarker) { throw null; }
+        public static void EndTrackingContext() { }
+        public static string EnsureFileTrackerOnPath() { throw null; }
+        public static string EnsureFileTrackerOnPath(string rootPath) { throw null; }
+        public static bool FileIsExcludedFromDependencies(string fileName) { throw null; }
+        public static bool FileIsUnderPath(string fileName, string path) { throw null; }
+        public static string FindTrackerOnPath() { throw null; }
+        public static bool ForceOutOfProcTracking(Microsoft.Build.Utilities.ExecutableType toolType) { throw null; }
+        public static bool ForceOutOfProcTracking(Microsoft.Build.Utilities.ExecutableType toolType, string dllName, string cancelEventName) { throw null; }
+        public static string FormatRootingMarker(Microsoft.Build.Framework.ITaskItem source) { throw null; }
+        public static string FormatRootingMarker(Microsoft.Build.Framework.ITaskItem source, Microsoft.Build.Framework.ITaskItem output) { throw null; }
+        public static string FormatRootingMarker(Microsoft.Build.Framework.ITaskItem[] sources) { throw null; }
+        public static string FormatRootingMarker(Microsoft.Build.Framework.ITaskItem[] sources, Microsoft.Build.Framework.ITaskItem[] outputs) { throw null; }
+        public static string GetFileTrackerPath(Microsoft.Build.Utilities.ExecutableType toolType) { throw null; }
+        public static string GetFileTrackerPath(Microsoft.Build.Utilities.ExecutableType toolType, string rootPath) { throw null; }
+        public static string GetTrackerPath(Microsoft.Build.Utilities.ExecutableType toolType) { throw null; }
+        public static string GetTrackerPath(Microsoft.Build.Utilities.ExecutableType toolType, string rootPath) { throw null; }
+        public static void ResumeTracking() { }
+        public static void SetThreadCount(int threadCount) { }
+        public static System.Diagnostics.Process StartProcess(string command, string arguments, Microsoft.Build.Utilities.ExecutableType toolType) { throw null; }
+        public static System.Diagnostics.Process StartProcess(string command, string arguments, Microsoft.Build.Utilities.ExecutableType toolType, string rootFiles) { throw null; }
+        public static System.Diagnostics.Process StartProcess(string command, string arguments, Microsoft.Build.Utilities.ExecutableType toolType, string intermediateDirectory, string rootFiles) { throw null; }
+        public static System.Diagnostics.Process StartProcess(string command, string arguments, Microsoft.Build.Utilities.ExecutableType toolType, string dllName, string intermediateDirectory, string rootFiles) { throw null; }
+        public static System.Diagnostics.Process StartProcess(string command, string arguments, Microsoft.Build.Utilities.ExecutableType toolType, string dllName, string intermediateDirectory, string rootFiles, string cancelEventName) { throw null; }
+        public static void StartTrackingContext(string intermediateDirectory, string taskName) { }
+        public static void StartTrackingContextWithRoot(string intermediateDirectory, string taskName, string rootMarkerResponseFile) { }
+        public static void StopTrackingAndCleanup() { }
+        public static void SuspendTracking() { }
+        public static string TrackerArguments(string command, string arguments, string dllName, string intermediateDirectory, string rootFiles) { throw null; }
+        public static string TrackerArguments(string command, string arguments, string dllName, string intermediateDirectory, string rootFiles, string cancelEventName) { throw null; }
+        public static string TrackerCommandArguments(string command, string arguments) { throw null; }
+        public static string TrackerResponseFileArguments(string dllName, string intermediateDirectory, string rootFiles) { throw null; }
+        public static string TrackerResponseFileArguments(string dllName, string intermediateDirectory, string rootFiles, string cancelEventName) { throw null; }
+        public static void WriteAllTLogs(string intermediateDirectory, string taskName) { }
+        public static void WriteContextTLogs(string intermediateDirectory, string taskName) { }
+    }
+    public partial class FlatTrackingData
+    {
+        public FlatTrackingData(Microsoft.Build.Framework.ITask ownerTask, Microsoft.Build.Framework.ITaskItem[] tlogFiles, bool skipMissingFiles) { }
+        public FlatTrackingData(Microsoft.Build.Framework.ITask ownerTask, Microsoft.Build.Framework.ITaskItem[] tlogFiles, System.DateTime missingFileTimeUtc) { }
+        public FlatTrackingData(Microsoft.Build.Framework.ITaskItem[] tlogFiles, Microsoft.Build.Framework.ITaskItem[] tlogFilesToIgnore, System.DateTime missingFileTimeUtc) { }
+        public FlatTrackingData(Microsoft.Build.Framework.ITaskItem[] tlogFiles, Microsoft.Build.Framework.ITaskItem[] tlogFilesToIgnore, System.DateTime missingFileTimeUtc, string[] excludedInputPaths, System.Collections.Generic.IDictionary<string, System.DateTime> sharedLastWriteTimeUtcCache) { }
+        public FlatTrackingData(Microsoft.Build.Framework.ITaskItem[] tlogFiles, bool skipMissingFiles) { }
+        public FlatTrackingData(Microsoft.Build.Framework.ITaskItem[] tlogFiles, System.DateTime missingFileTimeUtc) { }
+        public System.Collections.Generic.List<string> MissingFiles { get { throw null; } set { } }
+        public string NewestFileName { get { throw null; } set { } }
+        public System.DateTime NewestFileTime { get { throw null; } set { } }
+        public System.DateTime NewestFileTimeUtc { get { throw null; } set { } }
+        public string NewestTLogFileName { get { throw null; } set { } }
+        public System.DateTime NewestTLogTime { get { throw null; } set { } }
+        public System.DateTime NewestTLogTimeUtc { get { throw null; } set { } }
+        public string OldestFileName { get { throw null; } set { } }
+        public System.DateTime OldestFileTime { get { throw null; } set { } }
+        public System.DateTime OldestFileTimeUtc { get { throw null; } set { } }
+        public bool SkipMissingFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TlogFiles { get { throw null; } set { } }
+        public bool TlogsAvailable { get { throw null; } set { } }
+        public bool TreatRootMarkersAsEntries { get { throw null; } set { } }
+        public bool FileIsExcludedFromDependencyCheck(string fileName) { throw null; }
+        public static void FinalizeTLogs(bool trackedOperationsSucceeded, Microsoft.Build.Framework.ITaskItem[] readTLogNames, Microsoft.Build.Framework.ITaskItem[] writeTLogNames, Microsoft.Build.Framework.ITaskItem[] trackedFilesToRemoveFromTLogs) { }
+        public System.DateTime GetLastWriteTimeUtc(string file) { throw null; }
+        public static bool IsUpToDate(Microsoft.Build.Utilities.Task hostTask, Microsoft.Build.Utilities.UpToDateCheckType upToDateCheckType, Microsoft.Build.Framework.ITaskItem[] readTLogNames, Microsoft.Build.Framework.ITaskItem[] writeTLogNames) { throw null; }
+        public static bool IsUpToDate(Microsoft.Build.Utilities.TaskLoggingHelper Log, Microsoft.Build.Utilities.UpToDateCheckType upToDateCheckType, Microsoft.Build.Utilities.FlatTrackingData inputs, Microsoft.Build.Utilities.FlatTrackingData outputs) { throw null; }
+        public void SaveTlog() { }
+        public void SaveTlog(Microsoft.Build.Utilities.DependencyFilter includeInTLog) { }
+        public void UpdateFileEntryDetails() { }
+    }
+    public enum HostObjectInitializationStatus
+    {
+        NoActionReturnFailure = 3,
+        NoActionReturnSuccess = 2,
+        UseAlternateToolToExecute = 1,
+        UseHostObjectToExecute = 0,
+    }
+    public abstract partial class Logger : Microsoft.Build.Framework.ILogger
+    {
+        protected Logger() { }
+        public virtual string Parameters { get { throw null; } set { } }
+        public virtual Microsoft.Build.Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }
+        public virtual string FormatErrorEvent(Microsoft.Build.Framework.BuildErrorEventArgs args) { throw null; }
+        public virtual string FormatWarningEvent(Microsoft.Build.Framework.BuildWarningEventArgs args) { throw null; }
+        public abstract void Initialize(Microsoft.Build.Framework.IEventSource eventSource);
+        public bool IsVerbosityAtLeast(Microsoft.Build.Framework.LoggerVerbosity checkVerbosity) { throw null; }
+        public virtual void Shutdown() { }
+    }
+    public enum MultipleVersionSupport
+    {
+        Allow = 0,
+        Error = 2,
+        Warning = 1,
+    }
+    public partial class MuxLogger : Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
+    {
+        public MuxLogger() { }
+        public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
+        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int maxNodeCount) { }
+        public void RegisterLogger(int submissionId, Microsoft.Build.Framework.ILogger logger) { }
+        public void Shutdown() { }
+        public bool UnregisterLoggers(int submissionId) { throw null; }
+    }
+    public static partial class ProcessorArchitecture
+    {
+        public const string AMD64 = "AMD64";
+        public const string ARM = "ARM";
+        public const string IA64 = "IA64";
+        public const string MSIL = "MSIL";
+        public const string X86 = "x86";
+        public static string CurrentProcessArchitecture { get { throw null; } }
+    }
+    public partial class SDKManifest
+    {
+        public SDKManifest(string pathToSdk) { }
+        public System.Collections.Generic.IDictionary<string, string> AppxLocations { get { throw null; } }
+        public string CopyRedistToSubDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string DependsOnSDK { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string DisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, string> FrameworkIdentities { get { throw null; } }
+        public string FrameworkIdentity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string MaxOSVersionTested { get { throw null; } }
+        public string MaxPlatformVersion { get { throw null; } }
+        public string MinOSVersion { get { throw null; } }
+        public string MinVSVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string MoreInfo { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string PlatformIdentity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string ProductFamilyName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool ReadError { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string ReadErrorMessage { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Utilities.SDKType SDKType { get { throw null; } }
+        public string SupportedArchitectures { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string SupportPrefer32Bit { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Utilities.MultipleVersionSupport SupportsMultipleVersions { get { throw null; } }
+        public string TargetPlatform { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string TargetPlatformMinVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string TargetPlatformVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public static partial class Attributes
+        {
+            public const string APPX = "APPX";
+            public const string AppxLocation = "AppxLocation";
+            public const string CopyLocalExpandedReferenceAssemblies = "CopyLocalExpandedReferenceAssemblies";
+            public const string CopyRedist = "CopyRedist";
+            public const string CopyRedistToSubDirectory = "CopyRedistToSubDirectory";
+            public const string DependsOnSDK = "DependsOn";
+            public const string DisplayName = "DisplayName";
+            public const string ExpandReferenceAssemblies = "ExpandReferenceAssemblies";
+            public const string FrameworkIdentity = "FrameworkIdentity";
+            public const string MaxOSVersionTested = "MaxOSVersionTested";
+            public const string MaxPlatformVersion = "MaxPlatformVersion";
+            public const string MinOSVersion = "MinOSVersion";
+            public const string MinVSVersion = "MinVSVersion";
+            public const string MoreInfo = "MoreInfo";
+            public const string PlatformIdentity = "PlatformIdentity";
+            public const string ProductFamilyName = "ProductFamilyName";
+            public const string SDKType = "SDKType";
+            public const string SupportedArchitectures = "SupportedArchitectures";
+            public const string SupportPrefer32Bit = "SupportPrefer32Bit";
+            public const string SupportsMultipleVersions = "SupportsMultipleVersions";
+            public const string TargetedSDK = "TargetedSDKArchitecture";
+            public const string TargetedSDKConfiguration = "TargetedSDKConfiguration";
+            public const string TargetPlatform = "TargetPlatform";
+            public const string TargetPlatformMinVersion = "TargetPlatformMinVersion";
+            public const string TargetPlatformVersion = "TargetPlatformVersion";
+        }
+    }
+    public enum SDKType
+    {
+        External = 1,
+        Framework = 3,
+        Platform = 2,
+        Unspecified = 0,
+    }
+    public enum TargetDotNetFrameworkVersion
+    {
+        Version11 = 0,
+        Version20 = 1,
+        Version30 = 2,
+        Version35 = 3,
+        Version40 = 4,
+        Version45 = 5,
+        Version451 = 6,
+        Version452 = 9,
+        Version46 = 7,
+        Version461 = 8,
+        VersionLatest = 8,
+    }
+    public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
+    {
+        public TargetPlatformSDK(string targetPlatformIdentifier, System.Version targetPlatformVersion, string path) { }
+        public string DisplayName { get { throw null; } }
+        public System.Version MinOSVersion { get { throw null; } }
+        public System.Version MinVSVersion { get { throw null; } }
+        public string Path { get { throw null; } set { } }
+        public string TargetPlatformIdentifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Version TargetPlatformVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool ContainsPlatform(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+        public bool Equals(Microsoft.Build.Utilities.TargetPlatformSDK other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+    }
+    public abstract partial class Task : Microsoft.Build.Framework.ITask
+    {
+        protected Task() { }
+        protected Task(System.Resources.ResourceManager taskResources) { }
+        protected Task(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+        public Microsoft.Build.Framework.IBuildEngine BuildEngine { get { throw null; } set { } }
+        public Microsoft.Build.Framework.IBuildEngine2 BuildEngine2 { get { throw null; } }
+        public Microsoft.Build.Framework.IBuildEngine3 BuildEngine3 { get { throw null; } }
+        public Microsoft.Build.Framework.IBuildEngine4 BuildEngine4 { get { throw null; } }
+        protected string HelpKeywordPrefix { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskHost HostObject { get { throw null; } set { } }
+        public Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
+        protected System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+        public abstract bool Execute();
+    }
+    public sealed partial class TaskItem : System.MarshalByRefObject, Microsoft.Build.Framework.ITaskItem, Microsoft.Build.Framework.ITaskItem2
+    {
+        public TaskItem() { }
+        public TaskItem(Microsoft.Build.Framework.ITaskItem sourceItem) { }
+        public TaskItem(string itemSpec) { }
+        public TaskItem(string itemSpec, System.Collections.IDictionary itemMetadata) { }
+        public string ItemSpec { get { throw null; } set { } }
+        public int MetadataCount { get { throw null; } }
+        public System.Collections.ICollection MetadataNames { get { throw null; } }
+        string Microsoft.Build.Framework.ITaskItem2.EvaluatedIncludeEscaped { get { throw null; } set { } }
+        public System.Collections.IDictionary CloneCustomMetadata() { throw null; }
+        public void CopyMetadataTo(Microsoft.Build.Framework.ITaskItem destinationItem) { }
+        public string GetMetadata(string metadataName) { throw null; }
+        [System.Security.SecurityCriticalAttribute]
+        public override object InitializeLifetimeService() { throw null; }
+        System.Collections.IDictionary Microsoft.Build.Framework.ITaskItem2.CloneCustomMetadataEscaped() { throw null; }
+        string Microsoft.Build.Framework.ITaskItem2.GetMetadataValueEscaped(string metadataName) { throw null; }
+        void Microsoft.Build.Framework.ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue) { }
+        public static explicit operator string (Microsoft.Build.Utilities.TaskItem taskItemToCast) { throw null; }
+        public void RemoveMetadata(string metadataName) { }
+        public void SetMetadata(string metadataName, string metadataValue) { }
+        public override string ToString() { throw null; }
+    }
+    public partial class TaskLoggingHelper : System.MarshalByRefObject
+    {
+        public TaskLoggingHelper(Microsoft.Build.Framework.IBuildEngine buildEngine, string taskName) { }
+        public TaskLoggingHelper(Microsoft.Build.Framework.ITask taskInstance) { }
+        protected Microsoft.Build.Framework.IBuildEngine BuildEngine { get { throw null; } }
+        public bool HasLoggedErrors { get { throw null; } }
+        public string HelpKeywordPrefix { get { throw null; } set { } }
+        protected string TaskName { get { throw null; } }
+        public System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+        public string ExtractMessageCode(string message, out string messageWithoutCodePrefix) { messageWithoutCodePrefix = default(string); throw null; }
+        public virtual string FormatResourceString(string resourceName, params object[] args) { throw null; }
+        public virtual string FormatString(string unformatted, params object[] args) { throw null; }
+        public virtual string GetResourceMessage(string resourceName) { throw null; }
+        public override object InitializeLifetimeService() { throw null; }
+        public void LogCommandLine(Microsoft.Build.Framework.MessageImportance importance, string commandLine) { }
+        public void LogCommandLine(string commandLine) { }
+        public void LogCriticalMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogError(string message, params object[] messageArgs) { }
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogErrorFromException(System.Exception exception) { }
+        public void LogErrorFromException(System.Exception exception, bool showStackTrace) { }
+        public void LogErrorFromException(System.Exception exception, bool showStackTrace, bool showDetail, string file) { }
+        public void LogErrorFromResources(string messageResourceName, params object[] messageArgs) { }
+        public void LogErrorFromResources(string subcategoryResourceName, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+        public void LogErrorWithCodeFromResources(string messageResourceName, params object[] messageArgs) { }
+        public void LogErrorWithCodeFromResources(string subcategoryResourceName, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+        public void LogExternalProjectFinished(string message, string helpKeyword, string projectFile, bool succeeded) { }
+        public void LogExternalProjectStarted(string message, string helpKeyword, string projectFile, string targetNames) { }
+        public void LogMessage(Microsoft.Build.Framework.MessageImportance importance, string message, params object[] messageArgs) { }
+        public void LogMessage(string message, params object[] messageArgs) { }
+        public void LogMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, Microsoft.Build.Framework.MessageImportance importance, string message, params object[] messageArgs) { }
+        public void LogMessageFromResources(Microsoft.Build.Framework.MessageImportance importance, string messageResourceName, params object[] messageArgs) { }
+        public void LogMessageFromResources(string messageResourceName, params object[] messageArgs) { }
+        public bool LogMessageFromText(string lineOfText, Microsoft.Build.Framework.MessageImportance messageImportance) { throw null; }
+        public bool LogMessagesFromFile(string fileName) { throw null; }
+        public bool LogMessagesFromFile(string fileName, Microsoft.Build.Framework.MessageImportance messageImportance) { throw null; }
+        public bool LogMessagesFromStream(System.IO.TextReader stream, Microsoft.Build.Framework.MessageImportance messageImportance) { throw null; }
+        public void LogWarning(string message, params object[] messageArgs) { }
+        public void LogWarning(string subcategory, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+        public void LogWarningFromException(System.Exception exception) { }
+        public void LogWarningFromException(System.Exception exception, bool showStackTrace) { }
+        public void LogWarningFromResources(string messageResourceName, params object[] messageArgs) { }
+        public void LogWarningFromResources(string subcategoryResourceName, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+        public void LogWarningWithCodeFromResources(string messageResourceName, params object[] messageArgs) { }
+        public void LogWarningWithCodeFromResources(string subcategoryResourceName, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+        public void MarkAsInactive() { }
+    }
+    public static partial class ToolLocationHelper
+    {
+        public static string CurrentToolsVersion { get { throw null; } }
+        public static string PathToSystem { get { throw null; } }
+        public static void ClearSDKStaticCache() { }
+        public static System.Collections.Generic.IDictionary<string, string> FilterPlatformExtensionSDKs(System.Version targetPlatformVersion, System.Collections.Generic.IDictionary<string, string> extensionSdks) { throw null; }
+        public static System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> FilterTargetPlatformSdks(System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> targetPlatformSdkList, System.Version osVersion, System.Version vsVersion) { throw null; }
+        public static System.Collections.Generic.IList<Microsoft.Build.Utilities.AssemblyFoldersExInfo> GetAssemblyFoldersExInfo(string registryRoot, string targetFrameworkVersion, string registryKeySuffix, string osVersion, string platform, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
+        public static string GetDisplayNameForTargetFrameworkDirectory(string targetFrameworkDirectory, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+        public static string GetDotNetFrameworkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetDotNetFrameworkSdkInstallKeyValue(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetDotNetFrameworkSdkInstallKeyValue(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion) { throw null; }
+        public static string GetDotNetFrameworkSdkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetDotNetFrameworkSdkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion) { throw null; }
+        public static string GetDotNetFrameworkVersionFolderPrefix(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion) { throw null; }
+        public static string GetPathToBuildTools(string toolsVersion) { throw null; }
+        public static string GetPathToBuildTools(string toolsVersion, Microsoft.Build.Utilities.DotNetFrameworkArchitecture architecture) { throw null; }
+        public static string GetPathToBuildToolsFile(string fileName, string toolsVersion) { throw null; }
+        public static string GetPathToBuildToolsFile(string fileName, string toolsVersion, Microsoft.Build.Utilities.DotNetFrameworkArchitecture architecture) { throw null; }
+        public static string GetPathToDotNetFramework(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetPathToDotNetFramework(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.DotNetFrameworkArchitecture architecture) { throw null; }
+        public static string GetPathToDotNetFrameworkFile(string fileName, Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetPathToDotNetFrameworkFile(string fileName, Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.DotNetFrameworkArchitecture architecture) { throw null; }
+        public static string GetPathToDotNetFrameworkReferenceAssemblies(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetPathToDotNetFrameworkSdk() { throw null; }
+        public static string GetPathToDotNetFrameworkSdk(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetPathToDotNetFrameworkSdk(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion) { throw null; }
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName) { throw null; }
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.DotNetFrameworkArchitecture architecture) { throw null; }
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion) { throw null; }
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion, Microsoft.Build.Utilities.DotNetFrameworkArchitecture architecture) { throw null; }
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkRootPath, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile) { throw null; }
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile) { throw null; }
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget) { throw null; }
+        public static string GetPathToSystemFile(string fileName) { throw null; }
+        [System.ObsoleteAttribute("Consider using GetPlatformSDKLocation instead")]
+        public static string GetPathToWindowsSdk(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion) { throw null; }
+        [System.ObsoleteAttribute("Consider using GetPlatformSDKLocationFile instead")]
+        public static string GetPathToWindowsSdkFile(string fileName, Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion) { throw null; }
+        [System.ObsoleteAttribute("Consider using GetPlatformSDKLocationFile instead")]
+        public static string GetPathToWindowsSdkFile(string fileName, Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion, Microsoft.Build.Utilities.DotNetFrameworkArchitecture architecture) { throw null; }
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string extensionDiskRoots, string registryRoot) { throw null; }
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string registryRoot) { throw null; }
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string[] extensionDiskRoots, string registryRoot) { throw null; }
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string[] diskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string[] diskRoots, string[] extensionDiskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string[] diskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string[] diskRoots, string[] multiPlatformDiskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+        public static string[] GetPlatformOrFrameworkExtensionSdkReferences(string extensionSdkMoniker, string targetSdkIdentifier, string targetSdkVersion, string diskRoots, string extensionDiskRoots, string registryRoot) { throw null; }
+        public static string GetPlatformSDKDisplayName(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+        public static string GetPlatformSDKDisplayName(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string registryRoot) { throw null; }
+        public static string GetPlatformSDKPropsFileLocation(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion) { throw null; }
+        public static string GetPlatformSDKPropsFileLocation(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+        public static System.Collections.Generic.IEnumerable<string> GetPlatformsForSDK(string sdkIdentifier, System.Version sdkVersion) { throw null; }
+        public static System.Collections.Generic.IEnumerable<string> GetPlatformsForSDK(string sdkIdentifier, System.Version sdkVersion, string[] diskRoots, string registryRoot) { throw null; }
+        public static string GetProgramFilesReferenceAssemblyRoot() { throw null; }
+        public static System.Collections.Generic.IList<string> GetSDKDesignTimeFolders(string sdkRoot) { throw null; }
+        public static System.Collections.Generic.IList<string> GetSDKDesignTimeFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+        public static System.Collections.Generic.IList<string> GetSDKRedistFolders(string sdkRoot) { throw null; }
+        public static System.Collections.Generic.IList<string> GetSDKRedistFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+        public static System.Collections.Generic.IList<string> GetSDKReferenceFolders(string sdkRoot) { throw null; }
+        public static System.Collections.Generic.IList<string> GetSDKReferenceFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+        public static System.Collections.Generic.IList<string> GetSupportedTargetFrameworks() { throw null; }
+        public static string[] GetTargetPlatformReferences(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion) { throw null; }
+        public static string[] GetTargetPlatformReferences(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+        public static System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> GetTargetPlatformSdks() { throw null; }
+        public static System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> GetTargetPlatformSdks(string[] diskRoots, string registryRoot) { throw null; }
+        public static System.Runtime.Versioning.FrameworkName HighestVersionOfTargetFrameworkIdentifier(string targetFrameworkRootDirectory, string frameworkIdentifier) { throw null; }
+    }
+    public abstract partial class ToolTask : Microsoft.Build.Utilities.Task, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
+    {
+        protected ToolTask() { }
+        protected ToolTask(System.Resources.ResourceManager taskResources) { }
+        protected ToolTask(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+        public bool EchoOff { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ObsoleteAttribute("Use EnvironmentVariables property")]
+        protected virtual System.Collections.Specialized.StringDictionary EnvironmentOverride { get { throw null; } }
+        public string[] EnvironmentVariables { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public int ExitCode { get { throw null; } }
+        protected virtual bool HasLoggedErrors { get { throw null; } }
+        public bool LogStandardErrorAsError { get { throw null; } set { } }
+        protected virtual System.Text.Encoding ResponseFileEncoding { get { throw null; } }
+        protected virtual System.Text.Encoding StandardErrorEncoding { get { throw null; } }
+        public string StandardErrorImportance { get { throw null; } set { } }
+        protected Microsoft.Build.Framework.MessageImportance StandardErrorImportanceToUse { get { throw null; } }
+        protected virtual Microsoft.Build.Framework.MessageImportance StandardErrorLoggingImportance { get { throw null; } }
+        protected virtual System.Text.Encoding StandardOutputEncoding { get { throw null; } }
+        public string StandardOutputImportance { get { throw null; } set { } }
+        protected Microsoft.Build.Framework.MessageImportance StandardOutputImportanceToUse { get { throw null; } }
+        protected virtual Microsoft.Build.Framework.MessageImportance StandardOutputLoggingImportance { get { throw null; } }
+        protected int TaskProcessTerminationTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public virtual int Timeout { get { throw null; } set { } }
+        protected System.Threading.ManualResetEvent ToolCanceled { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public virtual string ToolExe { get { throw null; } set { } }
+        protected abstract string ToolName { get; }
+        public string ToolPath { get { throw null; } set { } }
+        public bool UseCommandProcessor { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool YieldDuringToolExecution { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        protected virtual bool CallHostObjectToExecute() { throw null; }
+        public virtual void Cancel() { }
+        protected void DeleteTempFile(string fileName) { }
+        public override bool Execute() { throw null; }
+        protected virtual int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands) { throw null; }
+        protected virtual string GenerateCommandLineCommands() { throw null; }
+        protected abstract string GenerateFullPathToTool();
+        protected virtual string GenerateResponseFileCommands() { throw null; }
+        protected System.Diagnostics.ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch) { throw null; }
+        protected virtual string GetResponseFileSwitch(string responseFilePath) { throw null; }
+        protected virtual string GetWorkingDirectory() { throw null; }
+        protected virtual bool HandleTaskExecutionErrors() { throw null; }
+        protected virtual Microsoft.Build.Utilities.HostObjectInitializationStatus InitializeHostObject() { throw null; }
+        protected virtual void LogEventsFromTextOutput(string singleLine, Microsoft.Build.Framework.MessageImportance messageImportance) { }
+        protected virtual void LogPathToTool(string toolName, string pathToTool) { }
+        protected virtual void LogToolCommand(string message) { }
+        protected virtual string ResponseFileEscape(string responseString) { throw null; }
+        protected virtual bool SkipTaskExecution() { throw null; }
+        protected internal virtual bool ValidateParameters() { throw null; }
+    }
+    public static partial class TrackedDependencies
+    {
+        public static Microsoft.Build.Framework.ITaskItem[] ExpandWildcards(Microsoft.Build.Framework.ITaskItem[] expand) { throw null; }
+    }
+    public enum UpToDateCheckType
+    {
+        InputNewerThanOutput = 0,
+        InputNewerThanTracking = 2,
+        InputOrOutputNewerThanTracking = 1,
+    }
+    public enum VisualStudioVersion
+    {
+        Version100 = 0,
+        Version110 = 1,
+        Version120 = 2,
+        Version140 = 3,
+        VersionLatest = 3,
+    }
+}

--- a/build/LegacyPackages/14.0/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -1,5 +1,6 @@
 namespace Microsoft.Build.Utilities
 {
+#if !NETSTANDARD
     [Microsoft.Build.Framework.LoadInSeparateAppDomainAttribute]
     public abstract partial class AppDomainIsolatedTask : System.MarshalByRefObject, Microsoft.Build.Framework.ITask
     {
@@ -74,6 +75,7 @@ namespace Microsoft.Build.Utilities
         public void SaveTlog() { }
         public void SaveTlog(Microsoft.Build.Utilities.DependencyFilter includeInTLog) { }
     }
+#endif
     public partial class CommandLineBuilder
     {
         public CommandLineBuilder() { }
@@ -102,13 +104,16 @@ namespace Microsoft.Build.Utilities
         public override string ToString() { throw null; }
         protected virtual void VerifyThrowNoEmbeddedDoubleQuotes(string switchName, string parameter) { }
     }
+#if !NETSTANDARD
     public delegate bool DependencyFilter(string fullPath);
+#endif
     public enum DotNetFrameworkArchitecture
     {
         Bitness32 = 1,
         Bitness64 = 2,
         Current = 0,
     }
+#if !NETSTANDARD
     public enum ExecutableType
     {
         Managed32Bit = 3,
@@ -188,6 +193,7 @@ namespace Microsoft.Build.Utilities
         public void SaveTlog(Microsoft.Build.Utilities.DependencyFilter includeInTLog) { }
         public void UpdateFileEntryDetails() { }
     }
+#endif
     public enum HostObjectInitializationStatus
     {
         NoActionReturnFailure = 3,
@@ -336,7 +342,11 @@ namespace Microsoft.Build.Utilities
         protected System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
         public abstract bool Execute();
     }
-    public sealed partial class TaskItem : System.MarshalByRefObject, Microsoft.Build.Framework.ITaskItem, Microsoft.Build.Framework.ITaskItem2
+    public sealed partial class TaskItem :
+#if !NETSTANDARD
+        System.MarshalByRefObject,
+#endif
+        Microsoft.Build.Framework.ITaskItem, Microsoft.Build.Framework.ITaskItem2
     {
         public TaskItem() { }
         public TaskItem(Microsoft.Build.Framework.ITaskItem sourceItem) { }
@@ -349,8 +359,10 @@ namespace Microsoft.Build.Utilities
         public System.Collections.IDictionary CloneCustomMetadata() { throw null; }
         public void CopyMetadataTo(Microsoft.Build.Framework.ITaskItem destinationItem) { }
         public string GetMetadata(string metadataName) { throw null; }
+#if !NETSTANDARD
         [System.Security.SecurityCriticalAttribute]
         public override object InitializeLifetimeService() { throw null; }
+#endif
         System.Collections.IDictionary Microsoft.Build.Framework.ITaskItem2.CloneCustomMetadataEscaped() { throw null; }
         string Microsoft.Build.Framework.ITaskItem2.GetMetadataValueEscaped(string metadataName) { throw null; }
         void Microsoft.Build.Framework.ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue) { }
@@ -359,7 +371,10 @@ namespace Microsoft.Build.Utilities
         public void SetMetadata(string metadataName, string metadataValue) { }
         public override string ToString() { throw null; }
     }
-    public partial class TaskLoggingHelper : System.MarshalByRefObject
+    public partial class TaskLoggingHelper
+#if !NETSTANDARD
+        : System.MarshalByRefObject
+#endif
     {
         public TaskLoggingHelper(Microsoft.Build.Framework.IBuildEngine buildEngine, string taskName) { }
         public TaskLoggingHelper(Microsoft.Build.Framework.ITask taskInstance) { }
@@ -372,7 +387,9 @@ namespace Microsoft.Build.Utilities
         public virtual string FormatResourceString(string resourceName, params object[] args) { throw null; }
         public virtual string FormatString(string unformatted, params object[] args) { throw null; }
         public virtual string GetResourceMessage(string resourceName) { throw null; }
+#if !NETSTANDARD
         public override object InitializeLifetimeService() { throw null; }
+#endif
         public void LogCommandLine(Microsoft.Build.Framework.MessageImportance importance, string commandLine) { }
         public void LogCommandLine(string commandLine) { }
         public void LogCriticalMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
@@ -404,7 +421,9 @@ namespace Microsoft.Build.Utilities
         public void LogWarningFromResources(string subcategoryResourceName, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
         public void LogWarningWithCodeFromResources(string messageResourceName, params object[] messageArgs) { }
         public void LogWarningWithCodeFromResources(string subcategoryResourceName, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+#if !NETSTANDARD
         public void MarkAsInactive() { }
+#endif
     }
     public static partial class ToolLocationHelper
     {
@@ -413,7 +432,9 @@ namespace Microsoft.Build.Utilities
         public static void ClearSDKStaticCache() { }
         public static System.Collections.Generic.IDictionary<string, string> FilterPlatformExtensionSDKs(System.Version targetPlatformVersion, System.Collections.Generic.IDictionary<string, string> extensionSdks) { throw null; }
         public static System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> FilterTargetPlatformSdks(System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> targetPlatformSdkList, System.Version osVersion, System.Version vsVersion) { throw null; }
+#if !NETSTANDARD
         public static System.Collections.Generic.IList<Microsoft.Build.Utilities.AssemblyFoldersExInfo> GetAssemblyFoldersExInfo(string registryRoot, string targetFrameworkVersion, string registryKeySuffix, string osVersion, string platform, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
+#endif
         public static string GetDisplayNameForTargetFrameworkDirectory(string targetFrameworkDirectory, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
         public static string GetDotNetFrameworkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
         public static string GetDotNetFrameworkSdkInstallKeyValue(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
@@ -542,12 +563,14 @@ namespace Microsoft.Build.Utilities
     {
         public static Microsoft.Build.Framework.ITaskItem[] ExpandWildcards(Microsoft.Build.Framework.ITaskItem[] expand) { throw null; }
     }
+#if !NETSTANDARD
     public enum UpToDateCheckType
     {
         InputNewerThanOutput = 0,
         InputNewerThanTracking = 2,
         InputOrOutputNewerThanTracking = 1,
     }
+#endif
     public enum VisualStudioVersion
     {
         Version100 = 0,

--- a/build/LegacyPackages/14.0/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.nuspec
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$id$</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <iconUrl>$iconUrl$</iconUrl>
+    <description>This package contains the $id$ assembly which is used to implement custom MSBuild tasks.</description>
+    <tags>MSBuild</tags>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="System.Collections.Specialized" version="4.0.1" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Resources.Reader" version="4.0.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+      </group>
+      <group targetFramework="net45">
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="lib\net45\$id$.dll" target="lib\net45\$id$.dll" />
+    <file src="bin\$configuration$\net45\$id$.dll" target="ref\net45\$id$.dll" />
+    <file src="bin\$configuration$\netstandard1.3\$id$.dll" target="ref\netstandard1.3\$id$.dll" />
+  </files>
+</package>

--- a/build/LegacyPackages/14.0/Microsoft.Build.Utilities.Core/project.json
+++ b/build/LegacyPackages/14.0/Microsoft.Build.Utilities.Core/project.json
@@ -1,0 +1,30 @@
+{
+  "version": "14.0.0.0",
+  "buildOptions": {
+    "keyFile": "../../../../Tools/MSFT.snk",
+    "publicSign": true
+  },
+  "dependencies": {
+    "Microsoft.Build.Framework": {
+      "target": "project"
+    }
+  },
+  "frameworks": {
+    "net45": {
+      "frameworkAssemblies": {
+
+      }
+    },
+    "netstandard1.3": {
+      "buildOptions": {
+        "define": [ "NETSTANDARD" ]
+      },
+      "dependencies": {
+        "System.Collections.Specialized": "4.0.1",
+        "System.Diagnostics.Process": "4.1.0",
+        "System.Resources.Reader": "4.0.0",
+        "System.Runtime.Extensions": "4.1.0"
+      }
+    }
+  }
+}

--- a/build/LegacyPackages/14.0/Microsoft.Build/Microsoft.Build.cs
+++ b/build/LegacyPackages/14.0/Microsoft.Build/Microsoft.Build.cs
@@ -761,12 +761,16 @@ namespace Microsoft.Build.Exceptions
     public partial class BuildAbortedException : System.Exception
     {
         public BuildAbortedException() { }
+#if !NETSTANDARD
         protected BuildAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#endif
         public BuildAbortedException(string message) { }
         public BuildAbortedException(string message, System.Exception innerException) { }
         public string ErrorCode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+#if !NETSTANDARD
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#endif
     }
     public sealed partial class InternalLoggerException : System.Exception
     {
@@ -777,8 +781,10 @@ namespace Microsoft.Build.Exceptions
         public string ErrorCode { get { throw null; } }
         public string HelpKeyword { get { throw null; } }
         public bool InitializationException { get { throw null; } }
+#if !NETSTANDARD
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#endif
     }
     public sealed partial class InvalidProjectFileException : System.Exception
     {
@@ -797,20 +803,26 @@ namespace Microsoft.Build.Exceptions
         public int LineNumber { get { throw null; } }
         public override string Message { get { throw null; } }
         public string ProjectFile { get { throw null; } }
+#if !NETSTANDARD
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#endif
     }
     public partial class InvalidToolsetDefinitionException : System.Exception
     {
         public InvalidToolsetDefinitionException() { }
+#if !NETSTANDARD
         protected InvalidToolsetDefinitionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#endif
         public InvalidToolsetDefinitionException(string message) { }
         public InvalidToolsetDefinitionException(string message, System.Exception innerException) { }
         public InvalidToolsetDefinitionException(string message, string errorCode) { }
         public InvalidToolsetDefinitionException(string message, string errorCode, System.Exception innerException) { }
         public string ErrorCode { get { throw null; } }
+#if !NETSTANDARD
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#endif
     }
 }
 namespace Microsoft.Build.Execution
@@ -837,7 +849,9 @@ namespace Microsoft.Build.Execution
         public BuildParameters() { }
         public BuildParameters(Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.IDictionary<string, string> BuildProcessEnvironment { get { throw null; } }
+#if !NETSTANDARD
         public System.Threading.ThreadPriority BuildThreadPriority { get { throw null; } set { } }
+#endif
         public System.Globalization.CultureInfo Culture { get { throw null; } set { } }
         public string DefaultToolsVersion { get { throw null; } set { } }
         public bool DetailedSummary { get { throw null; } set { } }

--- a/build/LegacyPackages/14.0/Microsoft.Build/Microsoft.Build.cs
+++ b/build/LegacyPackages/14.0/Microsoft.Build/Microsoft.Build.cs
@@ -1,0 +1,1331 @@
+namespace Microsoft.Build.Construction
+{
+    public abstract partial class ElementLocation
+    {
+        protected ElementLocation() { }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public abstract int Column { get; }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public abstract string File { get; }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public abstract int Line { get; }
+        public string LocationString { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("ProjectChooseElement (#Children={Count} HasOtherwise={OtherwiseElement != null})")]
+    public partial class ProjectChooseElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectChooseElement() { }
+        public override string Condition { get { throw null; } set { } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectOtherwiseElement OtherwiseElement { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectWhenElement> WhenElements { get { throw null; } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    public sealed partial class ProjectConfigurationInSolution
+    {
+        internal ProjectConfigurationInSolution() { }
+        public string ConfigurationName { get { throw null; } }
+        public string FullName { get { throw null; } }
+        public bool IncludeInBuild { get { throw null; } }
+        public string PlatformName { get { throw null; } }
+    }
+    public abstract partial class ProjectElement
+    {
+        internal ProjectElement() { }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Construction.ProjectElementContainer> AllParents { get { throw null; } }
+        public virtual string Condition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public virtual Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectRootElement ContainingProject { get { throw null; } }
+        public string Label { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation LabelLocation { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectElement NextSibling { [System.Diagnostics.DebuggerStepThroughAttribute, System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ProjectElementContainer Parent { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ProjectElement PreviousSibling { [System.Diagnostics.DebuggerStepThroughAttribute, System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ProjectElement Clone() { throw null; }
+        protected internal virtual Microsoft.Build.Construction.ProjectElement Clone(Microsoft.Build.Construction.ProjectRootElement factory) { throw null; }
+        public virtual void CopyFrom(Microsoft.Build.Construction.ProjectElement element) { }
+        protected abstract Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner);
+    }
+    public abstract partial class ProjectElementContainer : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectElementContainer() { }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Construction.ProjectElement> AllChildren { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectElement> Children { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectElement> ChildrenReversed { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public int Count { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ProjectElement FirstChild { [System.Diagnostics.DebuggerStepThroughAttribute, System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ProjectElement LastChild { [System.Diagnostics.DebuggerStepThroughAttribute, System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public void AppendChild(Microsoft.Build.Construction.ProjectElement child) { }
+        protected internal virtual Microsoft.Build.Construction.ProjectElementContainer DeepClone(Microsoft.Build.Construction.ProjectRootElement factory, Microsoft.Build.Construction.ProjectElementContainer parent) { throw null; }
+        public virtual void DeepCopyFrom(Microsoft.Build.Construction.ProjectElementContainer element) { }
+        public void InsertAfterChild(Microsoft.Build.Construction.ProjectElement child, Microsoft.Build.Construction.ProjectElement reference) { }
+        public void InsertBeforeChild(Microsoft.Build.Construction.ProjectElement child, Microsoft.Build.Construction.ProjectElement reference) { }
+        public void PrependChild(Microsoft.Build.Construction.ProjectElement child) { }
+        public void RemoveAllChildren() { }
+        public void RemoveChild(Microsoft.Build.Construction.ProjectElement child) { }
+    }
+    public partial class ProjectExtensionsElement : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectExtensionsElement() { }
+        public override string Condition { get { throw null; } set { } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public string Content { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public string this[string name] { get { throw null; } set { } }
+        public override void CopyFrom(Microsoft.Build.Construction.ProjectElement element) { }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Project={Project} Condition={Condition}")]
+    public partial class ProjectImportElement : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectImportElement() { }
+        public string Project { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation ProjectLocation { get { throw null; } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("#Imports={Count} Condition={Condition} Label={Label}")]
+    public partial class ProjectImportGroupElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectImportGroupElement() { }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectImportElement> Imports { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectImportElement AddImport(string project) { throw null; }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    public sealed partial class ProjectInSolution
+    {
+        internal ProjectInSolution() { }
+        public string AbsolutePath { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> Dependencies { get { throw null; } }
+        public string ParentProjectGuid { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Build.Construction.ProjectConfigurationInSolution> ProjectConfigurations { get { throw null; } }
+        public string ProjectGuid { get { throw null; } }
+        public string ProjectName { get { throw null; } }
+        public Microsoft.Build.Construction.SolutionProjectType ProjectType { get { throw null; } set { } }
+        public string RelativePath { get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{ItemType} #Metadata={Count} Condition={Condition}")]
+    public partial class ProjectItemDefinitionElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectItemDefinitionElement() { }
+        public string ItemType { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectMetadataElement> Metadata { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectMetadataElement AddMetadata(string name, string unevaluatedValue) { throw null; }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("#ItemDefinitions={Count} Condition={Condition} Label={Label}")]
+    public partial class ProjectItemDefinitionGroupElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectItemDefinitionGroupElement() { }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemDefinitionElement> ItemDefinitions { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectItemDefinitionElement AddItemDefinition(string itemType) { throw null; }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{ItemType} Include={Include} Exclude={Exclude} #Metadata={Count} Condition={Condition}")]
+    public partial class ProjectItemElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectItemElement() { }
+        public string Exclude { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation ExcludeLocation { get { throw null; } }
+        public bool HasMetadata { get { throw null; } }
+        public string Include { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation IncludeLocation { get { throw null; } }
+        public string ItemType { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public string KeepDuplicates { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation KeepDuplicatesLocation { get { throw null; } }
+        public string KeepMetadata { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation KeepMetadataLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectMetadataElement> Metadata { get { throw null; } }
+        public string Remove { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation RemoveLocation { get { throw null; } }
+        public string RemoveMetadata { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation RemoveMetadataLocation { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectMetadataElement AddMetadata(string name, string unevaluatedValue) { throw null; }
+        public override void CopyFrom(Microsoft.Build.Construction.ProjectElement element) { }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("#Items={Count} Condition={Condition} Label={Label}")]
+    public partial class ProjectItemGroupElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectItemGroupElement() { }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemElement> Items { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectItemElement AddItem(string itemType, string include) { throw null; }
+        public Microsoft.Build.Construction.ProjectItemElement AddItem(string itemType, string include, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) { throw null; }
+        public override void CopyFrom(Microsoft.Build.Construction.ProjectElement element) { }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{Name} Value={Value} Condition={Condition}")]
+    public partial class ProjectMetadataElement : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectMetadataElement() { }
+        public string Name { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("ExecuteTargets={ExecuteTargets}")]
+    public partial class ProjectOnErrorElement : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectOnErrorElement() { }
+        public string ExecuteTargetsAttribute { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation ExecuteTargetsLocation { get { throw null; } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("#Children={Count}")]
+    public partial class ProjectOtherwiseElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectOtherwiseElement() { }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectChooseElement> ChooseElements { get { throw null; } }
+        public override string Condition { get { throw null; } set { } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemGroupElement> ItemGroups { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyGroupElement> PropertyGroups { get { throw null; } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Name={Name} TaskParameter={TaskParameter} ItemName={ItemName} PropertyName={PropertyName} Condition={Condition}")]
+    public partial class ProjectOutputElement : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectOutputElement() { }
+        public bool IsOutputItem { get { throw null; } }
+        public bool IsOutputProperty { get { throw null; } }
+        public string ItemType { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation ItemTypeLocation { get { throw null; } }
+        public string PropertyName { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation PropertyNameLocation { get { throw null; } }
+        public string TaskParameter { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation TaskParameterLocation { get { throw null; } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{Name} Value={Value} Condition={Condition}")]
+    public partial class ProjectPropertyElement : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectPropertyElement() { }
+        public string Name { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("#Properties={Count} Condition={Condition} Label={Label}")]
+    public partial class ProjectPropertyGroupElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectPropertyGroupElement() { }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyElement> Properties { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyElement> PropertiesReversed { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectPropertyElement AddProperty(string name, string unevaluatedValue) { throw null; }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+        public Microsoft.Build.Construction.ProjectPropertyElement SetProperty(string name, string unevaluatedValue) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{FullPath} #Children={Count} DefaultTargets={DefaultTargets} ToolsVersion={ToolsVersion} InitialTargets={InitialTargets} ExplicitlyLoaded={IsExplicitlyLoaded}")]
+    public partial class ProjectRootElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectRootElement() { }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectChooseElement> ChooseElements { get { throw null; } }
+        public override string Condition { get { throw null; } set { } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public string DefaultTargets { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation DefaultTargetsLocation { get { throw null; } }
+        public string DirectoryPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Text.Encoding Encoding { get { throw null; } }
+        public string FullPath { get { throw null; } set { } }
+        public bool HasUnsavedChanges { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectImportGroupElement> ImportGroups { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectImportGroupElement> ImportGroupsReversed { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectImportElement> Imports { get { throw null; } }
+        public string InitialTargets { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation InitialTargetsLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemDefinitionGroupElement> ItemDefinitionGroups { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemDefinitionGroupElement> ItemDefinitionGroupsReversed { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemDefinitionElement> ItemDefinitions { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemGroupElement> ItemGroups { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemGroupElement> ItemGroupsReversed { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemElement> Items { get { throw null; } }
+        public System.DateTime LastWriteTimeWhenRead { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyElement> Properties { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyGroupElement> PropertyGroups { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyGroupElement> PropertyGroupsReversed { get { throw null; } }
+        public string RawXml { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectTargetElement> Targets { get { throw null; } }
+        public System.DateTime TimeLastChanged { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string ToolsVersion { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation ToolsVersionLocation { get { throw null; } }
+        public string TreatAsLocalProperty { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation TreatAsLocalPropertyLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectUsingTaskElement> UsingTasks { get { throw null; } }
+        public int Version { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectImportElement AddImport(string project) { throw null; }
+        public Microsoft.Build.Construction.ProjectImportGroupElement AddImportGroup() { throw null; }
+        public Microsoft.Build.Construction.ProjectItemElement AddItem(string itemType, string include) { throw null; }
+        public Microsoft.Build.Construction.ProjectItemElement AddItem(string itemType, string include, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) { throw null; }
+        public Microsoft.Build.Construction.ProjectItemDefinitionElement AddItemDefinition(string itemType) { throw null; }
+        public Microsoft.Build.Construction.ProjectItemDefinitionGroupElement AddItemDefinitionGroup() { throw null; }
+        public Microsoft.Build.Construction.ProjectItemGroupElement AddItemGroup() { throw null; }
+        public Microsoft.Build.Construction.ProjectPropertyElement AddProperty(string name, string value) { throw null; }
+        public Microsoft.Build.Construction.ProjectPropertyGroupElement AddPropertyGroup() { throw null; }
+        public Microsoft.Build.Construction.ProjectTargetElement AddTarget(string name) { throw null; }
+        public Microsoft.Build.Construction.ProjectUsingTaskElement AddUsingTask(string name, string assemblyFile, string assemblyName) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Create() { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Create(Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Create(string path) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Create(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Create(System.Xml.XmlReader xmlReader) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Create(System.Xml.XmlReader xmlReader, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
+        public Microsoft.Build.Construction.ProjectChooseElement CreateChooseElement() { throw null; }
+        public Microsoft.Build.Construction.ProjectImportElement CreateImportElement(string project) { throw null; }
+        public Microsoft.Build.Construction.ProjectImportGroupElement CreateImportGroupElement() { throw null; }
+        public Microsoft.Build.Construction.ProjectItemDefinitionElement CreateItemDefinitionElement(string itemType) { throw null; }
+        public Microsoft.Build.Construction.ProjectItemDefinitionGroupElement CreateItemDefinitionGroupElement() { throw null; }
+        public Microsoft.Build.Construction.ProjectItemElement CreateItemElement(string itemType) { throw null; }
+        public Microsoft.Build.Construction.ProjectItemElement CreateItemElement(string itemType, string include) { throw null; }
+        public Microsoft.Build.Construction.ProjectItemGroupElement CreateItemGroupElement() { throw null; }
+        public Microsoft.Build.Construction.ProjectMetadataElement CreateMetadataElement(string name) { throw null; }
+        public Microsoft.Build.Construction.ProjectMetadataElement CreateMetadataElement(string name, string unevaluatedValue) { throw null; }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+        public Microsoft.Build.Construction.ProjectOnErrorElement CreateOnErrorElement(string executeTargets) { throw null; }
+        public Microsoft.Build.Construction.ProjectOtherwiseElement CreateOtherwiseElement() { throw null; }
+        public Microsoft.Build.Construction.ProjectOutputElement CreateOutputElement(string taskParameter, string itemType, string propertyName) { throw null; }
+        public Microsoft.Build.Construction.ProjectExtensionsElement CreateProjectExtensionsElement() { throw null; }
+        public Microsoft.Build.Construction.ProjectPropertyElement CreatePropertyElement(string name) { throw null; }
+        public Microsoft.Build.Construction.ProjectPropertyGroupElement CreatePropertyGroupElement() { throw null; }
+        public Microsoft.Build.Construction.ProjectTargetElement CreateTargetElement(string name) { throw null; }
+        public Microsoft.Build.Construction.ProjectTaskElement CreateTaskElement(string name) { throw null; }
+        public Microsoft.Build.Construction.ProjectUsingTaskBodyElement CreateUsingTaskBodyElement(string evaluate, string body) { throw null; }
+        public Microsoft.Build.Construction.ProjectUsingTaskElement CreateUsingTaskElement(string taskName, string assemblyFile, string assemblyName) { throw null; }
+        public Microsoft.Build.Construction.ProjectUsingTaskElement CreateUsingTaskElement(string taskName, string assemblyFile, string assemblyName, string runtime, string architecture) { throw null; }
+        public Microsoft.Build.Construction.ProjectUsingTaskParameterElement CreateUsingTaskParameterElement(string name, string output, string required, string parameterType) { throw null; }
+        public Microsoft.Build.Construction.UsingTaskParameterGroupElement CreateUsingTaskParameterGroupElement() { throw null; }
+        public Microsoft.Build.Construction.ProjectWhenElement CreateWhenElement(string condition) { throw null; }
+        public Microsoft.Build.Construction.ProjectRootElement DeepClone() { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
+        public void Save() { }
+        public void Save(System.IO.TextWriter writer) { }
+        public void Save(string path) { }
+        public void Save(string path, System.Text.Encoding encoding) { }
+        public void Save(System.Text.Encoding saveEncoding) { }
+        public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Name={Name} #Children={Count} Condition={Condition}")]
+    public partial class ProjectTargetElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectTargetElement() { }
+        public string AfterTargets { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation AfterTargetsLocation { get { throw null; } }
+        public string BeforeTargets { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation BeforeTargetsLocation { get { throw null; } }
+        public string DependsOnTargets { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation DependsOnTargetsLocation { get { throw null; } }
+        public string Inputs { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation InputsLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemGroupElement> ItemGroups { get { throw null; } }
+        public string KeepDuplicateOutputs { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation KeepDuplicateOutputsLocation { get { throw null; } }
+        public string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation NameLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectOnErrorElement> OnErrors { get { throw null; } }
+        public string Outputs { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation OutputsLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyGroupElement> PropertyGroups { get { throw null; } }
+        public string Returns { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation ReturnsLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectTaskElement> Tasks { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectItemGroupElement AddItemGroup() { throw null; }
+        public Microsoft.Build.Construction.ProjectPropertyGroupElement AddPropertyGroup() { throw null; }
+        public Microsoft.Build.Construction.ProjectTaskElement AddTask(string taskName) { throw null; }
+        public override void CopyFrom(Microsoft.Build.Construction.ProjectElement element) { }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{Name} Condition={Condition} ContinueOnError={ContinueOnError} MSBuildRuntime={MSBuildRuntime} MSBuildArchitecture={MSBuildArchitecture} #Outputs={Count}")]
+    public partial class ProjectTaskElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectTaskElement() { }
+        public string ContinueOnError { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation ContinueOnErrorLocation { get { throw null; } }
+        public string MSBuildArchitecture { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation MSBuildArchitectureLocation { get { throw null; } }
+        public string MSBuildRuntime { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public Microsoft.Build.Construction.ElementLocation MSBuildRuntimeLocation { get { throw null; } }
+        public string Name { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectOutputElement> Outputs { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Microsoft.Build.Construction.ElementLocation>> ParameterLocations { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, string> Parameters { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectOutputElement AddOutputItem(string taskParameter, string itemType) { throw null; }
+        public Microsoft.Build.Construction.ProjectOutputElement AddOutputItem(string taskParameter, string itemType, string condition) { throw null; }
+        public Microsoft.Build.Construction.ProjectOutputElement AddOutputProperty(string taskParameter, string propertyName) { throw null; }
+        public Microsoft.Build.Construction.ProjectOutputElement AddOutputProperty(string taskParameter, string propertyName, string condition) { throw null; }
+        public override void CopyFrom(Microsoft.Build.Construction.ProjectElement element) { }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+        public string GetParameter(string name) { throw null; }
+        public void RemoveAllParameters() { }
+        public void RemoveParameter(string name) { }
+        public void SetParameter(string name, string unevaluatedValue) { }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Evaluate={Evaluate} TaskBody={TaskBody}")]
+    public partial class ProjectUsingTaskBodyElement : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectUsingTaskBodyElement() { }
+        public override string Condition { get { throw null; } set { } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public string Evaluate { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation EvaluateLocation { get { throw null; } }
+        public string TaskBody { get { throw null; } set { } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("TaskName={TaskName} AssemblyName={AssemblyName} AssemblyFile={AssemblyFile} Condition={Condition} Runtime={Runtime} Architecture={Architecture}")]
+    public partial class ProjectUsingTaskElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectUsingTaskElement() { }
+        public string Architecture { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation ArchitectureLocation { get { throw null; } }
+        public string AssemblyFile { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation AssemblyFileLocation { get { throw null; } }
+        public string AssemblyName { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation AssemblyNameLocation { get { throw null; } }
+        public Microsoft.Build.Construction.UsingTaskParameterGroupElement ParameterGroup { get { throw null; } }
+        public string Runtime { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation RuntimeLocation { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectUsingTaskBodyElement TaskBody { get { throw null; } }
+        public string TaskFactory { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation TaskFactoryLocation { get { throw null; } }
+        public string TaskName { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation TaskNameLocation { get { throw null; } }
+        public Microsoft.Build.Construction.UsingTaskParameterGroupElement AddParameterGroup() { throw null; }
+        public Microsoft.Build.Construction.ProjectUsingTaskBodyElement AddUsingTaskBody(string evaluate, string taskBody) { throw null; }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Name={Name} ParameterType={ParameterType} Output={Output} Required={Required}")]
+    public partial class ProjectUsingTaskParameterElement : Microsoft.Build.Construction.ProjectElement
+    {
+        internal ProjectUsingTaskParameterElement() { }
+        public override string Condition { get { throw null; } set { } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public string Output { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation OutputLocation { get { throw null; } }
+        public string ParameterType { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation ParameterTypeLocation { get { throw null; } }
+        public string Required { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ElementLocation RequiredLocation { get { throw null; } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("#Children={Count} Condition={Condition}")]
+    public partial class ProjectWhenElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal ProjectWhenElement() { }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectChooseElement> ChooseElements { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemGroupElement> ItemGroups { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyGroupElement> PropertyGroups { get { throw null; } }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+    public sealed partial class SolutionConfigurationInSolution
+    {
+        internal SolutionConfigurationInSolution() { }
+        public string ConfigurationName { get { throw null; } }
+        public string FullName { get { throw null; } }
+        public string PlatformName { get { throw null; } }
+    }
+    public sealed partial class SolutionFile
+    {
+        internal SolutionFile() { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Build.Construction.ProjectInSolution> ProjectsByGuid { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Microsoft.Build.Construction.ProjectInSolution> ProjectsInOrder { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Microsoft.Build.Construction.SolutionConfigurationInSolution> SolutionConfigurations { get { throw null; } }
+        public string GetDefaultConfigurationName() { throw null; }
+        public string GetDefaultPlatformName() { throw null; }
+        public static Microsoft.Build.Construction.SolutionFile Parse(string solutionFile) { throw null; }
+    }
+    public enum SolutionProjectType
+    {
+        EtpSubProject = 5,
+        KnownToBeMSBuildFormat = 1,
+        SolutionFolder = 2,
+        Unknown = 0,
+        WebDeploymentProject = 4,
+        WebProject = 3,
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("#Parameters={Count}")]
+    public partial class UsingTaskParameterGroupElement : Microsoft.Build.Construction.ProjectElementContainer
+    {
+        internal UsingTaskParameterGroupElement() { }
+        public override string Condition { get { throw null; } set { } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectUsingTaskParameterElement> Parameters { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectUsingTaskParameterElement AddParameter(string name) { throw null; }
+        public Microsoft.Build.Construction.ProjectUsingTaskParameterElement AddParameter(string name, string output, string required, string parameterType) { throw null; }
+        protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+    }
+}
+namespace Microsoft.Build.Evaluation
+{
+    [System.Diagnostics.DebuggerDisplayAttribute("{FullPath} EffectiveToolsVersion={ToolsVersion} #GlobalProperties={data.globalProperties.Count} #Properties={data.Properties.Count} #ItemTypes={data.ItemTypes.Count} #ItemDefinitions={data.ItemDefinitions.Count} #Items={data.Items.Count} #Targets={data.Targets.Count}")]
+    public partial class Project
+    {
+        public Project() { }
+        public Project(Microsoft.Build.Construction.ProjectRootElement xml) { }
+        public Project(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
+        public Project(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public Project(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Evaluation.ProjectLoadSettings loadSettings) { }
+        public Project(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Evaluation.ProjectLoadSettings loadSettings) { }
+        public Project(Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public Project(System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public Project(string projectFile) { }
+        public Project(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
+        public Project(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public Project(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Evaluation.ProjectLoadSettings loadSettings) { }
+        public Project(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Evaluation.ProjectLoadSettings loadSettings) { }
+        public Project(System.Xml.XmlReader xmlReader) { }
+        public Project(System.Xml.XmlReader xmlReader, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
+        public Project(System.Xml.XmlReader xmlReader, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public Project(System.Xml.XmlReader xmlReader, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Evaluation.ProjectLoadSettings loadSettings) { }
+        public Project(System.Xml.XmlReader xmlReader, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Evaluation.ProjectLoadSettings loadSettings) { }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectMetadata> AllEvaluatedItemDefinitionMetadata { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> AllEvaluatedItems { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectProperty> AllEvaluatedProperties { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.List<string>> ConditionedProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string DirectoryPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public bool DisableMarkDirty { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int EvaluationCounter { get { throw null; } }
+        public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.IList<Microsoft.Build.Evaluation.ResolvedImport> Imports { get { throw null; } }
+        public System.Collections.Generic.IList<Microsoft.Build.Evaluation.ResolvedImport> ImportsIncludingDuplicates { get { throw null; } }
+        public bool IsBuildEnabled { get { throw null; } set { } }
+        public bool IsDirty { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Build.Evaluation.ProjectItemDefinition> ItemDefinitions { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> Items { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> ItemsIgnoringCondition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<string> ItemTypes { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Evaluation.ProjectCollection ProjectCollection { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectProperty> Properties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public bool SkipEvaluation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string SubToolsetVersion { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectTargetInstance> Targets { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string ToolsVersion { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectRootElement Xml { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.IList<Microsoft.Build.Evaluation.ProjectItem> AddItem(string itemType, string unevaluatedInclude) { throw null; }
+        public System.Collections.Generic.IList<Microsoft.Build.Evaluation.ProjectItem> AddItem(string itemType, string unevaluatedInclude, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) { throw null; }
+        public System.Collections.Generic.IList<Microsoft.Build.Evaluation.ProjectItem> AddItemFast(string itemType, string unevaluatedInclude) { throw null; }
+        public System.Collections.Generic.IList<Microsoft.Build.Evaluation.ProjectItem> AddItemFast(string itemType, string unevaluatedInclude, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) { throw null; }
+        public bool Build() { throw null; }
+        public bool Build(Microsoft.Build.Framework.ILogger logger) { throw null; }
+        public bool Build(System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { throw null; }
+        public bool Build(System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { throw null; }
+        public bool Build(string target) { throw null; }
+        public bool Build(string target, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { throw null; }
+        public bool Build(string target, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { throw null; }
+        public bool Build(string[] targets) { throw null; }
+        public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { throw null; }
+        public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { throw null; }
+        public Microsoft.Build.Execution.ProjectInstance CreateProjectInstance() { throw null; }
+        public Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings) { throw null; }
+        public string ExpandString(string unexpandedValue) { throw null; }
+        public static string GetEvaluatedItemIncludeEscaped(Microsoft.Build.Evaluation.ProjectItem item) { throw null; }
+        public static string GetEvaluatedItemIncludeEscaped(Microsoft.Build.Evaluation.ProjectItemDefinition item) { throw null; }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItems(string itemType) { throw null; }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItemsByEvaluatedInclude(string evaluatedInclude) { throw null; }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItemsIgnoringCondition(string itemType) { throw null; }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Construction.ProjectElement> GetLogicalProject() { throw null; }
+        public static string GetMetadataValueEscaped(Microsoft.Build.Evaluation.ProjectItem item, string name) { throw null; }
+        public static string GetMetadataValueEscaped(Microsoft.Build.Evaluation.ProjectItemDefinition item, string name) { throw null; }
+        public static string GetMetadataValueEscaped(Microsoft.Build.Evaluation.ProjectMetadata metadatum) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public Microsoft.Build.Evaluation.ProjectProperty GetProperty(string name) { throw null; }
+        public string GetPropertyValue(string name) { throw null; }
+        public static string GetPropertyValueEscaped(Microsoft.Build.Evaluation.ProjectProperty property) { throw null; }
+        public void MarkDirty() { }
+        public void ReevaluateIfNecessary() { }
+        public bool RemoveGlobalProperty(string name) { throw null; }
+        public bool RemoveItem(Microsoft.Build.Evaluation.ProjectItem item) { throw null; }
+        public void RemoveItems(System.Collections.Generic.IEnumerable<Microsoft.Build.Evaluation.ProjectItem> items) { }
+        public bool RemoveProperty(Microsoft.Build.Evaluation.ProjectProperty property) { throw null; }
+        public void Save() { }
+        public void Save(System.IO.TextWriter writer) { }
+        public void Save(string path) { }
+        public void Save(string path, System.Text.Encoding encoding) { }
+        public void Save(System.Text.Encoding encoding) { }
+        public void SaveLogicalProject(System.IO.TextWriter writer) { }
+        public bool SetGlobalProperty(string name, string escapedValue) { throw null; }
+        public Microsoft.Build.Evaluation.ProjectProperty SetProperty(string name, string unevaluatedValue) { throw null; }
+    }
+    public partial class ProjectChangedEventArgs : System.EventArgs
+    {
+        internal ProjectChangedEventArgs() { }
+        public Microsoft.Build.Evaluation.Project Project { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
+    public partial class ProjectCollection : System.IDisposable
+    {
+        public ProjectCollection() { }
+        public ProjectCollection(Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetLocations) { }
+        public ProjectCollection(System.Collections.Generic.IDictionary<string, string> globalProperties) { }
+        public ProjectCollection(System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations) { }
+        public ProjectCollection(System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations, int maxNodeCount, bool onlyLogCriticalEvents) { }
+        public int Count { get { throw null; } }
+        public string DefaultToolsVersion { get { throw null; } set { } }
+        public bool DisableMarkDirty { get { throw null; } set { } }
+        public static Microsoft.Build.Evaluation.ProjectCollection GlobalProjectCollection { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } }
+        public Microsoft.Build.Execution.HostServices HostServices { get { throw null; } set { } }
+        public bool IsBuildEnabled { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.Project> LoadedProjects { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Framework.ILogger> Loggers { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public bool OnlyLogCriticalEvents { get { throw null; } set { } }
+        public bool SkipEvaluation { get { throw null; } set { } }
+        public Microsoft.Build.Evaluation.ToolsetDefinitionLocations ToolsetLocations { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.Toolset> Toolsets { get { throw null; } }
+        public static System.Version Version { get { throw null; } }
+        public event Microsoft.Build.Evaluation.ProjectCollection.ProjectAddedEventHandler ProjectAdded { add { } remove { } }
+        public event System.EventHandler<Microsoft.Build.Evaluation.ProjectChangedEventArgs> ProjectChanged { add { } remove { } }
+        public event System.EventHandler<Microsoft.Build.Evaluation.ProjectCollectionChangedEventArgs> ProjectCollectionChanged { add { } remove { } }
+        public event System.EventHandler<Microsoft.Build.Evaluation.ProjectXmlChangedEventArgs> ProjectXmlChanged { add { } remove { } }
+        public void AddToolset(Microsoft.Build.Evaluation.Toolset toolset) { }
+        public bool ContainsToolset(string toolsVersion) { throw null; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public static string Escape(string unescapedString) { throw null; }
+        public string GetEffectiveToolsVersion(string explicitToolsVersion, string toolsVersionFromProject) { throw null; }
+        public Microsoft.Build.Execution.ProjectPropertyInstance GetGlobalProperty(string name) { throw null; }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.Project> GetLoadedProjects(string fullPath) { throw null; }
+        public Microsoft.Build.Evaluation.Toolset GetToolset(string toolsVersion) { throw null; }
+        public Microsoft.Build.Evaluation.Project LoadProject(string fileName) { throw null; }
+        public Microsoft.Build.Evaluation.Project LoadProject(string fileName, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { throw null; }
+        public Microsoft.Build.Evaluation.Project LoadProject(string fileName, string toolsVersion) { throw null; }
+        public Microsoft.Build.Evaluation.Project LoadProject(System.Xml.XmlReader xmlReader) { throw null; }
+        public Microsoft.Build.Evaluation.Project LoadProject(System.Xml.XmlReader xmlReader, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { throw null; }
+        public Microsoft.Build.Evaluation.Project LoadProject(System.Xml.XmlReader xmlReader, string toolsVersion) { throw null; }
+        public void RegisterForwardingLoggers(System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { }
+        public void RegisterLogger(Microsoft.Build.Framework.ILogger logger) { }
+        public void RegisterLoggers(System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { }
+        public void RemoveAllToolsets() { }
+        public bool RemoveGlobalProperty(string name) { throw null; }
+        public bool RemoveToolset(string toolsVersion) { throw null; }
+        public void SetGlobalProperty(string name, string value) { }
+        public bool TryUnloadProject(Microsoft.Build.Construction.ProjectRootElement projectRootElement) { throw null; }
+        public static string Unescape(string escapedString) { throw null; }
+        public void UnloadAllProjects() { }
+        public void UnloadProject(Microsoft.Build.Construction.ProjectRootElement projectRootElement) { }
+        public void UnloadProject(Microsoft.Build.Evaluation.Project project) { }
+        public void UnregisterAllLoggers() { }
+        public delegate void ProjectAddedEventHandler(object sender, Microsoft.Build.Evaluation.ProjectCollection.ProjectAddedToProjectCollectionEventArgs e);
+        public partial class ProjectAddedToProjectCollectionEventArgs : System.EventArgs
+        {
+            public ProjectAddedToProjectCollectionEventArgs(Microsoft.Build.Construction.ProjectRootElement element) { }
+            public Microsoft.Build.Construction.ProjectRootElement ProjectRootElement { get { throw null; } }
+        }
+    }
+    public partial class ProjectCollectionChangedEventArgs : System.EventArgs
+    {
+        internal ProjectCollectionChangedEventArgs() { }
+        public Microsoft.Build.Evaluation.ProjectCollectionChangedState Changed { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
+    public enum ProjectCollectionChangedState
+    {
+        DefaultToolsVersion = 0,
+        DisableMarkDirty = 7,
+        GlobalProperties = 3,
+        HostServices = 6,
+        IsBuildEnabled = 4,
+        Loggers = 2,
+        OnlyLogCriticalEvents = 5,
+        SkipEvaluation = 8,
+        Toolsets = 1,
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{ItemType}={EvaluatedInclude} [{UnevaluatedInclude}] #DirectMetadata={DirectMetadataCount}")]
+    public partial class ProjectItem
+    {
+        internal ProjectItem() { }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Evaluation.ProjectMetadata> DirectMetadata { get { throw null; } }
+        public int DirectMetadataCount { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string EvaluatedInclude { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public bool IsImported { get { throw null; } }
+        public string ItemType { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectMetadata> Metadata { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public int MetadataCount { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public Microsoft.Build.Evaluation.Project Project { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string UnevaluatedInclude { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public Microsoft.Build.Construction.ProjectItemElement Xml { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Evaluation.ProjectMetadata GetMetadata(string name) { throw null; }
+        public string GetMetadataValue(string name) { throw null; }
+        public bool HasMetadata(string name) { throw null; }
+        public bool RemoveMetadata(string name) { throw null; }
+        public void Rename(string name) { }
+        public Microsoft.Build.Evaluation.ProjectMetadata SetMetadataValue(string name, string unevaluatedValue) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{itemType} #Metadata={MetadataCount}")]
+    public partial class ProjectItemDefinition
+    {
+        internal ProjectItemDefinition() { }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public string ItemType { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Evaluation.ProjectMetadata> Metadata { get { throw null; } }
+        public int MetadataCount { get { throw null; } }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public Microsoft.Build.Evaluation.Project Project { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public Microsoft.Build.Evaluation.ProjectMetadata GetMetadata(string name) { throw null; }
+        public string GetMetadataValue(string name) { throw null; }
+        public Microsoft.Build.Evaluation.ProjectMetadata SetMetadataValue(string name, string unevaluatedValue) { throw null; }
+    }
+    [System.FlagsAttribute]
+    public enum ProjectLoadSettings
+    {
+        Default = 0,
+        IgnoreMissingImports = 1,
+        RecordDuplicateButNotCircularImports = 2,
+        RejectCircularImports = 4,
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{Name}={EvaluatedValue} [{xml.Value}]")]
+    public partial class ProjectMetadata : System.IEquatable<Microsoft.Build.Evaluation.ProjectMetadata>
+    {
+        internal ProjectMetadata() { }
+        public Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public string EvaluatedValue { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public bool IsImported { get { throw null; } }
+        public string ItemType { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+        public string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Evaluation.ProjectMetadata Predecessor { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Evaluation.Project Project { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string UnevaluatedValue { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public Microsoft.Build.Construction.ProjectMetadataElement Xml { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        bool System.IEquatable<Microsoft.Build.Evaluation.ProjectMetadata>.Equals(Microsoft.Build.Evaluation.ProjectMetadata other) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{Name}={EvaluatedValue} [{UnevaluatedValue}]")]
+    public abstract partial class ProjectProperty : System.IEquatable<Microsoft.Build.Evaluation.ProjectProperty>
+    {
+        internal ProjectProperty() { }
+        public string EvaluatedValue { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public abstract bool IsEnvironmentProperty { [System.Diagnostics.DebuggerStepThroughAttribute]get; }
+        public abstract bool IsGlobalProperty { [System.Diagnostics.DebuggerStepThroughAttribute]get; }
+        public abstract bool IsImported { get; }
+        public abstract bool IsReservedProperty { [System.Diagnostics.DebuggerStepThroughAttribute]get; }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public abstract string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get; }
+        public abstract Microsoft.Build.Evaluation.ProjectProperty Predecessor { [System.Diagnostics.DebuggerStepThroughAttribute]get; }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public Microsoft.Build.Evaluation.Project Project { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public abstract string UnevaluatedValue { [System.Diagnostics.DebuggerStepThroughAttribute]get; set; }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public abstract Microsoft.Build.Construction.ProjectPropertyElement Xml { [System.Diagnostics.DebuggerStepThroughAttribute]get; }
+        bool System.IEquatable<Microsoft.Build.Evaluation.ProjectProperty>.Equals(Microsoft.Build.Evaluation.ProjectProperty other) { throw null; }
+    }
+    public partial class ProjectXmlChangedEventArgs : System.EventArgs
+    {
+        internal ProjectXmlChangedEventArgs() { }
+        public Microsoft.Build.Construction.ProjectRootElement ProjectXml { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Reason { get { throw null; } }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct ResolvedImport
+    {
+        public Microsoft.Build.Construction.ProjectRootElement ImportedProject { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectImportElement ImportingElement { get { throw null; } }
+        public bool IsImported { get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("SubToolsetVersion={SubToolsetVersion} #Properties={properties.Count}")]
+    public partial class SubToolset
+    {
+        internal SubToolset() { }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectPropertyInstance> Properties { get { throw null; } }
+        public string SubToolsetVersion { get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("ToolsVersion={ToolsVersion} ToolsPath={ToolsPath} #Properties={properties.Count}")]
+    public partial class Toolset
+    {
+        public Toolset(string toolsVersion, string toolsPath, Microsoft.Build.Evaluation.ProjectCollection projectCollection, string msbuildOverrideTasksPath) { }
+        public Toolset(string toolsVersion, string toolsPath, System.Collections.Generic.IDictionary<string, string> buildProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection, System.Collections.Generic.IDictionary<string, Microsoft.Build.Evaluation.SubToolset> subToolsets, string msbuildOverrideTasksPath) { }
+        public Toolset(string toolsVersion, string toolsPath, System.Collections.Generic.IDictionary<string, string> buildProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection, string msbuildOverrideTasksPath) { }
+        public string DefaultSubToolsetVersion { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectPropertyInstance> Properties { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Build.Evaluation.SubToolset> SubToolsets { get { throw null; } }
+        public string ToolsPath { get { throw null; } }
+        public string ToolsVersion { get { throw null; } }
+        public string GenerateSubToolsetVersion() { throw null; }
+        public string GenerateSubToolsetVersion(System.Collections.Generic.IDictionary<string, string> overrideGlobalProperties, int solutionVersion) { throw null; }
+        public Microsoft.Build.Execution.ProjectPropertyInstance GetProperty(string propertyName, string subToolsetVersion) { throw null; }
+    }
+    [System.FlagsAttribute]
+    public enum ToolsetDefinitionLocations
+    {
+        ConfigurationFile = 1,
+        None = 0,
+        Registry = 2,
+    }
+}
+namespace Microsoft.Build.Exceptions
+{
+    public partial class BuildAbortedException : System.Exception
+    {
+        public BuildAbortedException() { }
+        protected BuildAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public BuildAbortedException(string message) { }
+        public BuildAbortedException(string message, System.Exception innerException) { }
+        public string ErrorCode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public sealed partial class InternalLoggerException : System.Exception
+    {
+        public InternalLoggerException() { }
+        public InternalLoggerException(string message) { }
+        public InternalLoggerException(string message, System.Exception innerException) { }
+        public Microsoft.Build.Framework.BuildEventArgs BuildEventArgs { get { throw null; } }
+        public string ErrorCode { get { throw null; } }
+        public string HelpKeyword { get { throw null; } }
+        public bool InitializationException { get { throw null; } }
+        [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public sealed partial class InvalidProjectFileException : System.Exception
+    {
+        public InvalidProjectFileException() { }
+        public InvalidProjectFileException(string message) { }
+        public InvalidProjectFileException(string message, System.Exception innerException) { }
+        public InvalidProjectFileException(string projectFile, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string errorSubcategory, string errorCode, string helpKeyword) { }
+        public string BaseMessage { get { throw null; } }
+        public int ColumnNumber { get { throw null; } }
+        public int EndColumnNumber { get { throw null; } }
+        public int EndLineNumber { get { throw null; } }
+        public string ErrorCode { get { throw null; } }
+        public string ErrorSubcategory { get { throw null; } }
+        public bool HasBeenLogged { get { throw null; } }
+        public string HelpKeyword { get { throw null; } }
+        public int LineNumber { get { throw null; } }
+        public override string Message { get { throw null; } }
+        public string ProjectFile { get { throw null; } }
+        [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class InvalidToolsetDefinitionException : System.Exception
+    {
+        public InvalidToolsetDefinitionException() { }
+        protected InvalidToolsetDefinitionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidToolsetDefinitionException(string message) { }
+        public InvalidToolsetDefinitionException(string message, System.Exception innerException) { }
+        public InvalidToolsetDefinitionException(string message, string errorCode) { }
+        public InvalidToolsetDefinitionException(string message, string errorCode, System.Exception innerException) { }
+        public string ErrorCode { get { throw null; } }
+        [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+}
+namespace Microsoft.Build.Execution
+{
+    public partial class BuildManager : System.IDisposable
+    {
+        public BuildManager() { }
+        public BuildManager(string hostName) { }
+        public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
+        public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
+        public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public void CancelAllSubmissions() { }
+        public void Dispose() { }
+        public void EndBuild() { }
+        ~BuildManager() { }
+        public Microsoft.Build.Execution.ProjectInstance GetProjectInstanceForBuild(Microsoft.Build.Evaluation.Project project) { throw null; }
+        public Microsoft.Build.Execution.BuildSubmission PendBuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public void ResetCaches() { }
+        public void ShutdownAllNodes() { }
+    }
+    public partial class BuildParameters
+    {
+        public BuildParameters() { }
+        public BuildParameters(Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public System.Collections.Generic.IDictionary<string, string> BuildProcessEnvironment { get { throw null; } }
+        public System.Threading.ThreadPriority BuildThreadPriority { get { throw null; } set { } }
+        public System.Globalization.CultureInfo Culture { get { throw null; } set { } }
+        public string DefaultToolsVersion { get { throw null; } set { } }
+        public bool DetailedSummary { get { throw null; } set { } }
+        public bool DisableInProcNode { get { throw null; } set { } }
+        public bool EnableNodeReuse { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> EnvironmentProperties { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> ForwardingLoggers { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } set { } }
+        public Microsoft.Build.Execution.HostServices HostServices { get { throw null; } set { } }
+        public bool LegacyThreadingSemantics { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> Loggers { get { throw null; } set { } }
+        public bool LogInitialPropertiesAndItems { get { throw null; } set { } }
+        public bool LogTaskInputs { get { throw null; } set { } }
+        public int MaxNodeCount { get { throw null; } set { } }
+        public int MemoryUseLimit { get { throw null; } set { } }
+        public string NodeExeLocation { get { throw null; } set { } }
+        public bool OnlyLogCriticalEvents { get { throw null; } set { } }
+        public bool ResetCaches { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SaveOperatingEnvironment { get { throw null; } set { } }
+        public bool ShutdownInProcNodeOnBuildFinish { get { throw null; } set { } }
+        public Microsoft.Build.Evaluation.ToolsetDefinitionLocations ToolsetDefinitionLocations { get { throw null; } set { } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.Toolset> Toolsets { get { throw null; } }
+        public System.Globalization.CultureInfo UICulture { get { throw null; } set { } }
+        public bool UseSynchronousLogging { get { throw null; } set { } }
+        public Microsoft.Build.Execution.BuildParameters Clone() { throw null; }
+        public Microsoft.Build.Evaluation.Toolset GetToolset(string toolsVersion) { throw null; }
+    }
+    public partial class BuildRequestData
+    {
+        public BuildRequestData(Microsoft.Build.Execution.ProjectInstance projectInstance, string[] targetsToBuild) { }
+        public BuildRequestData(Microsoft.Build.Execution.ProjectInstance projectInstance, string[] targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public BuildRequestData(Microsoft.Build.Execution.ProjectInstance projectInstance, string[] targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public BuildRequestData(Microsoft.Build.Execution.ProjectInstance projectInstance, string[] targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags, System.Collections.Generic.IEnumerable<string> propertiesToTransfer) { }
+        public BuildRequestData(string projectFullPath, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string[] targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public BuildRequestData(string projectFullPath, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string[] targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public string ExplicitlySpecifiedToolsVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.BuildRequestDataFlags Flags { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectPropertyInstance> GlobalProperties { get { throw null; } }
+        public Microsoft.Build.Execution.HostServices HostServices { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string ProjectFullPath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.ProjectInstance ProjectInstance { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> PropertiesToTransfer { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<string> TargetNames { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
+    [System.FlagsAttribute]
+    public enum BuildRequestDataFlags
+    {
+        IgnoreExistingProjectState = 4,
+        None = 0,
+        ProvideProjectStateAfterBuild = 2,
+        ReplaceExistingProjectInstance = 1,
+    }
+    public partial class BuildResult
+    {
+        public BuildResult() { }
+        public bool CircularDependency { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public int ConfigurationId { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Exception Exception { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public int GlobalRequestId { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.ITargetResult this[string target] { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public int NodeRequestId { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.BuildResultCode OverallResult { get { throw null; } }
+        public int ParentGlobalRequestId { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.ProjectInstance ProjectStateAfterBuild { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.TargetResult> ResultsByTarget { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public int SubmissionId { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public void AddResultsForTarget(string target, Microsoft.Build.Execution.TargetResult result) { }
+        public bool HasResultsForTarget(string target) { throw null; }
+        public void MergeResults(Microsoft.Build.Execution.BuildResult results) { }
+    }
+    public enum BuildResultCode
+    {
+        Failure = 1,
+        Success = 0,
+    }
+    public partial class BuildSubmission
+    {
+        internal BuildSubmission() { }
+        public object AsyncContext { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.BuildManager BuildManager { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.BuildResult BuildResult { get { throw null; } set { } }
+        public bool IsCompleted { get { throw null; } }
+        public int SubmissionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Threading.WaitHandle WaitHandle { get { throw null; } }
+        public Microsoft.Build.Execution.BuildResult Execute() { throw null; }
+        public void ExecuteAsync(Microsoft.Build.Execution.BuildSubmissionCompleteCallback callback, object context) { }
+    }
+    public delegate void BuildSubmissionCompleteCallback(Microsoft.Build.Execution.BuildSubmission submission);
+    [System.Diagnostics.DebuggerDisplayAttribute("#Entries={hostObjectMap.Count}")]
+    public partial class HostServices
+    {
+        public HostServices() { }
+        public Microsoft.Build.Framework.ITaskHost GetHostObject(string projectFile, string targetName, string taskName) { throw null; }
+        public Microsoft.Build.Execution.NodeAffinity GetNodeAffinity(string projectFile) { throw null; }
+        public void OnRenameProject(string oldFullPath, string newFullPath) { }
+        public void RegisterHostObject(string projectFile, string targetName, string taskName, Microsoft.Build.Framework.ITaskHost hostObject) { }
+        public void SetNodeAffinity(string projectFile, Microsoft.Build.Execution.NodeAffinity nodeAffinity) { }
+        public void UnregisterProject(string projectFullPath) { }
+    }
+    public partial interface ITargetResult
+    {
+        System.Exception Exception { get; }
+        Microsoft.Build.Framework.ITaskItem[] Items { get; }
+        Microsoft.Build.Execution.TargetResultCode ResultCode { get; }
+    }
+    public enum NodeAffinity
+    {
+        Any = 2,
+        InProc = 0,
+        OutOfProc = 1,
+    }
+    public enum NodeEngineShutdownReason
+    {
+        BuildComplete = 0,
+        BuildCompleteReuse = 1,
+        ConnectionFailed = 2,
+        Error = 3,
+    }
+    public partial class OutOfProcNode
+    {
+        public OutOfProcNode() { }
+        public Microsoft.Build.Execution.NodeEngineShutdownReason Run(bool enableReuse, out System.Exception shutdownException) { shutdownException = default(System.Exception); throw null; }
+        public Microsoft.Build.Execution.NodeEngineShutdownReason Run(out System.Exception shutdownException) { shutdownException = default(System.Exception); throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{FullPath} #Targets={TargetsCount} DefaultTargets={(DefaultTargets == null) ? System.String.Empty : System.String.Join(\";\", DefaultTargets.ToArray())} ToolsVersion={Toolset.ToolsVersion} InitialTargets={(InitialTargets == null) ? System.String.Empty : System.String.Join(\";\", InitialTargets.ToArray())} #GlobalProperties={globalProperties.Count} #Properties={properties.Count} #ItemTypes={items.ItemTypes.Count} #Items={items.Count}")]
+    public partial class ProjectInstance
+    {
+        public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml) { }
+        public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectInstance(Microsoft.Build.Construction.ProjectRootElement xml, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectInstance(string projectFile) { }
+        public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
+        public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public System.Collections.Generic.List<string> DefaultTargets { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string Directory { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.List<string> InitialTargets { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool IsImmutable { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectItemDefinitionInstance> ItemDefinitions { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectItemInstance> Items { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<string> ItemTypes { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectPropertyInstance> Properties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectTargetInstance> Targets { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string ToolsVersion { get { throw null; } }
+        public Microsoft.Build.Execution.ProjectItemInstance AddItem(string itemType, string evaluatedInclude) { throw null; }
+        public Microsoft.Build.Execution.ProjectItemInstance AddItem(string itemType, string evaluatedInclude, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) { throw null; }
+        public bool Build() { throw null; }
+        public bool Build(System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { throw null; }
+        public bool Build(System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { throw null; }
+        public bool Build(string target, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { throw null; }
+        public bool Build(string target, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { throw null; }
+        public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { throw null; }
+        public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, out System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.TargetResult> targetOutputs) { targetOutputs = default(System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.TargetResult>); throw null; }
+        public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { throw null; }
+        public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, out System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.TargetResult> targetOutputs) { targetOutputs = default(System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.TargetResult>); throw null; }
+        public Microsoft.Build.Execution.ProjectInstance DeepCopy() { throw null; }
+        public Microsoft.Build.Execution.ProjectInstance DeepCopy(bool isImmutable) { throw null; }
+        public bool EvaluateCondition(string condition) { throw null; }
+        public string ExpandString(string unexpandedValue) { throw null; }
+        public static string GetEvaluatedItemIncludeEscaped(Microsoft.Build.Execution.ProjectItemDefinitionInstance item) { throw null; }
+        public static string GetEvaluatedItemIncludeEscaped(Microsoft.Build.Execution.ProjectItemInstance item) { throw null; }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectItemInstance> GetItems(string itemType) { throw null; }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Execution.ProjectItemInstance> GetItemsByItemTypeAndEvaluatedInclude(string itemType, string evaluatedInclude) { throw null; }
+        public static string GetMetadataValueEscaped(Microsoft.Build.Execution.ProjectItemDefinitionInstance item, string name) { throw null; }
+        public static string GetMetadataValueEscaped(Microsoft.Build.Execution.ProjectItemInstance item, string name) { throw null; }
+        public static string GetMetadataValueEscaped(Microsoft.Build.Execution.ProjectMetadataInstance metadatum) { throw null; }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public Microsoft.Build.Execution.ProjectPropertyInstance GetProperty(string name) { throw null; }
+        public string GetPropertyValue(string name) { throw null; }
+        public static string GetPropertyValueEscaped(Microsoft.Build.Execution.ProjectPropertyInstance property) { throw null; }
+        public bool RemoveItem(Microsoft.Build.Execution.ProjectItemInstance item) { throw null; }
+        public bool RemoveProperty(string name) { throw null; }
+        public Microsoft.Build.Execution.ProjectPropertyInstance SetProperty(string name, string evaluatedValue) { throw null; }
+        public Microsoft.Build.Construction.ProjectRootElement ToProjectRootElement() { throw null; }
+        public void UpdateStateFrom(Microsoft.Build.Execution.ProjectInstance projectState) { }
+    }
+    [System.FlagsAttribute]
+    public enum ProjectInstanceSettings
+    {
+        Immutable = 1,
+        ImmutableWithFastItemLookup = 3,
+        None = 0,
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{itemType} #Metadata={MetadataCount}")]
+    public partial class ProjectItemDefinitionInstance
+    {
+        internal ProjectItemDefinitionInstance() { }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public string ItemType { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectMetadataInstance> Metadata { get { throw null; } }
+        public int MetadataCount { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> MetadataNames { get { throw null; } }
+        [System.Diagnostics.DebuggerStepThroughAttribute]
+        public Microsoft.Build.Execution.ProjectMetadataInstance GetMetadata(string name) { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Condition={condition}")]
+    public partial class ProjectItemGroupTaskInstance : Microsoft.Build.Execution.ProjectTargetInstanceChild
+    {
+        internal ProjectItemGroupTaskInstance() { }
+        public override string Condition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectItemGroupTaskItemInstance> Items { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{itemType} Include={include} Exclude={exclude} Remove={remove} Condition={condition}")]
+    public partial class ProjectItemGroupTaskItemInstance
+    {
+        internal ProjectItemGroupTaskItemInstance() { }
+        public string Condition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ConditionLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Exclude { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ExcludeLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Include { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation IncludeLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string ItemType { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string KeepDuplicates { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation KeepDuplicatesLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string KeepMetadata { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation KeepMetadataLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation Location { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectItemGroupTaskMetadataInstance> Metadata { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Remove { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation RemoveLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string RemoveMetadata { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation RemoveMetadataLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{name} Value={value} Condition={condition}")]
+    public partial class ProjectItemGroupTaskMetadataInstance
+    {
+        internal ProjectItemGroupTaskMetadataInstance() { }
+        public string Condition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ConditionLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation Location { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Value { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{ItemType}={EvaluatedInclude} #DirectMetadata={DirectMetadataCount})")]
+    public partial class ProjectItemInstance : Microsoft.Build.Framework.ITaskItem, Microsoft.Build.Framework.ITaskItem2
+    {
+        internal ProjectItemInstance() { }
+        public int DirectMetadataCount { get { throw null; } }
+        public string EvaluatedInclude { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public string ItemType { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Execution.ProjectMetadataInstance> Metadata { get { throw null; } }
+        public int MetadataCount { get { throw null; } }
+        public System.Collections.Generic.ICollection<string> MetadataNames { get { throw null; } }
+        string Microsoft.Build.Framework.ITaskItem.ItemSpec { get { throw null; } set { } }
+        System.Collections.ICollection Microsoft.Build.Framework.ITaskItem.MetadataNames { get { throw null; } }
+        string Microsoft.Build.Framework.ITaskItem2.EvaluatedIncludeEscaped { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } set { } }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public Microsoft.Build.Execution.ProjectInstance Project { get { throw null; } }
+        public Microsoft.Build.Execution.ProjectMetadataInstance GetMetadata(string name) { throw null; }
+        public string GetMetadataValue(string name) { throw null; }
+        public bool HasMetadata(string name) { throw null; }
+        System.Collections.IDictionary Microsoft.Build.Framework.ITaskItem.CloneCustomMetadata() { throw null; }
+        void Microsoft.Build.Framework.ITaskItem.CopyMetadataTo(Microsoft.Build.Framework.ITaskItem destinationItem) { }
+        string Microsoft.Build.Framework.ITaskItem.GetMetadata(string metadataName) { throw null; }
+        void Microsoft.Build.Framework.ITaskItem.SetMetadata(string metadataName, string metadataValue) { }
+        System.Collections.IDictionary Microsoft.Build.Framework.ITaskItem2.CloneCustomMetadataEscaped() { throw null; }
+        string Microsoft.Build.Framework.ITaskItem2.GetMetadataValueEscaped(string name) { throw null; }
+        void Microsoft.Build.Framework.ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue) { }
+        public void RemoveMetadata(string metadataName) { }
+        public void SetMetadata(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadataDictionary) { }
+        public Microsoft.Build.Execution.ProjectMetadataInstance SetMetadata(string name, string evaluatedValue) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{name}={EvaluatedValue}")]
+    public partial class ProjectMetadataInstance : System.IEquatable<Microsoft.Build.Execution.ProjectMetadataInstance>
+    {
+        internal ProjectMetadataInstance() { }
+        public string EvaluatedValue { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.ProjectMetadataInstance DeepClone() { throw null; }
+        bool System.IEquatable<Microsoft.Build.Execution.ProjectMetadataInstance>.Equals(Microsoft.Build.Execution.ProjectMetadataInstance other) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("ExecuteTargets={executeTargets} Condition={condition}")]
+    public sealed partial class ProjectOnErrorInstance : Microsoft.Build.Execution.ProjectTargetInstanceChild
+    {
+        internal ProjectOnErrorInstance() { }
+        public override string Condition { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public string ExecuteTargets { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ExecuteTargetsLocation { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Condition={condition}")]
+    public partial class ProjectPropertyGroupTaskInstance : Microsoft.Build.Execution.ProjectTargetInstanceChild
+    {
+        internal ProjectPropertyGroupTaskInstance() { }
+        public override string Condition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectPropertyGroupTaskPropertyInstance> Properties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{name}={Value} Condition={condition}")]
+    public partial class ProjectPropertyGroupTaskPropertyInstance
+    {
+        internal ProjectPropertyGroupTaskPropertyInstance() { }
+        public string Condition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+        public string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Value { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("{name}={escapedValue}")]
+    public partial class ProjectPropertyInstance : System.IEquatable<Microsoft.Build.Execution.ProjectPropertyInstance>
+    {
+        internal ProjectPropertyInstance() { }
+        public string EvaluatedValue { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
+        public virtual bool IsImmutable { get { throw null; } }
+        [System.Diagnostics.DebuggerBrowsableAttribute((System.Diagnostics.DebuggerBrowsableState)(0))]
+        public string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        bool System.IEquatable<Microsoft.Build.Execution.ProjectPropertyInstance>.Equals(Microsoft.Build.Execution.ProjectPropertyInstance other) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Name={name} Count={children.Count} Condition={condition} Inputs={inputs} Outputs={outputs} DependsOnTargets={dependsOnTargets}")]
+    public sealed partial class ProjectTargetInstance
+    {
+        internal ProjectTargetInstance() { }
+        public Microsoft.Build.Construction.ElementLocation AfterTargetsLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation BeforeTargetsLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.IList<Microsoft.Build.Execution.ProjectTargetInstanceChild> Children { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Condition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ConditionLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string DependsOnTargets { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation DependsOnTargetsLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string FullPath { get { throw null; } }
+        public string Inputs { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation InputsLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string KeepDuplicateOutputs { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation KeepDuplicateOutputsLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation Location { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Name { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.IList<Microsoft.Build.Execution.ProjectOnErrorInstance> OnErrorChildren { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Outputs { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation OutputsLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public string Returns { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ReturnsLocation { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public System.Collections.Generic.ICollection<Microsoft.Build.Execution.ProjectTaskInstance> Tasks { get { throw null; } }
+    }
+    public abstract partial class ProjectTargetInstanceChild
+    {
+        protected ProjectTargetInstanceChild() { }
+        public abstract string Condition { get; }
+        public abstract Microsoft.Build.Construction.ElementLocation ConditionLocation { get; }
+        public string FullPath { get { throw null; } }
+        public abstract Microsoft.Build.Construction.ElementLocation Location { get; }
+    }
+    [System.Diagnostics.DebuggerDisplayAttribute("Name={name} Condition={condition} ContinueOnError={continueOnError} MSBuildRuntime={MSBuildRuntime} MSBuildArchitecture={MSBuildArchitecture} #Parameters={parameters.Count} #Outputs={outputs.Count}")]
+    public sealed partial class ProjectTaskInstance : Microsoft.Build.Execution.ProjectTargetInstanceChild
+    {
+        internal ProjectTaskInstance() { }
+        public override string Condition { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public string ContinueOnError { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ContinueOnErrorLocation { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+        public string MSBuildArchitecture { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation MSBuildArchitectureLocation { get { throw null; } }
+        public string MSBuildRuntime { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation MSBuildRuntimeLocation { get { throw null; } }
+        public string Name { get { throw null; } }
+        public System.Collections.Generic.IList<Microsoft.Build.Execution.ProjectTaskInstanceChild> Outputs { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, string> Parameters { get { throw null; } }
+    }
+    public abstract partial class ProjectTaskInstanceChild
+    {
+        protected ProjectTaskInstanceChild() { }
+        public abstract string Condition { get; }
+        public abstract Microsoft.Build.Construction.ElementLocation ConditionLocation { get; }
+        public abstract Microsoft.Build.Construction.ElementLocation Location { get; }
+        public abstract Microsoft.Build.Construction.ElementLocation TaskParameterLocation { get; }
+    }
+    public sealed partial class ProjectTaskOutputItemInstance : Microsoft.Build.Execution.ProjectTaskInstanceChild
+    {
+        internal ProjectTaskOutputItemInstance() { }
+        public override string Condition { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public string ItemType { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation ItemTypeLocation { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+        public string TaskParameter { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation TaskParameterLocation { get { throw null; } }
+    }
+    public sealed partial class ProjectTaskOutputPropertyInstance : Microsoft.Build.Execution.ProjectTaskInstanceChild
+    {
+        internal ProjectTaskOutputPropertyInstance() { }
+        public override string Condition { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation Location { get { throw null; } }
+        public string PropertyName { get { throw null; } }
+        public Microsoft.Build.Construction.ElementLocation PropertyNameLocation { get { throw null; } }
+        public string TaskParameter { get { throw null; } }
+        public override Microsoft.Build.Construction.ElementLocation TaskParameterLocation { get { throw null; } }
+    }
+    public partial class TargetResult : Microsoft.Build.Execution.ITargetResult
+    {
+        internal TargetResult() { }
+        public System.Exception Exception { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem[] Items { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public Microsoft.Build.Execution.TargetResultCode ResultCode { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+    }
+    public enum TargetResultCode : byte
+    {
+        Failure = (byte)2,
+        Skipped = (byte)0,
+        Success = (byte)1,
+    }
+}
+namespace Microsoft.Build.Logging
+{
+    public delegate void ColorResetter();
+    public delegate void ColorSetter(System.ConsoleColor color);
+    public partial class ConfigurableForwardingLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
+    {
+        public ConfigurableForwardingLogger() { }
+        public Microsoft.Build.Framework.IEventRedirector BuildEventRedirector { get { throw null; } set { } }
+        public int NodeId { get { throw null; } set { } }
+        public string Parameters { get { throw null; } set { } }
+        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }
+        protected virtual void ForwardToCentralLogger(Microsoft.Build.Framework.BuildEventArgs e) { }
+        public virtual void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
+        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
+        public virtual void Shutdown() { }
+    }
+    public partial class ConsoleLogger : Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
+    {
+        public ConsoleLogger() { }
+        public ConsoleLogger(Microsoft.Build.Framework.LoggerVerbosity verbosity) { }
+        public ConsoleLogger(Microsoft.Build.Framework.LoggerVerbosity verbosity, Microsoft.Build.Logging.WriteHandler write, Microsoft.Build.Logging.ColorSetter colorSet, Microsoft.Build.Logging.ColorResetter colorReset) { }
+        public string Parameters { get { throw null; } set { } }
+        public bool ShowSummary { get { throw null; } set { } }
+        public bool SkipProjectStartedText { get { throw null; } set { } }
+        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }
+        protected Microsoft.Build.Logging.WriteHandler WriteHandler { get { throw null; } set { } }
+        public void ApplyParameter(string parameterName, string parameterValue) { }
+        public void BuildFinishedHandler(object sender, Microsoft.Build.Framework.BuildFinishedEventArgs e) { }
+        public void BuildStartedHandler(object sender, Microsoft.Build.Framework.BuildStartedEventArgs e) { }
+        public void CustomEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e) { }
+        public void ErrorHandler(object sender, Microsoft.Build.Framework.BuildErrorEventArgs e) { }
+        public virtual void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
+        public virtual void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
+        public void MessageHandler(object sender, Microsoft.Build.Framework.BuildMessageEventArgs e) { }
+        public void ProjectFinishedHandler(object sender, Microsoft.Build.Framework.ProjectFinishedEventArgs e) { }
+        public void ProjectStartedHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e) { }
+        public virtual void Shutdown() { }
+        public void TargetFinishedHandler(object sender, Microsoft.Build.Framework.TargetFinishedEventArgs e) { }
+        public void TargetStartedHandler(object sender, Microsoft.Build.Framework.TargetStartedEventArgs e) { }
+        public void TaskFinishedHandler(object sender, Microsoft.Build.Framework.TaskFinishedEventArgs e) { }
+        public void TaskStartedHandler(object sender, Microsoft.Build.Framework.TaskStartedEventArgs e) { }
+        public void WarningHandler(object sender, Microsoft.Build.Framework.BuildWarningEventArgs e) { }
+    }
+    public partial class DistributedFileLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
+    {
+        public DistributedFileLogger() { }
+        public Microsoft.Build.Framework.IEventRedirector BuildEventRedirector { get { throw null; } set { } }
+        public int NodeId { get { throw null; } set { } }
+        public string Parameters { get { throw null; } set { } }
+        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }
+        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
+        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
+        public void Shutdown() { }
+    }
+    public partial class FileLogger : Microsoft.Build.Logging.ConsoleLogger
+    {
+        public FileLogger() { }
+        public override void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
+        public override void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
+        public override void Shutdown() { }
+    }
+    public partial class ForwardingLoggerRecord
+    {
+        public ForwardingLoggerRecord(Microsoft.Build.Framework.ILogger centralLogger, Microsoft.Build.Logging.LoggerDescription forwardingLoggerDescription) { }
+        public Microsoft.Build.Framework.ILogger CentralLogger { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Logging.LoggerDescription ForwardingLoggerDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+    }
+    public partial class LoggerDescription
+    {
+        public LoggerDescription(string loggerClassName, string loggerAssemblyName, string loggerAssemblyFile, string loggerSwitchParameters, Microsoft.Build.Framework.LoggerVerbosity verbosity) { }
+        public string LoggerSwitchParameters { get { throw null; } }
+        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get { throw null; } }
+        public Microsoft.Build.Framework.ILogger CreateLogger() { throw null; }
+    }
+    public delegate void WriteHandler(string message);
+}

--- a/build/LegacyPackages/14.0/Microsoft.Build/Microsoft.Build.nuspec
+++ b/build/LegacyPackages/14.0/Microsoft.Build/Microsoft.Build.nuspec
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$id$</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <iconUrl>$iconUrl$</iconUrl>
+    <description>This package contains the $id$ assembly which is used to create, edit, and evaluation MSBuild projects.</description>
+    <tags>MSBuild</tags>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="System.Console" version="4.0.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
+      </group>
+      <group targetFramework="net45">
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Xml" targetFramework="net45" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="lib\net45\$id$.dll" target="lib\net45\$id$.dll" />
+    <file src="bin\$configuration$\net45\$id$.dll" target="ref\net45\$id$.dll" />
+    <file src="bin\$configuration$\netstandard1.3\$id$.dll" target="ref\netstandard1.3\$id$.dll" />
+  </files>
+</package>

--- a/build/LegacyPackages/14.0/Microsoft.Build/project.json
+++ b/build/LegacyPackages/14.0/Microsoft.Build/project.json
@@ -1,0 +1,30 @@
+﻿{
+  "version": "14.0.0.0",
+  "buildOptions": {
+    "keyFile": "../../../../Tools/MSFT.snk",
+    "publicSign": true
+  },
+  "dependencies": {
+    "Microsoft.Build.Framework": {
+      "target": "project"
+    }
+  },
+  "frameworks": {
+    "net45": {
+      "frameworkAssemblies": {
+        "System.Xml": {}
+      }
+    },
+    "netstandard1.3": {
+      "buildOptions": {
+        "define": [ "NETSTANDARD" ]
+      },
+      "dependencies": {
+        "System.Console": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Globalization": "4.0.11",
+        "System.Xml.XmlDocument": "4.0.1"
+      }
+    }
+  }
+}

--- a/build/LegacyPackages/14.0/build.cmd
+++ b/build/LegacyPackages/14.0/build.cmd
@@ -13,7 +13,7 @@ SET VERSIONMAJOR=14
 :: The minor version here should align with the Visual Studio Update of MSBuild being packaged
 SET VERSIONMINOR=3
 :: The build number here should be incremented when servicing the NuGet package.  The tag should be prereleaseNN when trying out something new
-SET VERSIONBUILD=0-prerelease01
+SET VERSIONBUILD=0-prerelease02
 :: This is the path to where this file is located
 SET ROOT=%~dp0
 :: The path to where packages will be outputed to

--- a/build/LegacyPackages/14.0/build.cmd
+++ b/build/LegacyPackages/14.0/build.cmd
@@ -1,0 +1,86 @@
+@ECHO OFF
+SETLOCAL
+
+:: This batch file creates NuGet packages for shipped MSBuild 14.0 assemblies.  It copies the assemblies locally and then builds "reference"
+:: assemblies which are empty assemblies used by the compiler during a build.  The reference assembly is built for net45 and netstandard1.3 with
+:: certain code #ifdef'd out.  This allows users to compile a single assembly that should work cross-platform
+
+:: To update the packages, change the VERSIONMINOR, VERSIONBUILD, and BUILDDROP variables.  Generally packages should be pushed to the dotnet 
+:: NuGet feed until tested and then placed on NuGet.org.
+
+:: The major version here should align with the major version of MSBuild being packaged
+SET VERSIONMAJOR=14
+:: The minor version here should align with the Visual Studio Update of MSBuild being packaged
+SET VERSIONMINOR=3
+:: The build number here should be incremented when servicing the NuGet package.  The tag should be prereleaseNN when trying out something new
+SET VERSIONBUILD=0-prerelease01
+:: This is the path to where this file is located
+SET ROOT=%~dp0
+:: The path to where packages will be outputed to
+SET PKGDIR=%ROOT%packages
+:: The path to the build drop containing the assemblies to be packaged
+SET BUILDDROP=\\cpvsbuild\drops\VS\d14rel\raw\25420.01\binaries.x86ret\bin\i386\xmake
+:: The build configuration for the reference assemblies
+SET CONFIGURATION=Release
+:: The icon url to use in the packages
+SET ICONURL=https://go.microsoft.com/fwlink/?linkid=825694
+:: The license url to use in the packages
+SET LICENSEURL=http://go.microsoft.com/fwlink/?LinkId=329770
+:: The project url to use in the packages
+SET PROJECTURL=http://go.microsoft.com/fwlink/?LinkId=624683
+
+:: Ensure dotnet.exe is on the PATH
+where dotnet.exe>NUL 2>&1
+IF ERRORLEVEL 1 (
+    ECHO Could not find dotnet.exe on the PATH, please open a command window with dotnet.exe on the PATH or install the dotnet CLI first. 1>&2
+    EXIT /B 1
+)
+
+:: Ensure nuget.exe is on the PATH
+where nuget.exe>NUL 2>&1
+IF ERRORLEVEL 1 (
+    ECHO Could not find nuget.exe on the PATH, please open a command window with nuget.exe on the PATH. 1>&2
+    EXIT /B 1
+)
+
+
+:: Create a package for each assembly.  The ordering here sort of matters based on the dependencies of the assemblies
+CALL :CreatePackage "Microsoft.Build.Framework"
+CALL :CreatePackage "Microsoft.Build"
+CALL :CreatePackage "Microsoft.Build.Engine"
+CALL :CreatePackage "Microsoft.Build.Utilities.Core"
+CALL :CreatePackage "Microsoft.Build.Tasks.Core"
+CALL :CreatePackage "Microsoft.Build.Conversion.Core"
+
+GOTO :EOF
+
+:CreatePackage
+:: BasePath is the root path of the assembly to build
+SET BASEPATH=%ROOT%\%~1
+:: The path to the .nuspec
+SET NUSPEC=%BASEPATH%\%~1.nuspec
+:: The path to the project.json
+SET PROJECTJSON=%BASEPATH%\project.json
+:: The path to where to copy the shipped assembly locally
+SET LIBPATH=%BASEPATH%\lib\net45
+
+IF EXIST "%PROJECTJSON%" (
+    :: Restore NuGet packages based on the project.json
+    dotnet restore "%PROJECTJSON%"
+    IF ERRORLEVEL 1 ECHO Error restoring packages & EXIT /B 1
+
+    :: Build the referece assemblies.  This will build against all frameworks in the project.json
+    dotnet build "%PROJECTJSON%" --configuration "%CONFIGURATION%"
+    IF ERRORLEVEL 1 EXIT /B 1
+)
+:: Ensure the packages directory exists otherwise NuGet will complain...
+IF NOT EXIST "%PKGDIR%" MKDIR "%PKGDIR%"
+
+:: Copy the lib assembly locally for NuGet to consume
+xcopy /ydsi %BUILDDROP%\%~1.dll "%LIBPATH%\"
+IF ERRORLEVEL 1 EXIT /B 1
+
+:: Create the NuGet package
+NuGet PACK "%NUSPEC%" -BasePath "%BASEPATH%" -Properties "id=%~1;version=%VERSIONMAJOR%.%VERSIONMINOR%.%VERSIONBUILD%;configuration=%CONFIGURATION%;iconUrl=%ICONURL%;licenseUrl=%LICENSEURL%;projectUrl=%PROJECTURL%" -OutputDirectory "%PKGDIR%" -Verbosity Detailed
+
+GOTO :EOF


### PR DESCRIPTION
1. I ended up using `#if !NETSTANDARD` so that I could have just 1 source file per assembly.  This makes it a little tougher to see what is left out but not impossible
2. Please review each nuspec
3. The version I'm using for the packages is 14.VSUpdateNumber.PackageRevision[-tag].  So when this goes public it will be 14.3.0.  If we service it, we'll increment the build number.  If we push a new version of Visual Studio we'll update the minor version.
4. This requires both dotnet.exe and nuget.exe to be on the PATH to run.  Is that an okay detail?
5. This will all break once dotnet.exe changes to not use project.json for builds and moves to MSBuild.exe instead.  I'll have to update this to use a csproj and the appropriate .targets.

Fixes #926 