### PR TITLE
Remove unnecessary terniary checks

### DIFF
--- a/src/XMakeBuildEngine/Definition/ProjectItem.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectItem.cs
@@ -752,7 +752,7 @@ namespace Microsoft.Build.Evaluation
                 temporary.Add(metadatum);
             }
 
-            _directMetadata = (_directMetadata == null ? null : new PropertyDictionary<ProjectMetadata>(_directMetadata.Count));
+            _directMetadata = new PropertyDictionary<ProjectMetadata>(_directMetadata.Count);
 
             foreach (ProjectMetadata metadatum in temporary)
             {


### PR DESCRIPTION
Both `configurationReader` and `_directMetadata` have `if`-checks just before the ternary checks, ensuring that they're not `null`, making the ternary expression unnecessary. 

I also dropped the `configurationReaderToUse` variable, as it's a copy of `configurationReader` and the only place it's used is in the next line where we still have access to the same `configurationReader`.