### PR TITLE
Fix TargetFrameworkIdentifier for CoreCLR builds

### DIFF
--- a/Before.Microsoft.Common.targets
+++ b/Before.Microsoft.Common.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Reset any properties blindly set by Microsoft.Portable.CSharp.targets -->
+  <PropertyGroup Condition="'$(NetCoreBuild)' == 'true'">
+    <!--
+      This property is already defined in the root dir.props however importing Microsoft.Portable.CSharp.targets will
+      override it.  If you change it here, update it in the root dir.props as well.  -->
+    <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+    <!-- This property needs to be cleared -->
+    <TargetFrameworkMonikerDisplayName></TargetFrameworkMonikerDisplayName>
+  </PropertyGroup>
+</Project>

--- a/dir.props
+++ b/dir.props
@@ -213,6 +213,9 @@
   <!-- .NET Core build support -->
   <PropertyGroup Condition="'$(NetCoreBuild)' == 'true'">
     <TargetFrameworkVersion>v1.3</TargetFrameworkVersion>
+    <!--
+      This property is re-created after importing Microsoft.Portable.CSharp.targets.  If you change the value here, also
+      update it in Before.Microsoft.Common.targets -->
     <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
     <NetCoreSurface>true</NetCoreSurface>
 
@@ -228,6 +231,7 @@
     <CSharpTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</CSharpTargets>
     <CSharpPortableTargets>$(MSBuildExtensionsPath32)\Microsoft\Portable\v5.0\Microsoft.Portable.CSharp.targets</CSharpPortableTargets>
     <CSharpPortableTargetsFallback>$(ToolsDir)Extensions\Microsoft\Portable\v5.0\Microsoft.Portable.CSharp.targets</CSharpPortableTargetsFallback>
+    <CustomBeforeMicrosoftCommonTargets>$(RepoRoot)\Before.Microsoft.Common.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetCoreSurface)' != 'true'">


### PR DESCRIPTION
Microsoft.Portable.Core.props blindly sets <TargetFrameworkIdentifier /> so our assemblies show that as the framework instead of NETStandard1.3

I had to use a Before.Microsoft.Common.targets because the assembly info file contents are generated before our dir.targets is imported.