### PR TITLE
Ensure the MSBuild.exe.config is properly binplaced for unit tests

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -57,6 +57,10 @@
           DestinationFolder="$(TestDeploymentDir)\%(RecursiveDir)"
           SkipUnchangedFiles="true"
           />
+
+    <Copy SourceFiles="$(SourceDir)\Shared\UnitTests\App.config"
+          DestinationFiles="$(TestDeploymentDir)\MSBuild.exe.config"
+          />
   </Target>
 
   <Target Name="DeployForTargetRuntime"


### PR DESCRIPTION
The app.config in the test deployment directory is the same as the normal one.  The binplacing isn't working as part of the project because everything gets built to Windows_NT first and then copied to Windows_NT_Test second.  The first project containing an msbuild.exe.config binplaces the file but the rest, including the unit tests, don't bother because the file is up to date.