### PR TITLE
Update version number

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,1 +1,6 @@
-{ "version": "15.1" }
+{
+  "version": "15.1-preview5",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$"
+  ]
+}


### PR DESCRIPTION
Update version.json to specify "15.1-preview5" rather than just "15.1".
This makes it clear that the binaries and NuGet packages are pre-release
verions.

This impacts the naming of our NuGet packages, which will now be called
something like "MSBuild.15.1.208-preview5-g524a1042af.nupkg".