### PR TITLE
Update NerdBank.GitVersioning

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -37,7 +37,7 @@
     <CompilerToolsVersion>2.0.0-beta3</CompilerToolsVersion>
     <XunitVersion>2.1.0</XunitVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
-    <GitVersioningVersion>1.4.30</GitVersioningVersion>
+    <GitVersioningVersion>1.5.46</GitVersioningVersion>
 
     <ToolsDir>$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\</ToolsDir>
     <BuildToolsTaskDir>$(ToolsDir)net45\</BuildToolsTaskDir>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Net.Compilers" version="2.0.0-beta3" targetFramework="net451" userInstalled="true" />
   <package id="xunit.runner.console" version="2.1.0" />
   <package id="MicroBuild.Core" version="0.2.0" />
-  <package id="Nerdbank.GitVersioning" version="1.4.30" />
+  <package id="Nerdbank.GitVersioning" version="1.5.46" />
 </packages>


### PR DESCRIPTION
Update NerdBank.GitVersioning from 1.4.30 to 1.5.46. We have a problem
where VSTS builds don't properly recognize that they're producing
builds for public release and continue to add the commit ID (for example
"-g12345678") to NuGet package names, which is undesirable. So far we
haven't been able to track down what's going wrong, and I'm hoping a
newer version of GitVersioning will solve the problem.

Even if it doesn't, upgrading to a newer version doesn't hurt.