### PR TITLE
Drop superfluous casts

### DIFF
--- a/src/XMakeBuildEngine/UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -1141,7 +1141,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <param name="throwOnExecute">Should the task throw when executed</param>
         private void InitializeHost(bool throwOnExecute)
         {
-            _loggingService = LoggingService.CreateLoggingService(LoggerMode.Synchronous, 1) as ILoggingService;
+            _loggingService = LoggingService.CreateLoggingService(LoggerMode.Synchronous, 1);
             _logger = new MockLogger();
             _loggingService.RegisterLogger(_logger);
             _host = new TaskExecutionHost();

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -1375,14 +1375,14 @@ namespace TestTask
             Assert.Null(inlineTaskRecord.InlineTaskXmlBody);
             Assert.Equal(2, inlineTaskRecord.UsingTaskParameters.Count);
 
-            TaskPropertyInfo parameterInfo = inlineTaskRecord.UsingTaskParameters[defaultParameter.Name] as TaskPropertyInfo;
+            TaskPropertyInfo parameterInfo = inlineTaskRecord.UsingTaskParameters[defaultParameter.Name];
             Assert.NotNull(parameterInfo);
             Assert.Equal(parameterInfo.Name, defaultParameter.Name);
             Assert.Equal(parameterInfo.Output, false);
             Assert.Equal(parameterInfo.Required, false);
             Assert.Equal(parameterInfo.PropertyType, typeof(System.String));
 
-            parameterInfo = inlineTaskRecord.UsingTaskParameters[filledOutAttributesParameter.Name] as TaskPropertyInfo;
+            parameterInfo = inlineTaskRecord.UsingTaskParameters[filledOutAttributesParameter.Name];
             Assert.NotNull(parameterInfo);
             Assert.Equal(parameterInfo.Name, filledOutAttributesParameter.Name);
             Assert.Equal(parameterInfo.Output, true);
@@ -1747,7 +1747,7 @@ namespace TestTask
             string expandedRequired = RegistryExpander.ExpandIntoStringAndUnescape(filledOutAttributesParameter.Required, ExpanderOptions.ExpandPropertiesAndItems, filledOutAttributesParameter.RequiredLocation);
             string expandedType = RegistryExpander.ExpandIntoStringAndUnescape(filledOutAttributesParameter.ParameterType, ExpanderOptions.ExpandPropertiesAndItems, filledOutAttributesParameter.ParameterTypeLocation);
 
-            TaskPropertyInfo parameterInfo = inlineTaskRecord.UsingTaskParameters[filledOutAttributesParameter.Name] as TaskPropertyInfo;
+            TaskPropertyInfo parameterInfo = inlineTaskRecord.UsingTaskParameters[filledOutAttributesParameter.Name];
             Assert.NotNull(parameterInfo);
             Assert.Equal(parameterInfo.Name, filledOutAttributesParameter.Name);
             Assert.Equal(parameterInfo.Output, bool.Parse(expandedOutput));

--- a/src/XMakeTasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/XMakeTasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2032,8 +2032,8 @@ namespace Microsoft.Build.Tasks
                         // Some files may have been skipped. Log warnings for these.
                         for (int i = 0; i < whiteListErrors.Count; ++i)
                         {
-                            Exception e = whiteListErrors[i] as Exception;
-                            string filename = whiteListErrorFilesNames[i] as string;
+                            Exception e = whiteListErrors[i];
+                            string filename = whiteListErrorFilesNames[i];
 
                             // Give the user a warning about the bad file (or files).
                             Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.InvalidInstalledAssemblySubsetTablesFile", filename, SubsetListFinder.SubsetListFolder, e.Message);


### PR DESCRIPTION
As the return types for those methods/properties are already of the type indicated, the casts are superfluous.