### PR TITLE
More unnecessary if drops

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -825,27 +825,23 @@ namespace Microsoft.Build.Evaluation
                 EvaluateItemGroupElement(itemGroupElement, lazyEvaluator);
             }
 
-            if (lazyEvaluator != null)
+            // Tell the lazy evaluator to compute the items and add them to _data
+            IList<LazyItemEvaluator<P, I, M, D>.ItemData> items = lazyEvaluator.GetAllItems();
+            foreach (var itemData in items)
             {
-
-                // Tell the lazy evaluator to compute the items and add them to _data
-                IList<LazyItemEvaluator<P, I, M, D>.ItemData> items = lazyEvaluator.GetAllItems();
-                foreach (var itemData in items)
+                if (itemData.ConditionResult)
                 {
-                    if (itemData.ConditionResult)
-                    {
-                        _data.AddItem(itemData.Item);
-
-                        if (_data.ShouldEvaluateForDesignTime)
-                        {
-                            _data.AddToAllEvaluatedItemsList(itemData.Item);
-                        }
-                    }
+                    _data.AddItem(itemData.Item);
 
                     if (_data.ShouldEvaluateForDesignTime)
                     {
-                        _data.AddItemIgnoringCondition(itemData.Item);
+                        _data.AddToAllEvaluatedItemsList(itemData.Item);
                     }
+                }
+
+                if (_data.ShouldEvaluateForDesignTime)
+                {
+                    _data.AddItemIgnoringCondition(itemData.Item);
                 }
             }
 


### PR DESCRIPTION
Both `proj` and `lazyEvaluator` are local variables which get instantiated earlier in the functions guaranteeing them to be non-`null`, making the checks unnecessary.

In the `proj` case there are a couple of references to `proj.ProjectName` before the check, proving the point. :smile: