### PR TITLE
Remove *.nuget.targets and *.nuget.props

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -15,6 +15,12 @@
     <DoNotCopyLocalIfInGac>true</DoNotCopyLocalIfInGac>
     <TargetMSBuildToolsVersion>15.0</TargetMSBuildToolsVersion>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Disable the import of the dynamically generated NuGet files because they generate warnings anyway:
+         Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored. -->
+    <IncludeNuGetImports Condition="'$(IncludeNuGetImports)' == ''">false</IncludeNuGetImports>
+  </PropertyGroup>
 
   <PropertyGroup>
     <SerializeProjects>false</SerializeProjects>

--- a/src/Framework/Microsoft.Build.Framework.nuget.targets
+++ b/src/Framework/Microsoft.Build.Framework.nuget.targets
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="EmitMSBuildWarning" BeforeTargets="Build">
-    <Warning Text="Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored." />
-  </Target>
-</Project>

--- a/src/Utilities/Microsoft.Build.Utilities.nuget.targets
+++ b/src/Utilities/Microsoft.Build.Utilities.nuget.targets
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="EmitMSBuildWarning" BeforeTargets="Build">
-    <Warning Text="Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored." />
-  </Target>
-</Project>

--- a/src/XMakeBuildEngine/Microsoft.Build.nuget.targets
+++ b/src/XMakeBuildEngine/Microsoft.Build.nuget.targets
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="EmitMSBuildWarning" BeforeTargets="Build">
-    <Warning Text="Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored." />
-  </Target>
-</Project>

--- a/src/XMakeCommandLine/MSBuild.nuget.targets
+++ b/src/XMakeCommandLine/MSBuild.nuget.targets
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="EmitMSBuildWarning" BeforeTargets="Build">
-    <Warning Text="Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored." />
-  </Target>
-</Project>

--- a/src/XMakeTasks/Microsoft.Build.Tasks.nuget.targets
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.nuget.targets
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="EmitMSBuildWarning" BeforeTargets="Build">
-    <Warning Text="Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored." />
-  </Target>
-</Project>


### PR DESCRIPTION
These files are generated by NuGet restore and shouldn't be checked in (they are already in the `.gitignore`)

I also set the property `IncludeNuGetImports` to `false` so these files won't be imported because they just generate a warning anyway:

```
warning : Packages containing MSBuild targets and props files cannot be fully installed in
projects targeting multiple frameworks. The MSBuild targets and props files have been ignored.
```