### PR TITLE
Null check was with main object instead of casting object. 

### DIFF
--- a/src/XMakeTasks/AssemblyRemapping.cs
+++ b/src/XMakeTasks/AssemblyRemapping.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Tasks
         public override bool Equals(object obj)
         {
             AssemblyNameExtension name = obj as AssemblyNameExtension;
-            if (obj == null)
+            if (name == null)
             {
                 return false;
             }


### PR DESCRIPTION
In `AssemblyRemapping.cs`, there is invalid null object checking, there `name` variable should be checked for null instead of  main `obj`. 