### PR TITLE
Fix build warning

### DIFF
--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Linq;
-using Microsoft.Build.Construction;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;


### PR DESCRIPTION
Definition\ToolsetConfigurationReader.cs(15,7): warning CS0105: The using directive for 'Microsoft.Build.Construction' appeared previously in this namespace [D

Introduced here: https://github.com/Microsoft/msbuild/commit/0a3eb9b25c3ee9f3692d5fe83fcec80ae0698d9c#diff-9166d838beb43a2c911aa6d163edd91dR13