### PR TITLE
Drop another unnecessary if

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/ExpressionShredder.cs
+++ b/src/XMakeBuildEngine/Evaluation/ExpressionShredder.cs
@@ -278,11 +278,8 @@ namespace Microsoft.Build.Evaluation
                             continue;
                         }
 
-                        if (!isQuotedTransform && functionCapture == null)
-                        {
-                            i = restartPoint;
-                            transformOrFunctionFound = false;
-                        }
+                        i = restartPoint;
+                        transformOrFunctionFound = false;
                     }
 
                     if (!transformOrFunctionFound)
@@ -411,11 +408,8 @@ namespace Microsoft.Build.Evaluation
                             continue;
                         }
 
-                        if (!isQuotedTransform && functionCapture == null)
-                        {
-                            i = restartPoint;
-                            transformOrFunctionFound = false;
-                        }
+                        i = restartPoint;
+                        transformOrFunctionFound = false;
                     }
 
                     if (!transformOrFunctionFound)


### PR DESCRIPTION
Another unnecessary `if`.

The `if (isQuotedTransform)` on line 255, combined with the `continue` on line 265 ensures `!isQuotedTransform` will always evaluate to `true`.

The `if (functionCapture != null)` on line 270, combined with  the `continue` on line 278 ensures `functionCapture == null` will always evaluate to `true`.

Therefore this `if`-statement will always evaluate to `true`, making it unnecessary.

The same applies to the second instance.