### PR TITLE
Implement imports for project extensions

### DIFF
--- a/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
@@ -952,6 +952,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1016,6 +1017,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // ---------------------
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1080,6 +1082,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1138,6 +1141,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // ---------------------
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1196,6 +1200,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1254,6 +1259,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // ---------------------
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1312,6 +1318,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // ---------------------
             ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>
@@ -1370,6 +1377,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // ---------------------
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("foo.csproj", @"
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                     <PropertyGroup>
                         <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                         <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>

--- a/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
@@ -919,23 +919,23 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `Class;!@(foo)'^(Library1`, `Class;!@(foo)'^(Library1\Class;!@(foo)'^(Library1.csproj`, `{0B4B78CC-C752-43C2-BE9A-319D20216129}`
                 EndProject
                 Global
-	                GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		                Debug|Any CPU = Debug|Any CPU
-		                Release|Any CPU = Release|Any CPU
-	                EndGlobalSection
-	                GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		                {770F2381-8C39-49E9-8C96-0538FA4349A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		                {770F2381-8C39-49E9-8C96-0538FA4349A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		                {770F2381-8C39-49E9-8C96-0538FA4349A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		                {770F2381-8C39-49E9-8C96-0538FA4349A7}.Release|Any CPU.Build.0 = Release|Any CPU
-		                {0B4B78CC-C752-43C2-BE9A-319D20216129}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		                {0B4B78CC-C752-43C2-BE9A-319D20216129}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		                {0B4B78CC-C752-43C2-BE9A-319D20216129}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		                {0B4B78CC-C752-43C2-BE9A-319D20216129}.Release|Any CPU.Build.0 = Release|Any CPU
-	                EndGlobalSection
-	                GlobalSection(SolutionProperties) = preSolution
-		                HideSolutionNode = FALSE
-	                EndGlobalSection
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any CPU = Debug|Any CPU
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {770F2381-8C39-49E9-8C96-0538FA4349A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {770F2381-8C39-49E9-8C96-0538FA4349A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {770F2381-8C39-49E9-8C96-0538FA4349A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {770F2381-8C39-49E9-8C96-0538FA4349A7}.Release|Any CPU.Build.0 = Release|Any CPU
+                        {0B4B78CC-C752-43C2-BE9A-319D20216129}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {0B4B78CC-C752-43C2-BE9A-319D20216129}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {0B4B78CC-C752-43C2-BE9A-319D20216129}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {0B4B78CC-C752-43C2-BE9A-319D20216129}.Release|Any CPU.Build.0 = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
                 EndGlobal
                 ";
 
@@ -975,9 +975,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             ObjectModelHelpers.CreateFileInTempProjectDirectory("Class1.cs", @"
                 namespace ClassLibrary16
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
             ");
 
@@ -1039,9 +1039,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("Class1.cs", @"
                 namespace ClassLibrary16
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
             ");
 
@@ -1103,9 +1103,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             ObjectModelHelpers.CreateFileInTempProjectDirectory("Class1.cs", @"
                 namespace ClassLibrary16
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
             ");
 
@@ -1161,9 +1161,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("Class1.cs", @"
                 namespace ClassLibrary16
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
             ");
 
@@ -1219,9 +1219,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             ObjectModelHelpers.CreateFileInTempProjectDirectory("Class1.cs", @"
                 namespace ClassLibrary16
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
             ");
 
@@ -1277,9 +1277,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("Class1.cs", @"
                 namespace ClassLibrary16
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
             ");
 
@@ -1335,9 +1335,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             ObjectModelHelpers.CreateFileInTempProjectDirectory("Class;1.cs", @"
                 namespace ClassLibrary16
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
             ");
 
@@ -1393,9 +1393,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 ObjectModelHelpers.CreateFileInTempProjectDirectory("Class;1.cs", @"
                 namespace ClassLibrary16
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
             ");
 
@@ -1499,13 +1499,13 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
 
                 namespace Console____foo____Application1
                 {
-	                class Program
-	                {
-		                static void Main(string[] args)
-		                {
-			                Class____foo____Library1.Class1 foo = new Class____foo____Library1.Class1();
-		                }
-	                }
+                    class Program
+                    {
+                        static void Main(string[] args)
+                        {
+                            Class____foo____Library1.Class1 foo = new Class____foo____Library1.Class1();
+                        }
+                    }
                 }
                 ");
 
@@ -1566,9 +1566,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 @"
                 namespace Class____foo____Library1
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
                 ");
 
@@ -1670,13 +1670,13 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
 
                 namespace Console____foo____Application1
                 {
-	                class Program
-	                {
-		                static void Main(string[] args)
-		                {
-			                Class____foo____Library1.Class1 foo = new Class____foo____Library1.Class1();
-		                }
-	                }
+                    class Program
+                    {
+                        static void Main(string[] args)
+                        {
+                            Class____foo____Library1.Class1 foo = new Class____foo____Library1.Class1();
+                        }
+                    }
                 }
                 ");
 
@@ -1737,9 +1737,9 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                     @"
                 namespace Class____foo____Library1
                 {
-	                public class Class1
-	                {
-	                }
+                    public class Class1
+                    {
+                    }
                 }
                 ");
 

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -321,8 +321,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <AutoUnifyAssemblyReferences>true</AutoUnifyAssemblyReferences>
     <AutoUnifyAssemblyReferences Condition="'$(GenerateBindingRedirectsOutputType)' == 'true' and '$(AutoGenerateBindingRedirects)' != 'true'">false</AutoUnifyAssemblyReferences>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">obj\</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
     <CleanFile Condition="'$(CleanFile)'==''">$(MSBuildProjectFile).FileListAbsolute.txt</CleanFile>
     <!-- During DesignTime Builds, skip project reference build as Design time is only queueing information.-->
     <BuildProjectReferences Condition="'$(BuildProjectReferences)' == '' and '$(DesignTimeBuild)' == 'true'">false</BuildProjectReferences>

--- a/src/XMakeTasks/Microsoft.Common.props
+++ b/src/XMakeTasks/Microsoft.Common.props
@@ -32,6 +32,33 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
   <!-- 
+        Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
+          $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.props
+          
+        Each package management system should use a unique moniker to avoid collisions.  It is a wild-card import so the package
+        management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
+    -->
+  <PropertyGroup>
+    <!--
+            The declaration of $(BaseIntermediateOutputPath) had to be moved up from Microsoft.Common.CurrentVersion.targets
+            in order for the $(MSBuildProjectExtensionsPath) to use it as a default.
+        -->
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">obj\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
+    <MSBuildProjectExtensionsPath Condition="'$(MSBuildProjectExtensionsPath)' == '' ">$(BaseIntermediateOutputPath)</MSBuildProjectExtensionsPath>
+    <!--
+        Import paths that are relative default to be relative to the importing file.  However, since MSBuildExtensionsPath
+        defaults to BaseIntermediateOutputPath we expect it to be relative to the project directory.  So if the path is relative
+        it needs to be made absolute based on the project directory.
+      -->
+    <MSBuildProjectExtensionsPath Condition="'$([System.IO.Path]::IsPathRooted($(MSBuildProjectExtensionsPath)))' == 'false'">$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(MSBuildProjectExtensionsPath)'))</MSBuildProjectExtensionsPath>
+    <MSBuildProjectExtensionsPath Condition="!HasTrailingSlash('$(MSBuildProjectExtensionsPath)')">$(MSBuildProjectExtensionsPath)\</MSBuildProjectExtensionsPath>
+    <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.props" Condition="'$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+
+  <!-- 
         Import wildcard "ImportBefore" props files if we're actually in a 12.0+ project (rather than a project being
         treated as 4.0)
     -->

--- a/src/XMakeTasks/Microsoft.Common.targets
+++ b/src/XMakeTasks/Microsoft.Common.targets
@@ -113,6 +113,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(CommonTargetsPath)" />
 
+  <!--
+      Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
+          $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.targets
+          
+        Each package management system should use a unique moniker to avoid collisions.  It is a wild-card import so the package
+        management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
+    -->
+  <PropertyGroup>
+    <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.targets" Condition="'$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+
   <PropertyGroup>
     <ImportDirectoryBuildTargets Condition="'$(ImportDirectoryBuildTargets)' == ''">true</ImportDirectoryBuildTargets>
   </PropertyGroup>

--- a/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" Condition="!$(Configuration.EndsWith('MONO'))"/>
@@ -74,6 +74,9 @@
     <Compile Include="Move_Tests.cs" />
     <Compile Include="MSBuild_Tests.cs" />
     <Compile Include="PortableTasks_Tests.cs" />
+    <Compile Include="ProjectExtensionsImportTestBase.cs" />
+    <Compile Include="ProjectExtensionsPropsImportTest.cs" />
+    <Compile Include="ProjectExtensionsTargetsImportTest.cs" />
     <Compile Include="PropertyParser_Tests.cs" />
     <Compile Include="ReadLinesFromFile_Tests.cs" />
     <Compile Include="RemoveDir_Tests.cs" />
@@ -85,7 +88,6 @@
     <Compile Include="Touch_Tests.cs" />
     <Compile Include="TrustInfo_Tests.cs" />
     <Compile Include="WriteCodeFragment_Tests.cs" />
-
     <EmbeddedResource Include="SampleResx" />
     <None Include="..\..\Shared\UnitTests\App.config">
       <Link>App.config</Link>
@@ -125,7 +127,7 @@
     <Compile Include="MockTypeLib.cs" />
     <Compile Include="ResGen_Tests.cs" />
     <Compile Include="ResGenDependencies_Tests.cs" />
-	<Compile Include="AssemblyDependency\AssemblyFoldersFromConfig_Tests.cs" />
+    <Compile Include="AssemblyDependency\AssemblyFoldersFromConfig_Tests.cs" />
     <Compile Include="AssemblyDependency\FilePrimary.cs" />
     <Compile Include="AssemblyDependency\GlobalAssemblyCacheTests.cs" />
     <Compile Include="AssemblyDependency\InstalledSDKResolverFixture.cs" />

--- a/src/XMakeTasks/UnitTests/ProjectExtensionsImportTestBase.cs
+++ b/src/XMakeTasks/UnitTests/ProjectExtensionsImportTestBase.cs
@@ -1,0 +1,152 @@
+﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Evaluation;
+using System;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests
+{
+    public abstract class ProjectExtensionsImportTestBase : IDisposable
+    {
+        protected readonly string _projectRelativePath = Path.Combine("src", "foo", "foo.csproj");
+
+        protected ProjectExtensionsImportTestBase()
+        {
+            ObjectModelHelpers.DeleteTempProjectDirectory();
+        }
+
+        protected virtual string BasicProjectImportContents => $@"
+            <Project xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                <PropertyGroup>
+                <{PropertyNameToSignalImportSucceeded}>true</{PropertyNameToSignalImportSucceeded}>
+                </PropertyGroup>
+            </Project>";
+
+        protected abstract string CustomImportProjectPath { get; }
+        protected abstract string ImportProjectPath { get; }
+        protected abstract string PropertyNameToEnableImport { get; }
+
+        /// <summary>
+        /// The name of the property to use in a project that is imported.  This base class will generate a project containing the declaration of the property.
+        /// </summary>
+        protected abstract string PropertyNameToSignalImportSucceeded { get; }
+
+        public void Dispose()
+        {
+            ObjectModelHelpers.DeleteTempProjectDirectory();
+        }
+
+        /// <summary>
+        /// Ensures that when the MSBuildProjectExtensionsPath does not exist that nothing is imported.
+        /// </summary>
+        [Fact]
+        public void DoesNotImportProjectIfNotExist()
+        {
+            // ---------------------
+            // src\Foo\Foo.csproj
+            // ---------------------
+
+            Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
+
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />
+                </Project>
+            "));
+
+            string projectExtensionsPath = project.GetPropertyValue("MSBuildProjectExtensionsPath");
+
+            Assert.True(!String.IsNullOrWhiteSpace(projectExtensionsPath), "The property 'MSBuildProjectExtensionsPath' should not be empty during project evaluation.");
+            Assert.True(!Directory.Exists(projectExtensionsPath), $"The project extension directory '{projectExtensionsPath}' should not exist.");
+            Assert.Equal("true", project.GetPropertyValue(PropertyNameToEnableImport), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(String.Empty, project.GetPropertyValue(PropertyNameToSignalImportSucceeded), StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Ensures that even if the MSBuildProjectExtensionsPath exists, the extensions are not imported if the functionality is disabled via the <see cref="PropertyNameToEnableImport"/>.
+        /// </summary>
+        [Fact]
+        public void DoesNotImportProjectWhenDisabled()
+        {
+            // ---------------------
+            // Directory.Build.props
+            // ---------------------
+            ObjectModelHelpers.CreateFileInTempProjectDirectory(ImportProjectPath, BasicProjectImportContents);
+
+            // ---------------------
+            // src\Foo\Foo.csproj
+            // ---------------------
+
+            Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, $@"
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <PropertyGroup>
+                        <{PropertyNameToEnableImport}>false</{PropertyNameToEnableImport}>
+                    </PropertyGroup>
+
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
+
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />
+                </Project>
+            "));
+
+            string projectExtensionsDirectory = Path.Combine(ObjectModelHelpers.TempProjectDir, Path.GetDirectoryName(ImportProjectPath));
+
+            Assert.Equal("false", project.GetPropertyValue(PropertyNameToEnableImport), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(String.Empty, project.GetPropertyValue(PropertyNameToSignalImportSucceeded), StringComparer.OrdinalIgnoreCase);
+            Assert.True(Directory.Exists(projectExtensionsDirectory), $"The directory '{projectExtensionsDirectory}' should exist but doesn't.");
+            Assert.Equal($@"{projectExtensionsDirectory}{Path.DirectorySeparatorChar}", project.GetPropertyValue("MSBuildProjectExtensionsPath"));
+        }
+
+        /// <summary>
+        /// Ensures that if the user set a custom MSBuildProjectExtensionsPath that the import will still succeed.
+        /// </summary>
+        [Fact]
+        public void ImportsProjectIfCustomPath()
+        {
+            ObjectModelHelpers.CreateFileInTempProjectDirectory(CustomImportProjectPath, BasicProjectImportContents);
+
+            // ---------------------
+            // src\Foo\Foo.csproj
+            // ---------------------
+
+            Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, $@"
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <PropertyGroup>
+                        <MSBuildProjectExtensionsPath>{Path.GetDirectoryName(CustomImportProjectPath)}</MSBuildProjectExtensionsPath>
+                    </PropertyGroup>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
+
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />
+                </Project>
+            "));
+
+            Assert.Equal("true", project.GetPropertyValue(PropertyNameToEnableImport), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("true", project.GetPropertyValue(PropertyNameToSignalImportSucceeded), StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Ensures that if the default MSBuildProjectExtensions directory is used, that the projects will be imported.
+        /// </summary>
+        [Fact]
+        public void ImportsProjectIfExists()
+        {
+            ObjectModelHelpers.CreateFileInTempProjectDirectory(ImportProjectPath, BasicProjectImportContents);
+
+            // ---------------------
+            // src\Foo\Foo.csproj
+            // ---------------------
+
+            Project project = ObjectModelHelpers.LoadProjectFileInTempProjectDirectory(ObjectModelHelpers.CreateFileInTempProjectDirectory(_projectRelativePath, @"
+                <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
+
+                    <Import Project=`$(MSBuildBinPath)\Microsoft.CSharp.targets` />
+                </Project>
+            "));
+
+            Assert.Equal("true", project.GetPropertyValue(PropertyNameToEnableImport), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("true", project.GetPropertyValue(PropertyNameToSignalImportSucceeded), StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/XMakeTasks/UnitTests/ProjectExtensionsPropsImportTest.cs
+++ b/src/XMakeTasks/UnitTests/ProjectExtensionsPropsImportTest.cs
@@ -1,0 +1,20 @@
+﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Tests that Microsoft.Common.props successfully imports project extensions written by package management systems.
+    /// </summary>
+    sealed public class ProjectExtensionsPropsImportTest : ProjectExtensionsImportTestBase
+    {
+        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.props");
+
+        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.props");
+
+        protected override string PropertyNameToEnableImport => "ImportProjectExtensionProps";
+
+        protected override string PropertyNameToSignalImportSucceeded => "WasProjectExtensionPropsImported";
+    }
+}

--- a/src/XMakeTasks/UnitTests/ProjectExtensionsTargetsImportTest.cs
+++ b/src/XMakeTasks/UnitTests/ProjectExtensionsTargetsImportTest.cs
@@ -1,0 +1,20 @@
+﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// Tests that Microsoft.Common.props successfully imports project extensions written by package management systems.
+    /// </summary>
+    sealed public class ProjectExtensionsTargetsImportTest : ProjectExtensionsImportTestBase
+    {
+        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.targets");
+
+        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.targets");
+
+        protected override string PropertyNameToEnableImport => "ImportProjectExtensionTargets";
+
+        protected override string PropertyNameToSignalImportSucceeded => "WasProjectExtensionTargetsImported";
+    }
+}


### PR DESCRIPTION
Implementation according to this: https://github.com/Microsoft/msbuild/issues/784#issuecomment-241880891

Fixes #784

- Should this import come before or after the directory.build.props?  I had the import come **after** but this might give users less control because their local imports will happen before the NuGet imports.

FYI @eerhardt