### PR TITLE
Common Item spec representation

### DIFF
--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -6,8 +6,8 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -1097,28 +1097,21 @@ namespace Microsoft.Build.Evaluation
 
         private IEnumerable<GlobResult> GetAllGlobs(ProjectItemElement itemElement)
         {
-            Func<string, IElementLocation, HashSet<string>> expandItemSpecIntoFragments = (s, l) =>
-                {
-                    var expandedItemSpec = _data.Expander.ExpandIntoStringListLeaveEscaped(s, ExpanderOptions.ExpandProperties, l);
+            var includeItemspec = new ItemSpec<ProjectProperty, ProjectItem>(itemElement.Include, _data.Expander, itemElement.IncludeLocation);
+            var excludeItemspec = new ItemSpec<ProjectProperty, ProjectItem>(itemElement.Exclude, _data.Expander, itemElement.ExcludeLocation);
 
-                    // don't care about duplicates
-                    var set = new HashSet<string>(expandedItemSpec);
+            var excludeSet =
+                new Lazy<IEnumerable<string>>(
+                    () =>
+                        excludeItemspec.Fragments.Where(
+                            // take out item references, we can't reason about them
+                            f => !(f is ItemExpressionFragment<ProjectProperty, ProjectItem>))
+                            .Select(f => f.ItemSpecFragment)
+                            .ToImmutableHashSet());
 
-                    // take out item references, we can't reason about them
-                    set.RemoveWhere(IsItemReferenceFragment);
-
-                    return set;
-                };
-
-            var includeFragments = expandItemSpecIntoFragments(itemElement.Include, itemElement.IncludeLocation);
-            var excludeFragments = expandItemSpecIntoFragments(itemElement.Exclude, itemElement.ExcludeLocation);
-
-            foreach (var itemFragment in includeFragments)
+            foreach (var globFragment in includeItemspec.Fragments.Where(f => f is GlobFragment))
             {
-                if (IsGlobFragment(itemFragment))
-                {
-                    yield return new GlobResult(itemElement, itemFragment, excludeFragments);
-                }
+                yield return new GlobResult(itemElement, globFragment.ItemSpecFragment, excludeSet.Value);
             }
         }
 
@@ -1191,6 +1184,11 @@ namespace Microsoft.Build.Evaluation
         /// </param>
         public List<ProvenanceResult> GetItemProvenance(ProjectItem item)
         {
+            if (item == null)
+            {
+                return new List<ProvenanceResult>();
+            }
+
             var itemElementsAbove = GetItemElementsAboveItem(_data.EvaluatedItemElements, item);
 
             return GetItemProvenance(item.EvaluatedInclude, itemElementsAbove);
@@ -1222,8 +1220,6 @@ namespace Microsoft.Build.Evaluation
 
         private ProvenanceResult ComputeProvenanceResult(string itemToMatch, ProjectItemElement itemElement)
         {
-            Func<IElementLocation, Func<string, ExpanderOptions, string>> expandForXmlLocation = (l) => (s, o) => _data.Expander.ExpandIntoStringLeaveEscaped(s, o, l);
-
             Func<string, IElementLocation, Operation, ProvenanceResult> singleItemSpecProvenance = (itemSpec, elementLocation, operation) =>
             {
                 if (elementLocation == null)
@@ -1231,7 +1227,9 @@ namespace Microsoft.Build.Evaluation
                     return null;
                 }
 
-                var result = ComputeProvenanceResult(itemToMatch, itemSpec, expandForXmlLocation(elementLocation));
+                Provenance provenance;
+                var matchOccurrences = ItemMatchesInSpecCompareViaExpander(itemToMatch, itemSpec, elementLocation, _data.Expander, out provenance);
+                var result = matchOccurrences > 0 ? Tuple.Create(provenance, matchOccurrences) : null;
 
                 return result?.Item2 > 0
                     ? new ProvenanceResult(itemElement, operation, result.Item1, result.Item2)
@@ -1265,14 +1263,6 @@ namespace Microsoft.Build.Evaluation
             return provenanceProviders.Select(provider => provider()).FirstOrDefault(provenanceResult => provenanceResult != null);
         }
 
-        private Tuple<Provenance, int> ComputeProvenanceResult(string itemToMatch, string itemSpecToLookIn, Func<string, ExpanderOptions, string> expand)
-        {
-            Provenance provenance;
-            var matchOccurrences = ItemMatchesInSpecCompareViaExpander(itemToMatch, itemSpecToLookIn, expand, out provenance);
-
-            return matchOccurrences > 0 ? Tuple.Create(provenance, matchOccurrences) : null;
-        }
-
         /// <summary>
         /// Since:
         ///     - we have no proper AST and interpreter for itemspecs that we can do analysis on
@@ -1280,7 +1270,7 @@ namespace Microsoft.Build.Evaluation
         /// 
         /// The temporary hack is to use the expander to expand the strings, and if any property or item references were encountered, return Provenance.Inconclusive
         /// </summary>
-        private int ItemMatchesInSpecCompareViaExpander(string itemToMatch, string itemSpec, Func<string, ExpanderOptions, string> expand, out Provenance provenance)
+        private int ItemMatchesInSpecCompareViaExpander(string itemToMatch, string itemSpec, IElementLocation elementLocation, Expander<ProjectProperty, ProjectItem> expander, out Provenance provenance)
         {
             if (string.IsNullOrEmpty(itemSpec))
             {
@@ -1289,96 +1279,57 @@ namespace Microsoft.Build.Evaluation
             }
 
             // look into the itemspec as if it were expanded by the Expander
-            Provenance provenanceFromExpandedPropertiesAndItems;
-            var expandedMatches = ItemMatchesInSpec(itemToMatch, expand(itemSpec, ExpanderOptions.ExpandPropertiesAndItems), out provenanceFromExpandedPropertiesAndItems);
+            Provenance provenanceFromExpandedProperties;
+            var itemSpecWithExpandedProperties = new ItemSpec<ProjectProperty, ProjectItem>(itemSpec, expander, elementLocation, expandProperties: true);
+            var expandedMatches = ItemMatchesInSpec(itemToMatch, itemSpecWithExpandedProperties, out provenanceFromExpandedProperties);
 
             // look into the raw itemspec
-            Provenance provenanceFromNonExpandedString;
-            var nonExpandedMatches = ItemMatchesInSpec(itemToMatch, itemSpec, out provenanceFromNonExpandedString);
+            Provenance provenanceFromNonExpandedProperties;
+            var itemSpecWithoutExpandedProperties = new ItemSpec<ProjectProperty, ProjectItem>(itemSpec, expander, elementLocation, expandProperties: false);
+            var nonExpandedMatches = ItemMatchesInSpec(itemToMatch, itemSpecWithoutExpandedProperties, out provenanceFromNonExpandedProperties);
 
             if (expandedMatches > nonExpandedMatches)
             {
-                // return the number of occurences when properties AND items are expanded to get the correct occurence count
-
-                // return the provenance WITHOUT item expansion. Otherwise the items coming from a referenced item get interpreted as StringLiteral
-                // include="*.cs;@(Compile)" needs to return Inconclusive|Glob and not Inconclusive|Glob|StringLiteral
-                Provenance provenanceFromExpandedProperties;
-                ItemMatchesInSpec(itemToMatch, expand(itemSpec, ExpanderOptions.ExpandProperties), out provenanceFromExpandedProperties);
+                // return the number of occurences when properties are expanded to get the correct occurence count
 
                 provenance = Provenance.Inconclusive | provenanceFromExpandedProperties;
                 return expandedMatches;
             }
             else
             {
-                provenance = provenanceFromNonExpandedString;
+                provenance = provenanceFromNonExpandedProperties;
                 return nonExpandedMatches;
             }
         }
 
-        private int ItemMatchesInSpec(string itemToMatch, string itemSpec, out Provenance provenance)
+        private int ItemMatchesInSpec(string itemToMatch, ItemSpec<ProjectProperty, ProjectItem> itemSpec, out Provenance provenance)
         {
             provenance = Provenance.Undefined;
 
             var occurrences = 0;
 
-            if (string.IsNullOrEmpty(itemSpec))
+            var fragmentsMatchingItem = itemSpec.FragmentsMatchingItem(itemToMatch, out occurrences);
+            foreach (var fragment in fragmentsMatchingItem)
             {
-                return occurrences;
-            }
-
-            foreach (var itemFragment in ExpressionShredder.SplitSemiColonSeparatedList(itemSpec))
-            {
-                if (IsPropertyReferenceFragment(itemFragment) || IsItemReferenceFragment(itemFragment))
-                {
-                    continue;
-                }
-
-                if (IsGlobFragment(itemFragment) && ItemMatchesGlob(itemFragment, itemToMatch))
-                {
-                    provenance |= Provenance.Glob;
-                    occurrences++;
-                }
-
-                if (ItemMatchesStringLiteral(itemToMatch, itemFragment))
+                if (fragment is ValueFragment)
                 {
                     provenance |= Provenance.StringLiteral;
-                    occurrences++;
+                }
+                else if (fragment is GlobFragment)
+                {
+                    provenance |= Provenance.Glob;
+                }
+                else if (fragment is ItemExpressionFragment<ProjectProperty, ProjectItem>)
+                {
+                    provenance |= Provenance.Inconclusive;
+                }
+                else
+                {
+                    ErrorUtilities.ThrowInternalErrorUnreachable();
                 }
             }
 
             return occurrences;
-        }
-
-        private bool ItemMatchesStringLiteral(string itemToMatch, string itemFragment)
-        {
-            var thisProjectPath = _data.Directory;
-
-            // It is either a direct string match or the two strings refer to the same file, relative to the project directory
-            return itemToMatch.Equals(itemFragment) || FileUtilities.ComparePathsNoThrow(itemToMatch, itemFragment, thisProjectPath);
-        }
-
-        private static bool ItemMatchesGlob(string globPattern, string file)
-        {
-            var match = FileMatcher.FileMatch(globPattern, file);
-            return match.isLegalFileSpec && match.isMatch;
-        }
-
-        private static bool IsGlobFragment(string itemFragment)
-        {
-            var containsEscapedWildcards = EscapingUtilities.ContainsEscapedWildcards(itemFragment);
-            var containsRealWildcards = FileMatcher.HasWildcards(itemFragment);
-
-            return !containsEscapedWildcards && containsRealWildcards;
-        }
-
-        private static bool IsItemReferenceFragment(string itemFragment)
-        {
-            return itemFragment.Contains("@(");
-        }
-
-        private static bool IsPropertyReferenceFragment(string itemFragment)
-        {
-            return itemFragment.Contains("$(");
         }
 
         /// <summary>
@@ -3505,10 +3456,10 @@ namespace Microsoft.Build.Evaluation
     public class GlobResult
     {
         public string Glob { get; private set; }
-        public ISet<string> Excludes{ get; private set; }
+        public IEnumerable<string> Excludes{ get; private set; }
         public ProjectItemElement ItemElement { get; private set; }
 
-        public GlobResult(ProjectItemElement itemElement, string glob, ISet<string> excludes)
+        public GlobResult(ProjectItemElement itemElement, string glob, IEnumerable<string> excludes)
         {
             ItemElement = itemElement;
             Glob = glob;

--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -1078,6 +1078,10 @@ namespace Microsoft.Build.Evaluation
         /// <param name="itemType">Confine search to item elements of this type</param>
         public List<GlobResult> GetAllGlobs(string itemType)
         {
+            if (string.IsNullOrEmpty(itemType))
+            {
+                return new List<GlobResult>();
+            }
             return GetAllGlobs(GetItemElementsByType(_data.EvaluatedItemElements, itemType));
         }
 
@@ -1087,6 +1091,11 @@ namespace Microsoft.Build.Evaluation
         /// <param name="item">Confine search to item elements appearing above this item, inclusively.</param>
         public List<GlobResult> GetAllGlobs(ProjectItem item)
         {
+            if (item == null)
+            {
+                return new List<GlobResult>();
+            }
+
             return GetAllGlobs(GetItemElementsAboveItem(_data.EvaluatedItemElements, item));
         }
 
@@ -1212,6 +1221,11 @@ namespace Microsoft.Build.Evaluation
 
         private List<ProvenanceResult> GetItemProvenance(string itemToMatch, IEnumerable<ProjectItemElement> projectItemElements )
         {
+            if (string.IsNullOrEmpty(itemToMatch))
+            {
+                return new List<ProvenanceResult>();
+            }
+
             return
                 projectItemElements.Select(i => ComputeProvenanceResult(itemToMatch, i))
                     .Where(r => r != null)

--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -412,6 +412,17 @@ namespace Microsoft.Build.Evaluation
                 includeNullEntries, out isTransformExpression, elementLocation);
         }
 
+        internal bool ExpandExpressionCapture(
+            ExpressionShredder.ItemExpressionCapture expressionCapture,
+            IElementLocation elementLocation,
+            ExpanderOptions options,
+            bool includeNullEntries,
+            out bool isTransformExpression,
+            out IList<Tuple<string, I>> itemsFromCapture)
+        {
+            return ItemExpander.ExpandExpressionCapture(this, expressionCapture, _items, elementLocation, options, includeNullEntries, out isTransformExpression, out itemsFromCapture);
+        }
+
         /// <summary>
         /// Returns true if the supplied string contains a valid property name
         /// </summary>
@@ -1596,7 +1607,9 @@ namespace Microsoft.Build.Evaluation
             {
                 ErrorUtilities.VerifyThrow(items != null, "Cannot expand items without providing items");
 
+                IList<T> result = null;
                 isTransformExpression = false;
+                bool brokeEarlyNonEmpty;
 
                 // If the incoming factory doesn't have an item type that it can use to 
                 // create items, it's our indication that the caller wants its items to have the type of the
@@ -1607,8 +1620,6 @@ namespace Microsoft.Build.Evaluation
                     itemFactory.ItemType = expressionCapture.ItemType;
                 }
 
-                IList<T> result = null;
-
                 if (expressionCapture.Separator != null)
                 {
                     // Reference contains a separator, for example @(Compile, ';').
@@ -1618,7 +1629,7 @@ namespace Microsoft.Build.Evaluation
                     string expandedItemVector;
                     using (var builder = new ReuseableStringBuilder())
                     {
-                        bool brokeEarlyNonEmpty = ExpandItemVectorMatchIntoStringBuilder(expander, expressionCapture, items, elementLocation, builder, options);
+                        brokeEarlyNonEmpty = ExpandExpressionCaptureIntoStringBuilder(expander, expressionCapture, items, elementLocation, builder, options);
 
                         if (brokeEarlyNonEmpty)
                         {
@@ -1640,62 +1651,31 @@ namespace Microsoft.Build.Evaluation
                     return result;
                 }
 
-                // No separator. Expand to a list of items
-                // 
-                // eg.,:
-                // expands @(Compile) to a set of items cloned from the items in the "Compile" list
-                // expands @(Compile->'%(foo)') to a set of items with the Include value of items in the "Compile" list.
-                if (expressionCapture.Captures != null)
+                IList<Tuple<string, S>> itemsFromCapture;
+                brokeEarlyNonEmpty = ExpandExpressionCapture(expander, expressionCapture, items, elementLocation /* including null items */, options, true, out isTransformExpression, out itemsFromCapture);
+
+                if (brokeEarlyNonEmpty)
                 {
-                    isTransformExpression = true;
+                    return null;
                 }
 
-                ICollection<S> itemsOfType = items.GetItems(expressionCapture.ItemType);
+                result = new List<T>(itemsFromCapture.Count);
 
-                // If there are no items of the given type, then bail out early
-                if (itemsOfType.Count == 0)
+                foreach (var itemTuple in itemsFromCapture)
                 {
-                    // .. but only if there isn't a function "Count()", since that will want to return something (zero) for an empty list
-                    if (expressionCapture.Captures == null || !expressionCapture.Captures.Any(capture => String.Equals(capture.FunctionName, "Count", StringComparison.OrdinalIgnoreCase)))
-                    {
-                        return new List<T>();
-                    }
-                }
+                    var itemSpec = itemTuple.Item1;
+                    var originalItem = itemTuple.Item2;
 
-                result = new List<T>(itemsOfType.Count);
-
-                if (!isTransformExpression)
-                {
-                    // No transform: expression is like @(Compile), so copy the items
-                    foreach (S item in itemsOfType)
-                    {
-                        if ((options & ExpanderOptions.BreakOnNotEmpty) != 0)
-                        {
-                            return null;
-                        }
-
-                        T newItem = itemFactory.CreateItem(item, elementLocation.File);
-
-                        result.Add(newItem);
-                    }
-
-                    return result;
-                }
-
-                Stack<TransformFunction<S>> transformFunctionStack = PrepareTransformStackFromMatch<S>(elementLocation, expressionCapture);
-
-                // iterate over our tranform chain, creating the final items from its results
-                foreach (Tuple<string, S> itemTuple in Transform<S>(expander, includeNullEntries, transformFunctionStack, IntrinsicItemFunctions<S>.GetItemTupleEnumerator(itemsOfType)))
-                {
-                    if (itemTuple.Item1 != null && itemTuple.Item2 == null)
+                    if (itemSpec != null && originalItem == null)
                     {
                         // We have an itemspec, but no base item
-                        result.Add(itemFactory.CreateItem(itemTuple.Item1, elementLocation.File));
+                        result.Add(itemFactory.CreateItem(itemSpec, elementLocation.File));
                     }
-                    else if (itemTuple.Item1 != null && itemTuple.Item2 != null)
+                    else if (itemSpec != null && originalItem != null)
                     {
-                        // We have both an itemspec, and a base item
-                        result.Add(itemFactory.CreateItem(itemTuple.Item1, itemTuple.Item2, elementLocation.File));
+                        result.Add(itemSpec.Equals(originalItem.EvaluatedIncludeEscaped)
+                            ? itemFactory.CreateItem(originalItem, elementLocation.File) // itemspec came from direct item reference, no transforms
+                            : itemFactory.CreateItem(itemSpec, originalItem, elementLocation.File)); // itemspec came from a transform and is different from its original item
                     }
                     else if (includeNullEntries)
                     {
@@ -1705,6 +1685,100 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 return result;
+            }
+
+            /// <summary>
+            /// Expands an expression capture into a list of items
+            /// If the capture uses a separator, then all the items are concatenated into one string using that separator.
+            /// 
+            /// Returns true if ExpanderOptions.BreakOnNotEmpty was passed, expression was going to be non-empty, and so it broke out early.
+            /// </summary>
+            /// 
+            /// <param name="itemsFromCapture">
+            /// List of items.
+            /// 
+            /// Item1 represents the item string, escaped
+            /// Item2 represents the original item.
+            /// 
+            /// Item1 differs from Item2's string when it is coming from a transform
+            /// 
+            /// </param>
+            internal static bool ExpandExpressionCapture<S>(
+                Expander<P, I> expander,
+                ExpressionShredder.ItemExpressionCapture expressionCapture,
+                IItemProvider<S> evaluatedItems,
+                IElementLocation elementLocation,
+                ExpanderOptions options,
+                bool includeNullEntries,
+                out bool isTransformExpression,
+                out IList<Tuple<string, S>> itemsFromCapture
+                )
+                where S : class, IItem
+            {
+                ErrorUtilities.VerifyThrow(evaluatedItems != null, "Cannot expand items without providing items");
+                // There's something wrong with the expression, and we ended up with a blank item type
+                ProjectErrorUtilities.VerifyThrowInvalidProject(!string.IsNullOrEmpty(expressionCapture.ItemType), elementLocation, "InvalidFunctionPropertyExpression");
+
+                isTransformExpression = false;
+
+                var itemsOfType = evaluatedItems.GetItems(expressionCapture.ItemType);
+
+                // If there are no items of the given type, then bail out early
+                if (itemsOfType.Count == 0)
+                {
+                    // .. but only if there isn't a function "Count()", since that will want to return something (zero) for an empty list
+                    if (expressionCapture.Captures == null ||
+                        !expressionCapture.Captures.Any(capture => string.Equals(capture.FunctionName, "Count", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        itemsFromCapture = new List<Tuple<string, S>>();
+                        return false;
+                    }
+                }
+
+                if (expressionCapture.Captures != null)
+                {
+                    isTransformExpression = true;
+                }
+
+                itemsFromCapture = new List<Tuple<string, S>>(itemsOfType.Count);
+
+                if (!isTransformExpression)
+                {
+                    // No transform: expression is like @(Compile), so include the item spec without a transform base item
+                    foreach (S item in itemsOfType)
+                    {
+                        if ((item.EvaluatedIncludeEscaped.Length > 0) && (options & ExpanderOptions.BreakOnNotEmpty) != 0)
+                        {
+                            return true;
+                        }
+
+                        itemsFromCapture.Add(new Tuple<string, S>(item.EvaluatedIncludeEscaped, item));
+                    }
+                }
+                else
+                {
+                    Stack<TransformFunction<S>> transformFunctionStack = PrepareTransformStackFromMatch<S>(elementLocation, expressionCapture);
+
+                    // iterate over the tranform chain, creating the final items from its results
+                    foreach (Tuple<string, S> itemTuple in Transform<S>(expander, includeNullEntries, transformFunctionStack, IntrinsicItemFunctions<S>.GetItemTupleEnumerator(itemsOfType)))
+                    {
+                        if (!string.IsNullOrEmpty(itemTuple.Item1) && (options & ExpanderOptions.BreakOnNotEmpty) != 0)
+                        {
+                            return true; // broke out early; result cannot be trusted
+                        }
+
+                        itemsFromCapture.Add(itemTuple);
+                    }
+                }
+
+                if (expressionCapture.Separator != null)
+                {
+                    var joinedItems = string.Join(expressionCapture.Separator, itemsFromCapture.Select(i => i.Item1));
+                    itemsFromCapture.Clear();
+                    itemsFromCapture.Add(new Tuple<string, S>(joinedItems, null));
+                }
+
+                return false; // did not break early
             }
 
             /// <summary>
@@ -1748,7 +1822,7 @@ namespace Microsoft.Build.Evaluation
                             builder.Append(expression, lastStringIndex, matches[i].Index - lastStringIndex);
                         }
 
-                        bool brokeEarlyNonEmpty = ExpandItemVectorMatchIntoStringBuilder(expander, matches[i], items, elementLocation, builder, options);
+                        bool brokeEarlyNonEmpty = ExpandExpressionCaptureIntoStringBuilder(expander, matches[i], items, elementLocation, builder, options);
 
                         if (brokeEarlyNonEmpty)
                         {
@@ -1812,68 +1886,29 @@ namespace Microsoft.Build.Evaluation
             /// Returns true if ExpanderOptions.BreakOnNotEmpty was passed, expression was going to be non-empty, and so it broke out early.
             /// </summary>
             /// <typeparam name="S">Type of source items</typeparam>
-            private static bool ExpandItemVectorMatchIntoStringBuilder<S>(Expander<P, I> expander, ExpressionShredder.ItemExpressionCapture match, IItemProvider<S> items, IElementLocation elementLocation, ReuseableStringBuilder builder, ExpanderOptions options)
+            private static bool ExpandExpressionCaptureIntoStringBuilder<S>(
+                Expander<P, I> expander,
+                ExpressionShredder.ItemExpressionCapture capture,
+                IItemProvider<S> evaluatedItems,
+                IElementLocation elementLocation,
+                ReuseableStringBuilder builder,
+                ExpanderOptions options
+                )
                 where S : class, IItem
             {
-                string itemType = match.ItemType;
-                string separator = (match.Separator != null) ? match.Separator : ";";
+                IList<Tuple<string, S>> itemsFromCapture;
+                bool throwaway;
+                var brokeEarlyNonEmpty = ExpandExpressionCapture(expander, capture, evaluatedItems, elementLocation /* including null items */, options, true, out throwaway, out itemsFromCapture);
 
-                // There's something wrong with the expression, and we ended up with a blank item type
-                ProjectErrorUtilities.VerifyThrowInvalidProject(!String.IsNullOrEmpty(itemType), elementLocation, "InvalidFunctionPropertyExpression");
-
-                ICollection<S> itemsOfType = items.GetItems(itemType);
-
-                // If there are no items of the given type, then bail out early
-                if (itemsOfType.Count == 0)
+                if (brokeEarlyNonEmpty)
                 {
-                    // .. but only if there isn't a function "Count()", since that will want to return something (zero) for an empty list
-                    if (match.Captures == null || !match.Captures.Any(capture => String.Equals(capture.FunctionName, "Count", StringComparison.OrdinalIgnoreCase)))
-                    {
-                        return false; // false because the result is reliable
-                    }
+                    return true;
                 }
 
-                if (match.Captures == null)
-                {
-                    foreach (S item in itemsOfType)
-                    {
-                        // No transform: expression is like @(Compile), so append the item spec
-                        if ((item.EvaluatedIncludeEscaped.Length > 0) && (options & ExpanderOptions.BreakOnNotEmpty) != 0)
-                        {
-                            return true;
-                        }
+                // if the capture.Separator is not null, then ExpandExpressionCapture would have joined the items using that separator itself
+                builder.Append(string.Join(";", itemsFromCapture.Select(i => i.Item1)));
 
-                        builder.Append(item.EvaluatedIncludeEscaped);
-                        builder.Append(separator);
-                    }
-                }
-                else
-                {
-                    Stack<TransformFunction<S>> transformFunctionStack = PrepareTransformStackFromMatch<S>(elementLocation, match);
-
-                    // iterate over our tranform chain, creating the final items from its results
-                    foreach (Tuple<string, S> itemTuple in Transform(expander, true /* including null items */, transformFunctionStack, IntrinsicItemFunctions<S>.GetItemTupleEnumerator(itemsOfType)))
-                    {
-                        if (itemTuple.Item1 != null && itemTuple.Item1.Length > 0 && (options & ExpanderOptions.BreakOnNotEmpty) != 0)
-                        {
-                            return true; // broke out early; result cannot be trusted
-                        }
-                        else if (itemTuple.Item1 != null)
-                        {
-                            builder.Append(itemTuple.Item1);
-                        }
-
-                        builder.Append(separator);
-                    }
-                }
-
-                // Remove the extra separator
-                if (builder.Length > 0)
-                {
-                    builder.Remove(builder.Length - separator.Length, separator.Length);
-                }
-
-                return false; // did not break early
+                return false;
             }
 
             /// <summary>

--- a/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
+++ b/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
@@ -206,9 +206,11 @@ namespace Microsoft.Build.Evaluation
             if (_itemValueFragments == null || _expander != _containingItemSpec.Expander)
             {
                 _expander = _containingItemSpec.Expander;
-                _itemValueFragments =_expander.ExpandExpressionCaptureIntoItems(Capture, false, _containingItemSpec.ItemSpecLocation)
-                    .Select(i => new ValueFragment(i.EvaluatedInclude))
-                    .ToList();
+
+                IList<Tuple<string, I>> itemsFromCapture;
+                bool throwaway;
+                _expander.ExpandExpressionCapture(Capture, _containingItemSpec.ItemSpecLocation, ExpanderOptions.ExpandItems, false /* do not include null expansion results */, out throwaway, out itemsFromCapture);
+                _itemValueFragments = itemsFromCapture.Select(i => new ValueFragment(i.Item1)).ToList();
             }
 
             return _itemValueFragments.Any(v => v.MatchesItem(itemToMatch));

--- a/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
+++ b/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
@@ -1,59 +1,73 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//-----------------------------------------------------------------------
-// </copyright>
-// <summary>Expands item/property/metadata in expressions.</summary>
-//-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Evaluation
 {
-    internal class ItemSpec
+
+    /// <summary>
+    /// Represents the elements of an item specification string and 
+    /// provides some operations over them (like matching items against a given ItemSpec)
+    /// </summary>
+    internal class ItemSpec<P, I>
+        where P : class, IProperty
+        where I : class, IItem
     {
-        public string ItemSpecString { get; private set; }
+        public string ItemSpecString { get; }
 
-        public IEnumerable<ItemFragment> Fragments { get; private set; }
+        /// <summary>
+        /// The fragments that compose an item spec string (values, globs, item references)
+        /// </summary>
+        public IEnumerable<ItemFragment> Fragments { get; }
 
-        public ItemSpec(string itemSpec, ICollection<ItemFragment> itemFragments)
+        /// <summary>
+        /// The expander needs to have a default item factory set.
+        /// </summary>
+        public Expander<P, I> Expander { get; set; }
+
+        /// <summary>
+        /// The xml attribute where this itemspec comes from
+        /// </summary>
+        public IElementLocation ItemSpecLocation { get; }
+
+        /// <param name="itemSpec">The string containing item syntax</param>
+        /// <param name="expander">Expects the expander to have a default item factory set</param>
+        /// <param name="itemSpecLocation">The xml location the itemspec comes from</param>
+        public ItemSpec(string itemSpec, Expander<P, I> expander, IElementLocation itemSpecLocation)
         {
             ItemSpecString = itemSpec;
+            Expander = expander;
+            ItemSpecLocation = itemSpecLocation;
 
-            Fragments = itemFragments;
+            Fragments = BuildItemFragments(itemSpecLocation);
         }
 
-        public static ItemSpec BuildItemSpec<P, I>(string itemSpec, Expander<P, I> expander, IElementLocation itemSpecLocation)
-            where P : class, IProperty
-            where I : class, IItem
-        {
-            var itemFragments = BuildItemFragments(itemSpec, expander, itemSpecLocation);
-
-            return new ItemSpec(itemSpec, itemFragments);
-        }
-
-        private static ImmutableList<ItemFragment> BuildItemFragments<P, I>(string itemSpec, Expander<P, I> expander, IElementLocation itemSpecLocation)
-            where P : class, IProperty
-            where I : class, IItem
+        private IEnumerable<ItemFragment> BuildItemFragments(IElementLocation itemSpecLocation)
         {
             var builder = ImmutableList.CreateBuilder<ItemFragment>();
 
             //  Code corresponds to Evaluator.CreateItemsFromInclude
 
             // STEP 1: Expand properties in Include
-            string evaluatedIncludeEscaped = expander.ExpandIntoStringLeaveEscaped(itemSpec, ExpanderOptions.ExpandProperties, itemSpecLocation);
+            var evaluatedIncludeEscaped = Expander.ExpandIntoStringLeaveEscaped(ItemSpecString, ExpanderOptions.ExpandProperties, itemSpecLocation);
 
             // STEP 2: Split Include on any semicolons, and take each split in turn
             if (evaluatedIncludeEscaped.Length > 0)
             {
-                IList<string> includeSplitsEscaped = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedIncludeEscaped);
+                var includeSplitsEscaped =
+                    ExpressionShredder.SplitSemiColonSeparatedList(evaluatedIncludeEscaped);
 
-                foreach (string includeSplitEscaped in includeSplitsEscaped)
+                foreach (var includeSplitEscaped in includeSplitsEscaped)
                 {
                     // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
                     bool isItemListExpression;
-                    var itemReferenceFragment = ProcessSingleItemVectorExpression<P, I>(includeSplitEscaped, itemSpecLocation, out isItemListExpression);
+                    var itemReferenceFragment = ProcessItemExpression(includeSplitEscaped, itemSpecLocation, out isItemListExpression);
 
                     if (isItemListExpression)
                     {
@@ -64,15 +78,13 @@ namespace Microsoft.Build.Evaluation
                         // The expression is not of the form "@(X)". Treat as string
 
                         //  Code corresponds to EngineFileUtilities.GetFileList
-                        bool containsEscapedWildcards = EscapingUtilities.ContainsEscapedWildcards(includeSplitEscaped);
-                        bool containsRealWildcards = FileMatcher.HasWildcards(includeSplitEscaped);
+                        var containsEscapedWildcards = EscapingUtilities.ContainsEscapedWildcards(includeSplitEscaped);
+                        var containsRealWildcards = FileMatcher.HasWildcards(includeSplitEscaped);
 
+                        // '*' is an illegal character to have in a filename.
+                        // todo file-system assumption on legal path characters: https://github.com/Microsoft/msbuild/issues/781
                         if (containsEscapedWildcards && containsRealWildcards)
                         {
-                            // Umm, this makes no sense.  The item's Include has both escaped wildcards and 
-                            // real wildcards.  What does he want us to do?  Go to the file system and find
-                            // files that literally have '*' in their filename?  Well, that's not going to 
-                            // happen because '*' is an illegal character to have in a filename.
 
                             // Just return the original string.
                             builder.Add(new ValueFragment(includeSplitEscaped));
@@ -80,7 +92,7 @@ namespace Microsoft.Build.Evaluation
                         else if (!containsEscapedWildcards && containsRealWildcards)
                         {
                             // Unescape before handing it to the filesystem.
-                            string filespecUnescaped = EscapingUtilities.UnescapeAll(includeSplitEscaped);
+                            var filespecUnescaped = EscapingUtilities.UnescapeAll(includeSplitEscaped);
 
                             builder.Add(new GlobFragment(filespecUnescaped));
                         }
@@ -99,9 +111,7 @@ namespace Microsoft.Build.Evaluation
             return builder.ToImmutable();
         }
 
-        private static ItemExpressionFragment ProcessSingleItemVectorExpression<P, I>(string expression, IElementLocation elementLocation, out bool isItemListExpression)
-            where P : class, IProperty
-            where I : class, IItem
+        private ItemExpressionFragment<P, I> ProcessItemExpression(string expression, IElementLocation elementLocation, out bool isItemListExpression)
         {
             isItemListExpression = false;
 
@@ -111,50 +121,97 @@ namespace Microsoft.Build.Evaluation
                 return null;
             }
 
-            ExpressionShredder.ItemExpressionCapture match = Expander<P, I>.ExpandSingleItemVectorExpressionIntoExpressionCapture(expression, ExpanderOptions.ExpandItems, elementLocation);
+            var capture = Expander<P, I>.ExpandSingleItemVectorExpressionIntoExpressionCapture(expression, ExpanderOptions.ExpandItems, elementLocation);
 
-            if (match == null)
+            if (capture == null)
             {
                 return null;
             }
 
             isItemListExpression = true;
 
-            return new ItemExpressionFragment(match);
+            return new ItemExpressionFragment<P, I>(capture, this);
+        }
+
+        public IEnumerable<I> FilterItems(IEnumerable<I> items)
+        {
+            return items.Where(i => Fragments.Any(f => f.MatchesItem(i.EvaluatedInclude)));
+        }
+
+        public IEnumerable<string> FilterItems(IEnumerable<string> items)
+        {
+            return items.Where(s => Fragments.Any(f => f.MatchesItem(s)));
         }
     }
 
-    internal abstract class ItemFragment
+    internal interface ItemFragment
     {
+        bool MatchesItem(string itemToMatch);
     }
 
     internal class ValueFragment : ItemFragment
     {
-        public string Value { get; private set; }
+        public string Value { get; }
 
         public ValueFragment(string value)
         {
             Value = value;
         }
+
+        public bool MatchesItem(string itemToMatch)
+        {
+            // todo file-system assumption on case sensitivity https://github.com/Microsoft/msbuild/issues/781
+            return Value.Equals(itemToMatch, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     internal class GlobFragment : ItemFragment
     {
-        public string Glob { get; private set; }
+        public string Glob { get; }
+
+        private readonly Lazy<Func<string, bool>> _globMatcher;
 
         public GlobFragment(string glob)
         {
             Glob = glob;
+            _globMatcher = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetMatchTester(Glob));
+        }
+
+        public bool MatchesItem(string itemToMatch)
+        {
+            return _globMatcher.Value(itemToMatch);
         }
     }
 
-    internal class ItemExpressionFragment : ItemFragment
+    internal class ItemExpressionFragment<P, I> : ItemFragment
+        where P : class, IProperty
+        where I : class, IItem
     {
-        public ExpressionShredder.ItemExpressionCapture Capture { get; private set; }
+        public ExpressionShredder.ItemExpressionCapture Capture { get; }
+        private readonly ItemSpec<P, I> _containingItemSpec;
+        private List<ValueFragment> _itemValueFragments;
+        private Expander<P, I> _expander;
 
-        public ItemExpressionFragment(ExpressionShredder.ItemExpressionCapture capture)
+        public ItemExpressionFragment(ExpressionShredder.ItemExpressionCapture capture, ItemSpec<P, I> containingItemSpec)
         {
             Capture = capture;
+            _containingItemSpec = containingItemSpec;
+            _expander = _containingItemSpec.Expander;
+        }
+
+        public bool MatchesItem(string itemToMatch)
+        {
+            // cache referenced items as long as the expander does not change
+            // reference equality works for now since the expander cannot mutate its item state (hopefully it stays that way)
+            if (_itemValueFragments == null || _expander != _containingItemSpec.Expander)
+            {
+                _expander = _containingItemSpec.Expander;
+                _itemValueFragments =_expander.ExpandExpressionCaptureIntoItems(Capture, false, _containingItemSpec.ItemSpecLocation)
+                    .Select(i => new ValueFragment(i.EvaluatedInclude))
+                    .ToList();
+            }
+
+            return _itemValueFragments.Any(v => v.MatchesItem(itemToMatch));
         }
     }
 }

--- a/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
+++ b/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+// <summary>Expands item/property/metadata in expressions.</summary>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal class ItemSpec
+    {
+        public string ItemSpecString { get; private set; }
+
+        public IEnumerable<ItemFragment> Fragments { get; private set; }
+
+        public ItemSpec(string itemSpec, ICollection<ItemFragment> itemFragments)
+        {
+            ItemSpecString = itemSpec;
+
+            Fragments = itemFragments;
+        }
+
+        public static ItemSpec BuildItemSpec<P, I>(string itemSpec, Expander<P, I> expander, IElementLocation itemSpecLocation)
+            where P : class, IProperty
+            where I : class, IItem
+        {
+            var itemFragments = BuildItemFragments(itemSpec, expander, itemSpecLocation);
+
+            return new ItemSpec(itemSpec, itemFragments);
+        }
+
+        private static ImmutableList<ItemFragment> BuildItemFragments<P, I>(string itemSpec, Expander<P, I> expander, IElementLocation itemSpecLocation)
+            where P : class, IProperty
+            where I : class, IItem
+        {
+            var builder = ImmutableList.CreateBuilder<ItemFragment>();
+
+            //  Code corresponds to Evaluator.CreateItemsFromInclude
+
+            // STEP 1: Expand properties in Include
+            string evaluatedIncludeEscaped = expander.ExpandIntoStringLeaveEscaped(itemSpec, ExpanderOptions.ExpandProperties, itemSpecLocation);
+
+            // STEP 2: Split Include on any semicolons, and take each split in turn
+            if (evaluatedIncludeEscaped.Length > 0)
+            {
+                IList<string> includeSplitsEscaped = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedIncludeEscaped);
+
+                foreach (string includeSplitEscaped in includeSplitsEscaped)
+                {
+                    // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
+                    bool isItemListExpression;
+                    var itemReferenceFragment = ProcessSingleItemVectorExpression<P, I>(includeSplitEscaped, itemSpecLocation, out isItemListExpression);
+
+                    if (isItemListExpression)
+                    {
+                        builder.Add(itemReferenceFragment);
+                    }
+                    else
+                    {
+                        // The expression is not of the form "@(X)". Treat as string
+
+                        //  Code corresponds to EngineFileUtilities.GetFileList
+                        bool containsEscapedWildcards = EscapingUtilities.ContainsEscapedWildcards(includeSplitEscaped);
+                        bool containsRealWildcards = FileMatcher.HasWildcards(includeSplitEscaped);
+
+                        if (containsEscapedWildcards && containsRealWildcards)
+                        {
+                            // Umm, this makes no sense.  The item's Include has both escaped wildcards and 
+                            // real wildcards.  What does he want us to do?  Go to the file system and find
+                            // files that literally have '*' in their filename?  Well, that's not going to 
+                            // happen because '*' is an illegal character to have in a filename.
+
+                            // Just return the original string.
+                            builder.Add(new ValueFragment(includeSplitEscaped));
+                        }
+                        else if (!containsEscapedWildcards && containsRealWildcards)
+                        {
+                            // Unescape before handing it to the filesystem.
+                            string filespecUnescaped = EscapingUtilities.UnescapeAll(includeSplitEscaped);
+
+                            builder.Add(new GlobFragment(filespecUnescaped));
+                        }
+                        else
+                        {
+                            // No real wildcards means we just return the original string.  Don't even bother 
+                            // escaping ... it should already be escaped appropriately since it came directly
+                            // from the project file
+
+                            builder.Add(new ValueFragment(includeSplitEscaped));
+                        }
+                    }
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static ItemExpressionFragment ProcessSingleItemVectorExpression<P, I>(string expression, IElementLocation elementLocation, out bool isItemListExpression)
+            where P : class, IProperty
+            where I : class, IItem
+        {
+            isItemListExpression = false;
+
+            //  Code corresponds to Expander.ExpandSingleItemVectorExpressionIntoItems
+            if (expression.Length == 0)
+            {
+                return null;
+            }
+
+            ExpressionShredder.ItemExpressionCapture match = Expander<P, I>.ExpandSingleItemVectorExpressionIntoExpressionCapture(expression, ExpanderOptions.ExpandItems, elementLocation);
+
+            if (match == null)
+            {
+                return null;
+            }
+
+            isItemListExpression = true;
+
+            return new ItemExpressionFragment(match);
+        }
+    }
+
+    internal abstract class ItemFragment
+    {
+    }
+
+    internal class ValueFragment : ItemFragment
+    {
+        public string Value { get; private set; }
+
+        public ValueFragment(string value)
+        {
+            Value = value;
+        }
+    }
+
+    internal class GlobFragment : ItemFragment
+    {
+        public string Glob { get; private set; }
+
+        public GlobFragment(string glob)
+        {
+            Glob = glob;
+        }
+    }
+
+    internal class ItemExpressionFragment : ItemFragment
+    {
+        public ExpressionShredder.ItemExpressionCapture Capture { get; private set; }
+
+        public ItemExpressionFragment(ExpressionShredder.ItemExpressionCapture capture)
+        {
+            Capture = capture;
+        }
+    }
+}

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.Build.Collections;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Collections;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -61,14 +61,14 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
-                foreach (var operation in _operations)
+                foreach (var fragment in _fragments)
                 {
-                    if (operation.Item1 == ItemOperationType.Expression)
+                    if (fragment.Item1 == ItemFragmentType.Expression)
                     {
                         // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
                         bool throwaway;
                         var itemsFromExpression = _expander.ExpandExpressionCaptureIntoItems(
-                            (ExpressionShredder.ItemExpressionCapture) operation.Item2, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
+                            (ExpressionShredder.ItemExpressionCapture) fragment.Item2, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
                             false /* do not include null expansion results */, out throwaway, _itemElement.IncludeLocation);
 
                         if (excludeTester != null)
@@ -80,9 +80,9 @@ namespace Microsoft.Build.Evaluation
                             itemsToAdd.AddRange(itemsFromExpression);
                         }
                     }
-                    else if (operation.Item1 == ItemOperationType.Value)
+                    else if (fragment.Item1 == ItemFragmentType.Value)
                     {
-                        string value = (string)operation.Item2;
+                        string value = (string)fragment.Item2;
 
                         if (excludeTester == null ||
                             !excludeTester.Value(value))
@@ -91,9 +91,9 @@ namespace Microsoft.Build.Evaluation
                             itemsToAdd.Add(item);
                         }
                     }
-                    else if (operation.Item1 == ItemOperationType.Glob)
+                    else if (fragment.Item1 == ItemFragmentType.Glob)
                     {
-                        string glob = (string)operation.Item2;
+                        string glob = (string)fragment.Item2;
                         string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(_rootDirectory, glob,
                             excludePatterns.Count > 0 ? (IEnumerable<string>) excludePatterns.Concat(globsToIgnore) : globsToIgnore);
                         foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Evaluation
                     }
                     else
                     {
-                        throw new InvalidOperationException(operation.Item1.ToString());
+                        throw new InvalidOperationException(fragment.Item1.ToString());
                     }
                 }
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -1,14 +1,11 @@
-﻿using Microsoft.Build.Collections;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Build.BackEnd;
 using Microsoft.Build.Construction;
-using Microsoft.Build.Execution;
 using System.Collections.Immutable;
-using Microsoft.Build.Shared;
 using Microsoft.Build.Internal;
 
 namespace Microsoft.Build.Evaluation
@@ -63,12 +60,12 @@ namespace Microsoft.Build.Evaluation
 
                 foreach (var fragment in _itemSpec.Fragments)
                 {
-                    if (fragment is ItemExpressionFragment)
+                    if (fragment is ItemExpressionFragment<P, I>)
                     {
                         // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
                         bool throwaway;
                         var itemsFromExpression = _expander.ExpandExpressionCaptureIntoItems(
-                            ((ItemExpressionFragment)fragment).Capture, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
+                            ((ItemExpressionFragment<P, I>)fragment).Capture, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
                             false /* do not include null expansion results */, out throwaway, _itemElement.IncludeLocation);
 
                         if (excludeTester != null)

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (fragment is ValueFragment)
                     {
-                        string value = ((ValueFragment)fragment).Value;
+                        string value = ((ValueFragment)fragment).ItemSpecFragment;
 
                         if (excludeTester == null ||
                             !excludeTester.Value(value))
@@ -90,7 +90,7 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (fragment is GlobFragment)
                     {
-                        string glob = ((GlobFragment)fragment).Glob;
+                        string glob = ((GlobFragment)fragment).ItemSpecFragment;
                         string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(_rootDirectory, glob,
                             excludePatterns.Count > 0 ? (IEnumerable<string>) excludePatterns.Concat(globsToIgnore) : globsToIgnore);
                         foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -61,14 +61,14 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
-                foreach (var fragment in _fragments)
+                foreach (var fragment in _itemSpec.Fragments)
                 {
-                    if (fragment.Item1 == ItemFragmentType.Expression)
+                    if (fragment is ItemExpressionFragment)
                     {
                         // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
                         bool throwaway;
                         var itemsFromExpression = _expander.ExpandExpressionCaptureIntoItems(
-                            (ExpressionShredder.ItemExpressionCapture) fragment.Item2, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
+                            ((ItemExpressionFragment)fragment).Capture, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
                             false /* do not include null expansion results */, out throwaway, _itemElement.IncludeLocation);
 
                         if (excludeTester != null)
@@ -80,9 +80,9 @@ namespace Microsoft.Build.Evaluation
                             itemsToAdd.AddRange(itemsFromExpression);
                         }
                     }
-                    else if (fragment.Item1 == ItemFragmentType.Value)
+                    else if (fragment is ValueFragment)
                     {
-                        string value = (string)fragment.Item2;
+                        string value = ((ValueFragment)fragment).Value;
 
                         if (excludeTester == null ||
                             !excludeTester.Value(value))
@@ -91,9 +91,9 @@ namespace Microsoft.Build.Evaluation
                             itemsToAdd.Add(item);
                         }
                     }
-                    else if (fragment.Item1 == ItemFragmentType.Glob)
+                    else if (fragment is GlobFragment)
                     {
-                        string glob = (string)fragment.Item2;
+                        string glob = ((GlobFragment)fragment).Glob;
                         string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(_rootDirectory, glob,
                             excludePatterns.Count > 0 ? (IEnumerable<string>) excludePatterns.Concat(globsToIgnore) : globsToIgnore);
                         foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Evaluation
                     }
                     else
                     {
-                        throw new InvalidOperationException(fragment.Item1.ToString());
+                        throw new InvalidOperationException(fragment.GetType().ToString());
                     }
                 }
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.ItemFactoryWrapper.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.ItemFactoryWrapper.cs
@@ -1,12 +1,9 @@
-﻿using Microsoft.Build.Collections;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Build.BackEnd;
 using Microsoft.Build.Construction;
-using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Evaluation

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -24,16 +25,12 @@ namespace Microsoft.Build.Evaluation
 
             public ImmutableHashSet<string>.Builder GetRemovedGlobs()
             {
-                var ret = ImmutableHashSet.CreateBuilder<string>();
-                foreach (var operation in _fragments)
-                {
-                    if (operation.Item1 == ItemFragmentType.Glob)
-                    {
-                        ret.Add((string)operation.Item2);
-                    }
-                }
+                var globs = _itemSpec.Fragments.OfType<GlobFragment>().Select(g => g.ItemSpecFragment);
+                var builder = ImmutableHashSet.CreateBuilder<string>();
 
-                return ret;
+                builder.UnionWith(globs);
+
+                return builder;
             }
         }
     }

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Build.Evaluation
             public ImmutableHashSet<string>.Builder GetRemovedGlobs()
             {
                 var ret = ImmutableHashSet.CreateBuilder<string>();
-                foreach (var operation in _operations)
+                foreach (var operation in _fragments)
                 {
-                    if (operation.Item1 == ItemOperationType.Glob)
+                    if (operation.Item1 == ItemFragmentType.Glob)
                     {
                         ret.Add((string)operation.Item2);
                     }

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
 using Microsoft.Build.Construction;
 using System.Collections.Immutable;
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Build.Evaluation
             }
             else
             {
-                throw new NotImplementedException();
+                ErrorUtilities.ThrowInternalErrorUnreachable();
             }
 
             LazyItemList previousItemList = GetItemList(itemElement.ItemType);

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private static CompareInfo s_invariantCompareInfo = CultureInfo.InvariantCulture.CompareInfo;
 
-        Dictionary<string, LazyItemList> _itemLists = new Dictionary<string, LazyItemList>();
+        private Dictionary<string, LazyItemList> _itemLists = new Dictionary<string, LazyItemList>();
 
         public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, BuildEventContext buildEventContext, ILoggingService loggingService)
         {
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Evaluation
             _loggingService = loggingService;
         }
 
-        ICollection<ItemData> GetItems(string itemType)
+        private ICollection<ItemData> GetItems(string itemType)
         {
             LazyItemList itemList = GetItemList(itemType);
             if (itemList == null)
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Evaluation
             return EvaluateCondition(element, expanderOptions, parserOptions, _expander, this);
         }
 
-        static bool EvaluateCondition(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions, Expander<P, I> expander, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
+        private static bool EvaluateCondition(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions, Expander<P, I> expander, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
         {
             if (element.Condition.Length == 0)
             {
@@ -118,9 +118,9 @@ namespace Microsoft.Build.Evaluation
 
         public struct ItemData
         {
-            I _item;
-            int _elementOrder;
-            bool _conditionResult;
+            private I _item;
+            private int _elementOrder;
+            private bool _conditionResult;
 
             public ItemData(I item, int elementOrder, bool conditionResult)
             {
@@ -135,10 +135,10 @@ namespace Microsoft.Build.Evaluation
         }
 
 
-        class LazyItemList
+        private class LazyItemList
         {
-            readonly LazyItemList _previous;
-            readonly LazyItemOperation _operation;
+            private readonly LazyItemList _previous;
+            private readonly LazyItemOperation _operation;
 
             public LazyItemList(LazyItemList previous, LazyItemOperation operation)
             {
@@ -181,35 +181,11 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        //  ItemFragments:
-        //  Add
-        //      Previous value
-        //      List<string> globs
-        //      List<string> values
-        //      List<LazyItemList> itemLists
-        //      List<string> excludes
-        //  Remove
-        //      Previous value
-        //      List<string> globsToRemove
-        //      List<string> valuesToRemove
-        //      List<LazyItemList> itemListsToRemove
-        //  Update - ???
-
-        // TODO: verify whether the ItemElement values are ever escaped
-        enum ItemFragmentType
-        {
-            //  Values are escaped
-            Value,
-            //  Globs are not escaped
-            Glob,
-            Expression
-        }
-
-        class OperationBuilder
+        private class OperationBuilder
         {
             public ProjectItemElement ItemElement { get; set; }
             public string ItemType { get; set; }
-            public ImmutableList<Tuple<ItemFragmentType, object>>.Builder ItemFragments = ImmutableList.CreateBuilder<Tuple<ItemFragmentType, object>>();
+            public ItemSpec ItemSpec { get; set; }
 
             public ImmutableDictionary<string, LazyItemList>.Builder ReferencedItemLists { get; set; } = ImmutableDictionary.CreateBuilder<string, LazyItemList>();
 
@@ -220,7 +196,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        class OperationBuilderWithMetadata : OperationBuilder
+        private class OperationBuilderWithMetadata : OperationBuilder
         {
             public ImmutableList<ProjectMetadataElement>.Builder Metadata = ImmutableList.CreateBuilder<ProjectMetadataElement>();
 
@@ -229,7 +205,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        LazyItemList GetItemList(string itemType)
+        private LazyItemList GetItemList(string itemType)
         {
             LazyItemList ret;
             _itemLists.TryGetValue(itemType, out ret);
@@ -271,74 +247,19 @@ namespace Microsoft.Build.Evaluation
             _itemLists[itemElement.ItemType] = newList;
         }
 
-        UpdateOperation BuildUpdateOperation(string rootDirectory, ProjectItemElement itemElement)
+        private UpdateOperation BuildUpdateOperation(string rootDirectory, ProjectItemElement itemElement)
         {
             OperationBuilderWithMetadata operationBuilder = new OperationBuilderWithMetadata(itemElement);
 
             // Proces Update attribute
-            ProcessItemSpec(operationBuilder, itemElement.Update, itemElement.UpdateLocation);
+            ProcessItemSpec(itemElement.Update, itemElement.UpdateLocation, operationBuilder);
 
             ProcessMetadataElements(itemElement, operationBuilder);
 
             return new UpdateOperation(operationBuilder, this);
         }
 
-        void ProcessItemSpec(OperationBuilder operationBuilder, string itemSpec, ElementLocation itemSpecLocation)
-        {
-            //  Code corresponds to Evaluator.CreateItemsFromInclude
-
-            // STEP 1: Expand properties in Include
-            string evaluatedIncludeEscaped = _outerExpander.ExpandIntoStringLeaveEscaped(itemSpec, ExpanderOptions.ExpandProperties, itemSpecLocation);
-
-            // STEP 2: Split Include on any semicolons, and take each split in turn
-            if (evaluatedIncludeEscaped.Length > 0)
-            {
-                IList<string> includeSplitsEscaped = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedIncludeEscaped);
-
-                foreach (string includeSplitEscaped in includeSplitsEscaped)
-                {
-                    // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
-                    bool isItemListExpression;
-                    ProcessSingleItemVectorExpression(includeSplitEscaped, operationBuilder, itemSpecLocation, out isItemListExpression);
-
-                    if (!isItemListExpression)
-                    {
-                        // The expression is not of the form "@(X)". Treat as string
-
-                        //  Code corresponds to EngineFileUtilities.GetFileList
-                        bool containsEscapedWildcards = EscapingUtilities.ContainsEscapedWildcards(includeSplitEscaped);
-                        bool containsRealWildcards = FileMatcher.HasWildcards(includeSplitEscaped);
-
-                        if (containsEscapedWildcards && containsRealWildcards)
-                        {
-                            // Umm, this makes no sense.  The item's Include has both escaped wildcards and 
-                            // real wildcards.  What does he want us to do?  Go to the file system and find
-                            // files that literally have '*' in their filename?  Well, that's not going to 
-                            // happen because '*' is an illegal character to have in a filename.
-
-                            // Just return the original string.
-                            operationBuilder.ItemFragments.Add(Tuple.Create(ItemFragmentType.Value, (object) includeSplitEscaped));
-                        }
-                        else if (!containsEscapedWildcards && containsRealWildcards)
-                        {
-                            // Unescape before handing it to the filesystem.
-                            string filespecUnescaped = EscapingUtilities.UnescapeAll(includeSplitEscaped);
-                            operationBuilder.ItemFragments.Add(Tuple.Create(ItemFragmentType.Glob, (object)filespecUnescaped));
-                        }
-                        else
-                        {
-                            // No real wildcards means we just return the original string.  Don't even bother 
-                            // escaping ... it should already be escaped appropriately since it came directly
-                            // from the project file
-                            operationBuilder.ItemFragments.Add(Tuple.Create(ItemFragmentType.Value, (object) includeSplitEscaped));
-                        }
-
-                    }
-                }
-            }
-        }
-
-        IncludeOperation BuildIncludeOperation(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)
+        private IncludeOperation BuildIncludeOperation(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)
         {
             IncludeOperationBuilder operationBuilder = new IncludeOperationBuilder(itemElement);
             operationBuilder.ElementOrder = _nextElementOrder++;
@@ -346,7 +267,7 @@ namespace Microsoft.Build.Evaluation
             operationBuilder.ConditionResult = conditionResult;
 
             // Process include
-            ProcessItemSpec(operationBuilder, itemElement.Include, itemElement.IncludeLocation);
+            ProcessItemSpec(itemElement.Include, itemElement.IncludeLocation, operationBuilder);
 
             //  Code corresponds to Evaluator.EvaluateItemElement
 
@@ -374,6 +295,21 @@ namespace Microsoft.Build.Evaluation
             ProcessMetadataElements(itemElement, operationBuilder);
 
             return new IncludeOperation(operationBuilder, this);
+        }
+
+        private RemoveOperation BuildRemoveOperation(string rootDirectory, ProjectItemElement itemElement)
+        {
+            OperationBuilder operationBuilder = new OperationBuilder(itemElement);
+
+            ProcessItemSpec(itemElement.Remove, itemElement.RemoveLocation, operationBuilder);
+
+            return new RemoveOperation(operationBuilder, this);
+        }
+
+        private void ProcessItemSpec(string itemSpec, IElementLocation itemSpecLocation, OperationBuilder builder)
+        {
+            builder.ItemSpec = ItemSpec.BuildItemSpec(itemSpec, _outerExpander, itemSpecLocation);
+            AddReferencedItemLists(builder, builder.ItemSpec.Fragments.OfType<ItemExpressionFragment>().Select(i => i.Capture));
         }
 
         private void ProcessMetadataElements(ProjectItemElement itemElement, OperationBuilderWithMetadata operationBuilder)
@@ -405,7 +341,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        void AddItemReferences(string expression, IncludeOperationBuilder operationBuilder, IElementLocation elementLocation)
+        private void AddItemReferences(string expression, IncludeOperationBuilder operationBuilder, IElementLocation elementLocation)
         {
             if (expression.Length == 0)
             {
@@ -425,34 +361,15 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        void ProcessSingleItemVectorExpression(string expression, OperationBuilder operationBuilder, IElementLocation elementLocation, out bool isItemListExpression)
+        private void AddReferencedItemLists(OperationBuilder operationBuilder, IEnumerable<ExpressionShredder.ItemExpressionCapture> captures)
         {
-            isItemListExpression = false;
-
-            //  Code corresponds to Expander.ExpandSingleItemVectorExpressionIntoItems
-            if (expression.Length == 0)
+            foreach (var capture in captures)
             {
-                return;
-            }
-            else
-            {
-                ExpressionShredder.ItemExpressionCapture match = Expander<P, I>.ExpandSingleItemVectorExpressionIntoExpressionCapture(
-                    expression, ExpanderOptions.ExpandItems, elementLocation);
-
-                if (match == null)
-                {
-                    return;
-                }
-
-                isItemListExpression = true;
-
-                operationBuilder.ItemFragments.Add(Tuple.Create(ItemFragmentType.Expression, (object) match));
-
-                AddReferencedItemLists(operationBuilder, match);
+                AddReferencedItemLists(operationBuilder, capture);
             }
         }
 
-        void AddReferencedItemLists(OperationBuilder operationBuilder, ExpressionShredder.ItemExpressionCapture match)
+        private void AddReferencedItemLists(OperationBuilder operationBuilder, ExpressionShredder.ItemExpressionCapture match)
         {
             if (match.ItemType != null)
             {
@@ -469,15 +386,6 @@ namespace Microsoft.Build.Evaluation
                     AddReferencedItemLists(operationBuilder, subMatch);
                 }
             }
-        }
-
-        RemoveOperation BuildRemoveOperation(string rootDirectory, ProjectItemElement itemElement)
-        {
-            OperationBuilder operationBuilder = new OperationBuilder(itemElement);
-
-            ProcessItemSpec(operationBuilder, itemElement.Remove, itemElement.RemoveLocation);
-
-            return new RemoveOperation(operationBuilder, this);
         }
     }
 }

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
@@ -1,17 +1,16 @@
-﻿using Microsoft.Build.BackEnd.Logging;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
-using Microsoft.Build.Debugging;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -185,9 +184,9 @@ namespace Microsoft.Build.Evaluation
         {
             public ProjectItemElement ItemElement { get; set; }
             public string ItemType { get; set; }
-            public ItemSpec ItemSpec { get; set; }
+            public ItemSpec<P,I> ItemSpec { get; set; }
 
-            public ImmutableDictionary<string, LazyItemList>.Builder ReferencedItemLists { get; set; } = ImmutableDictionary.CreateBuilder<string, LazyItemList>();
+            public ImmutableDictionary<string, LazyItemList>.Builder ReferencedItemLists { get; } = ImmutableDictionary.CreateBuilder<string, LazyItemList>();
 
             public OperationBuilder(ProjectItemElement itemElement)
             {
@@ -308,8 +307,9 @@ namespace Microsoft.Build.Evaluation
 
         private void ProcessItemSpec(string itemSpec, IElementLocation itemSpecLocation, OperationBuilder builder)
         {
-            builder.ItemSpec = ItemSpec.BuildItemSpec(itemSpec, _outerExpander, itemSpecLocation);
-            AddReferencedItemLists(builder, builder.ItemSpec.Fragments.OfType<ItemExpressionFragment>().Select(i => i.Capture));
+            builder.ItemSpec = new ItemSpec<P, I>(itemSpec, _outerExpander, itemSpecLocation);
+
+            AddReferencedItemLists(builder, builder.ItemSpec.Fragments.OfType<ItemExpressionFragment<P, I>>().Select(i => i.Capture));
         }
 
         private void ProcessMetadataElements(ProjectItemElement itemElement, OperationBuilderWithMetadata operationBuilder)

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -165,6 +165,7 @@
     </Compile>
     <Compile Include="Definition\ProjectCollectionChangedEventArgs.cs" />
     <Compile Include="Definition\ProjectImportPathMatch.cs" />
+    <Compile Include="Evaluation\ItemSpec.cs" />
     <Compile Include="Evaluation\ItemsAndMetadataPair.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.UpdateOperation.cs" />

--- a/src/XMakeBuildEngine/Utilities/EngineFileUtilities.cs
+++ b/src/XMakeBuildEngine/Utilities/EngineFileUtilities.cs
@@ -221,5 +221,10 @@ namespace Microsoft.Build.Internal
                 return false;
             };
         }
+
+        internal static Func<string, bool> GetMatchTester(string filespec)
+        {
+            return GetMatchTester(new List<string>() {filespec});
+        }
     }
 }


### PR DESCRIPTION
I've started doing this so addressing bugs like [this one](https://github.com/Microsoft/msbuild/issues/931) does not require me to change 3 different code clones (or more).

I extracted out the ItemSpec class out of the lazy evaluator code and gave it the capability of matching items against itself.

Todos:
- [x] change item provenance and getallglobs to use it
- [ ] change execution time item operations to use it (**future PR**)
- [x] introduce non-canonic path matching (so `.\program.cs` matches with `program.cs` which should match with `.\.\.\program.cs`)