### PR TITLE
More if-tweaking

### DIFF
--- a/src/XMakeTasks/CodeTaskFactory.cs
+++ b/src/XMakeTasks/CodeTaskFactory.cs
@@ -254,11 +254,6 @@ namespace Microsoft.Build.Tasks
 
             _sourceCode = taskContent.InnerText;
 
-            if (_log.HasLoggedErrors)
-            {
-                return false;
-            }
-
             if (_type == null)
             {
                 _type = "Fragment";

--- a/src/XMakeTasks/ResolveKeySource.cs
+++ b/src/XMakeTasks/ResolveKeySource.cs
@@ -199,10 +199,7 @@ namespace Microsoft.Build.Tasks
                                     Log.LogErrorWithCodeFromResources("ResolveKeySource.KeyFileForSignAssemblyNotImported", KeyFile, hashedContainerName);
                                 }
 
-                                if (!pfxSuccess)
-                                {
-                                    Log.LogErrorWithCodeFromResources("ResolveKeySource.KeyImportError", KeyFile);
-                                }
+                                Log.LogErrorWithCodeFromResources("ResolveKeySource.KeyImportError", KeyFile);
                             }
                             if (pfxSuccess)
                             {


### PR DESCRIPTION
The first `if` is identical to the one at line 250 and `_log.HasLoggedErrors` can't have changed in the meantime, making the check obsolete.

And `pfxSuccess` is set to `false` in line 165. It is only modified in the `if` at line 190 and therefore will always be `true` in the else, making the `!pfxSuccess` check obsolete.