### PR TITLE
Change #if RETAIL to !DEBUG

### DIFF
--- a/src/Shared/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Shared/MSBuildNameIgnoreCaseComparer.cs
@@ -129,7 +129,6 @@ namespace Microsoft.Build.Collections
                 return false;
             }
 
-#if RETAIL
             if ((s_runningProcessorArchitecture != NativeMethodsShared.PROCESSOR_ARCHITECTURE_IA64) && (s_runningProcessorArchitecture != NativeMethodsShared.PROCESSOR_ARCHITECTURE_ARM))
             {
                 // The use of unsafe here is quite a bit faster than the regular
@@ -159,13 +158,11 @@ namespace Microsoft.Build.Collections
                 }
             }
             else
-#endif
             {
                 return String.Compare(compareToString, 0, constrainedString, start, lengthToCompare, StringComparison.OrdinalIgnoreCase) == 0;
             }
-#if RETAIL
+
             return true;
-#endif
         }
 
         /// <summary>
@@ -348,7 +345,7 @@ namespace Microsoft.Build.Collections
                     }
                 }
             }
-#if RETAIL
+
             if ((s_runningProcessorArchitecture != NativeMethodsShared.PROCESSOR_ARCHITECTURE_IA64) && (s_runningProcessorArchitecture != NativeMethodsShared.PROCESSOR_ARCHITECTURE_ARM))
             {
                 unsafe
@@ -400,7 +397,6 @@ namespace Microsoft.Build.Collections
                 }
             }
             else
-#endif
             {
                 return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Substring(start, length));
             }


### PR DESCRIPTION
When we moved to GitHub, we never set up the projects to define RETAIL for
release builds, as was done in the old repo. This led to a memory-use
regression because we were calling the debug method instead of the
optimized one.

Instead of defining RETAIL, I've switched to !DEBUG which reduces the
number of independent switches but seems to keep the required concept
afloat.