### PR TITLE
Simplify logic

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -1811,22 +1811,12 @@ namespace Microsoft.Build.Evaluation
                     include.Add(itemElement.Include);
                     ItemsAndMetadataPair itemsAndMetadataFromInclude = ExpressionShredder.GetReferencedItemNamesAndMetadata(include);
 
-                    if (itemsAndMetadataFromInclude.Items != null && itemsAndMetadataFromInclude.Items.Count > 0)
-                    {
-                        needToProcessItemsIndividually = true;
-                    }
-                    else
-                    {
-                        // If there is bare built-in metadata, we must always run items individually, as that almost
-                        // always differs between items.
-
-                        // UNDONE: When batching is implemented for real, we need to make sure that
-                        // item definition metadata is included in all metadata operations during evaluation
-                        if (itemsAndMetadataFound.Metadata.Values.Count > 0)
-                        {
-                            needToProcessItemsIndividually = true;
-                        }
-                    }
+                    // If there is bare built-in metadata, we must always run items individually, as that almost
+                    // always differs between items.
+                    // 
+                    // UNDONE: When batching is implemented for real, we need to make sure that
+                    // item definition metadata is included in all metadata operations during evaluation
+                    needToProcessItemsIndividually = true;
                 }
 
                 if (needToProcessItemsIndividually)

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -128,23 +128,13 @@ namespace Microsoft.Build.Evaluation
                     {
                         // If there is bare metadata of any kind, and the Include involved an item list, we should
                         // run items individually, as even non-built-in metadata might differ between items
-
-                        if (_referencedItemLists.Count >= 0)
-                        {
-                            needToProcessItemsIndividually = true;
-                        }
-                        else
-                        {
-                            // If there is bare built-in metadata, we must always run items individually, as that almost
-                            // always differs between items.
-
-                            // UNDONE: When batching is implemented for real, we need to make sure that
-                            // item definition metadata is included in all metadata operations during evaluation
-                            if (itemsAndMetadataFound.Metadata.Values.Count > 0)
-                            {
-                                needToProcessItemsIndividually = true;
-                            }
-                        }
+                        //
+                        // If there is bare built-in metadata, we must always run items individually, as that almost
+                        // always differs between items.
+                        //
+                        // UNDONE: When batching is implemented for real, we need to make sure that
+                        // item definition metadata is included in all metadata operations during evaluation
+                        needToProcessItemsIndividually = true;
                     }
 
                     if (needToProcessItemsIndividually)


### PR DESCRIPTION
In `Evaluator.cs` the `if (itemsAndMetadataFound.Metadata.Values.Count > 0)` check is already done at line 1806, making the `if` at 1825 unnecessary.

After dropping it, the logic in the `if` at line 1814 is identical to the `else` at line 1818, making the use of the `if`-statement unnecessary as well.

I didn't really know how to handle the comment, so I left that in place. 

The same applies to `LazyItemEvaluator.LazyItemOperation.cs`.