### PR TITLE
Import all search paths when importing a wildcard

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -2197,6 +2197,8 @@ namespace Microsoft.Build.Evaluation
 
             bool atleastOneExactFilePathWasLookedAtAndNotFound = false;
 
+            // If there are wildcards in the Import, a list of all the matches from all import search
+            // paths will be returned (union of all files that match).
             var allProjects = new List<ProjectRootElement>();
             bool containsWildcards = FileMatcher.HasWildcards(importElement.Project);
 

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -13,6 +13,7 @@ using Xunit;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Build.UnitTests;
 
 namespace Microsoft.Build.UnitTests.Evaluation
 {
@@ -163,6 +164,59 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     Assert.True(project.Build("FromExtn2"));
                     Console.WriteLine("checking logcontains");
                     logger.AssertLogDoesntContain("MSB4057"); // Should not contain TargetDoesNotExist
+                });
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathWithWildCardAndSelfImport()
+        {
+            string mainTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='Main'>
+                        <Message Text='Running Main'/>
+                    </Target>
+
+                    <Import Project='$(MSBuildExtensionsPath)\circularwildcardtest\*.proj'/>
+                </Project>";
+
+            string extnTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='{0}'>
+                        <Message Text='Running {0}'/>
+                    </Target>
+                </Project>";
+
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Import Project='$(MSBuildExtensionsPath)\circularwildcardtest\*.proj'/>
+                    <Target Name='{0}'>
+                        <Message Text='Running {0}'/>
+                    </Target>
+                </Project>";
+
+            // Importing a wildcard will union all matching results from all fallback locations.
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("circularwildcardtest", "extn.proj"),
+                string.Format(extnTargetsFileContent, "FromExtn1"));
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("circularwildcardtest", "extn.proj"),
+                string.Format(extnTargetsFileContent, "FromExtn2"));
+            string extnDir3 = GetNewExtensionsPathAndCreateFile("extensions3", Path.Combine("circularwildcardtest", "extn3.proj"),
+                string.Format(extnTargetsFileContent2, "FromExtn3"));
+
+            // Main project path is under "circularwildcardtest"
+            // Note: This project will try to be imported again and cause a warning (MSB4210). This test should ensure that the
+            // code does not stop looking in the fallback locations when this happens (extn3.proj should still be imported).
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine("extensions2", "circularwildcardtest", "main.proj"), mainTargetsFileContent);
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath",
+                new[] { extnDir1, extnDir2, extnDir3 },
+                null,
+                (project, logger) =>
+                {
+                    Console.WriteLine(logger.FullLog);
+                    Assert.True(project.Build("FromExtn1"));
+                    Assert.True(project.Build("FromExtn2"));
+                    Assert.True(project.Build("FromExtn3"));
+                    logger.AssertLogContains("MSB4210");
                 });
         }
 
@@ -756,7 +810,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
         string GetNewExtensionsPathAndCreateFile(string extnDirName, string relativeFilePath, string fileContents)
         {
-            var extnDir = Path.Combine(Path.GetTempPath(), extnDirName);
+            var extnDir = Path.Combine(ObjectModelHelpers.TempProjectDir, extnDirName);
             Directory.CreateDirectory(Path.Combine(extnDir, Path.GetDirectoryName(relativeFilePath)));
             File.WriteAllText(Path.Combine(extnDir, relativeFilePath), fileContents);
 


### PR DESCRIPTION
Changed the import search path logic to import matches from ALL folders
when a wildcard is specified. For example:
  - <Project Import="$(propsdir)\*.props">
    - (Where $(propsdir) has fallback to c:\1, c:\2)
  - MSBuild will import c:\1\*.props AND c:\2\*.props.

The motivation behind this change is when packages install to common
extension points in VS "15". Some packages may still install to the old
(global) MSBuildExtensionsPath location and others may install to the
app-local path. This change will allow for MSBuild to import the union of
those extension points.

Note: We discussed as a team having MSBuild "de-dupe" imports (i.e. if it
imported foo.props in the original location it would not import a fallback
foo.props). This method becomes very tricky with all the import options
(**\*.props, for example).