### PR TITLE
Drop unnecessary if statements

### DIFF
--- a/src/XMakeTasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/XMakeTasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -852,18 +852,12 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                             }
                             catch (XmlException ex)
                             {
-                                if (validate)
-                                {
-                                    Debug.Fail("Failed to load schema '" + schemaPath + "' due to the following exception:\r\n" + ex.Message);
-                                }
+                                Debug.Fail("Failed to load schema '" + schemaPath + "' due to the following exception:\r\n" + ex.Message);
                                 validate = false;
                             }
                             catch (System.Xml.Schema.XmlSchemaException ex)
                             {
-                                if (validate)
-                                {
-                                    Debug.Fail("Failed to load schema '" + schemaPath + "' due to the following exception:\r\n" + ex.Message);
-                                }
+                                Debug.Fail("Failed to load schema '" + schemaPath + "' due to the following exception:\r\n" + ex.Message);
                                 validate = false;
                             }
                         }


### PR DESCRIPTION
On line [826](https://github.com/Microsoft/msbuild/blob/master/src/XMakeTasks/BootstrapperUtil/BootstrapperBuilder.cs#L826) the local boolean variable `validate` is checked to be `true`.

As there is no code between there and these `if` statements that can modify `validate`, these `if` statements will always resolve to `true`, making them unnecessary.