### PR TITLE
Drop PropertyGroupsAll else if

### DIFF
--- a/src/OrcasEngine/Choose/GroupEnumeratorHelper.cs
+++ b/src/OrcasEngine/Choose/GroupEnumeratorHelper.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Build.BuildEngine
                                     yield return nestedGroup;
                                 }
                             }
-                            else if (this.type == ListType.PropertyGroupsAll)
+                            else
                             {
                                 foreach (IItemPropertyGrouping nestedGroup in when.PropertyAndItemLists.PropertyGroupsAll)
                                 {
@@ -132,7 +132,7 @@ namespace Microsoft.Build.BuildEngine
                                     yield return nestedGroup;
                                 }
                             }
-                            else if (this.type == ListType.PropertyGroupsAll)
+                            else
                             {
                                 foreach (IItemPropertyGrouping nestedGroup in choose.Otherwise.PropertyAndItemLists.PropertyGroupsAll)
                                 {


### PR DESCRIPTION
At line [104](https://github.com/BBosman/msbuild/blob/master/src/OrcasEngine/Choose/GroupEnumeratorHelper.cs#L104) the `if` statement scopes `this.type` to being `ListType.ItemGroupsAll` or `ListType.PropertyGroupsAll`, therefore it will always be `ListType.PropertyGroupsAll` within these `else` clauses, making the extra check unnecessary.