### PR TITLE
Remove unnecessary format items

### DIFF
--- a/src/XMakeBuildEngine/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2213,7 +2213,7 @@ namespace Microsoft.Build.BackEnd
                     using (StreamWriter file = new StreamWriter(String.Format(CultureInfo.CurrentCulture, Path.Combine(_debugDumpPath, "SchedulerState_{0}.txt"), Process.GetCurrentProcess().Id), true))
                     {
                         file.WriteLine("Scheduler state at timestamp {0}:", _schedulingData.EventTime.Ticks);
-                        file.WriteLine("------------------------------------------------", _schedulingData.EventTime.Ticks);
+                        file.WriteLine("------------------------------------------------");
 
                         foreach (int nodeId in _availableNodes.Keys)
                         {

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/MSBuild_Tests.cs
@@ -687,8 +687,8 @@ namespace Microsoft.Build.UnitTests
                 Assert.True(success); // "Build failed.  See 'Standard Out' tab for details."
 
                 string expectedItemOutputs = string.Format(@"
-                    h1.dll : MSBuildSourceProjectFile={1} ; MSBuildSourceTargetName=TargetH
-                    ", projectFile1, projectFile2);
+                    h1.dll : MSBuildSourceProjectFile={0} ; MSBuildSourceTargetName=TargetH
+                    ", projectFile2);
 
                 Assert.True(targetOutputs.ContainsKey("Build"));
                 Assert.Equal(1, targetOutputs["Build"].Items.Length);

--- a/src/XMakeTasks/ManifestUtil/XmlUtil.cs
+++ b/src/XMakeTasks/ManifestUtil/XmlUtil.cs
@@ -72,14 +72,14 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
             int t2 = Environment.TickCount;
             XPathDocument d = new XPathDocument(s);
-            Util.WriteLog(String.Format(CultureInfo.CurrentCulture, "new XPathDocument(1) t={1}", resource, Environment.TickCount - t2));
+            Util.WriteLog(String.Format(CultureInfo.CurrentCulture, "new XPathDocument(1) t={0}", Environment.TickCount - t2));
 
             int t3 = Environment.TickCount;
             XslCompiledTransform xslc = new XslCompiledTransform();
             // Using the Trusted Xslt is fine as the style sheet comes from our own assemblies.
             // This is similar to the prior this.GetType().Assembly/Evidence method that was used in the now depricated XslTransform.
             xslc.Load(d, XsltSettings.TrustedXslt, s_resolver);
-            Util.WriteLog(String.Format(CultureInfo.CurrentCulture, "XslCompiledTransform.Load t={1}", resource, Environment.TickCount - t3));
+            Util.WriteLog(String.Format(CultureInfo.CurrentCulture, "XslCompiledTransform.Load t={0}", Environment.TickCount - t3));
 
             // Need to copy input stream because XmlReader will close it,
             // causing errors for later callers that access the same stream
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
             int t4 = Environment.TickCount;
             XmlReader xml = XmlReader.Create(clonedInput);
-            Util.WriteLog(String.Format(CultureInfo.CurrentCulture, "new XmlReader(2) t={1}", resource, Environment.TickCount - t4));
+            Util.WriteLog(String.Format(CultureInfo.CurrentCulture, "new XmlReader(2) t={0}", Environment.TickCount - t4));
 
             XsltArgumentList args = null;
             if (entries.Length > 0)
@@ -109,7 +109,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
             int t5 = Environment.TickCount;
             xslc.Transform(xml, args, w, s_resolver);
-            Util.WriteLog(String.Format(CultureInfo.CurrentCulture, "XslCompiledTransform.Transform t={1}", resource, Environment.TickCount - t4));
+            Util.WriteLog(String.Format(CultureInfo.CurrentCulture, "XslCompiledTransform.Transform t={0}", Environment.TickCount - t4));
 
             w.WriteEndDocument();
             w.Flush();

--- a/src/XMakeTasks/UnitTests/MSBuild_Tests.cs
+++ b/src/XMakeTasks/UnitTests/MSBuild_Tests.cs
@@ -577,8 +577,8 @@ namespace Microsoft.Build.UnitTests
                 Assert.True(success); // "Build failed.  See 'Standard Out' tab for details."
 
                 string expectedItemOutputs = string.Format(@"
-                    h1.dll : MSBuildSourceProjectFile={1} ; MSBuildSourceTargetName=TargetH
-                    ", projectFile1, projectFile2);
+                    h1.dll : MSBuildSourceProjectFile={0} ; MSBuildSourceTargetName=TargetH
+                    ", projectFile2);
 
                 ObjectModelHelpers.AssertItemsMatch(expectedItemOutputs, msbuildTask.TargetOutputs, false /* order of items not enforced */);
             }


### PR DESCRIPTION
Not all given format items are used in the format string. This removes the unused format items.