### PR TITLE
Copy the 64 bit satellite assemblies for 64 bit msbuild in the vsix package

### DIFF
--- a/setup/files.swr
+++ b/setup/files.swr
@@ -159,89 +159,89 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)Microsoft.WorkflowBuildExtensions.targets
 
 folder InstallDir:\MSBuild\15.0\Bin\amd64\cs
-  file source=$(X86BinPath)cs\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)cs\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)cs\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)cs\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)cs\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)cs\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\de
-  file source=$(X86BinPath)de\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)de\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)de\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)de\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)de\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)de\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)de\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)de\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)de\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)de\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\en
-  file source=$(X86BinPath)en\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)en\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)en\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)en\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)en\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)en\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)en\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)en\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)en\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)en\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\es
-  file source=$(X86BinPath)es\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)es\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)es\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)es\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)es\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)es\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)es\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)es\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)es\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)es\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\fr
-  file source=$(X86BinPath)fr\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)fr\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)fr\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)fr\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)fr\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)fr\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\it
-  file source=$(X86BinPath)it\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)it\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)it\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)it\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)it\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)it\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)it\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)it\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)it\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)it\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\ja
-  file source=$(X86BinPath)ja\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ja\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ja\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ja\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ja\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ja\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\ko
-  file source=$(X86BinPath)ko\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ko\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ko\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ko\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ko\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ko\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\pl
-  file source=$(X86BinPath)pl\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)pl\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)pl\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pl\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pl\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pl\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\pt
-  file source=$(X86BinPath)pt\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)pt\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)pt\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)pt\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)pt\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pt\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pt\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pt\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pt\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)pt\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\ru
-  file source=$(X86BinPath)ru\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ru\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)ru\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ru\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ru\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)ru\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\tr
-  file source=$(X86BinPath)tr\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)tr\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)tr\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)tr\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)tr\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)tr\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\zh-Hans
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)zh-Hans\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)zh-Hans\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hans\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hans\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 folder InstallDir:\MSBuild\15.0\Bin\amd64\zh-Hant
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)zh-Hant\MSBuild.resources.dll vs.file.ngen=yes
-  file source=$(X86BinPath)zh-Hant\MSBuildTaskHost.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hant\MSBuild.resources.dll vs.file.ngen=yes
+  file source=$(X64BinPath)zh-Hant\MSBuildTaskHost.resources.dll vs.file.ngen=yes
 
 folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)Framework\Microsoft.Build.Framework.pkgdef


### PR DESCRIPTION
64 bit msbuild failed because our previous vsix setup copied the x86 satellites into the x64 bin directory.

To test this, I built the vsix package locally and ran msbuild from the command line from both the x86 and the x64 vsix bin directories.