### PR TITLE
Fix asserts

### DIFF
--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -2835,10 +2835,7 @@ namespace Microsoft.Build.CommandLine
             {
                 logger = loggerDescription.CreateLogger();
 
-                if (logger == null)
-                {
-                    InitializationException.VerifyThrow(logger != null, "LoggerNotFoundError", unquotedParameter);
-                }
+                InitializationException.VerifyThrow(logger != null, "LoggerNotFoundError", unquotedParameter);
             }
             catch (IOException e)
             {


### PR DESCRIPTION
The surrounding `if`-clauses prevent the checks from actually guarding against anything.