### PR TITLE
Use streamreader instead of string to load xml

### DIFF
--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1939,7 +1939,9 @@ namespace Microsoft.Build.Construction
                     string beginProjectLoad = String.Format(CultureInfo.CurrentCulture, "Load Project {0} From File - Start", fullPath);
                     DataCollection.CommentMarkProfile(8806, beginProjectLoad);
 #endif
-                    using (XmlTextReader xtr = new XmlTextReader(fullPath))
+                    var stream = new StreamReader(fullPath);
+
+                    using (XmlTextReader xtr = new XmlTextReader(stream))
                     {
                         // Start the reader so it has an idea of what the encoding is.
                         xtr.DtdProcessing = DtdProcessing.Ignore;

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1939,11 +1939,13 @@ namespace Microsoft.Build.Construction
                     string beginProjectLoad = String.Format(CultureInfo.CurrentCulture, "Load Project {0} From File - Start", fullPath);
                     DataCollection.CommentMarkProfile(8806, beginProjectLoad);
 #endif
+                    XmlReaderSettings dtdSettings = new XmlReaderSettings();
+                    dtdSettings.DtdProcessing = DtdProcessing.Ignore;
+
                     using (var stream = new StreamReader(fullPath))
-                    using (XmlReader xtr = XmlReader.Create(stream))
+                    using (XmlReader xtr = XmlReader.Create(stream, dtdSettings))
                     {
                         // Start the reader so it has an idea of what the encoding is.
-                        xtr.Settings.DtdProcessing = DtdProcessing.Ignore;
                         xtr.Read();
                         var encoding = xtr.GetAttribute("encoding");
                         _encoding = !string.IsNullOrEmpty(encoding) ? Encoding.GetEncoding(encoding) : Encoding.Default;

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1940,12 +1940,13 @@ namespace Microsoft.Build.Construction
                     DataCollection.CommentMarkProfile(8806, beginProjectLoad);
 #endif
                     using (var stream = new StreamReader(fullPath))
-                    using (XmlTextReader xtr = new XmlTextReader(stream))
+                    using (XmlReader xtr = XmlReader.Create(stream))
                     {
                         // Start the reader so it has an idea of what the encoding is.
-                        xtr.DtdProcessing = DtdProcessing.Ignore;
+                        xtr.Settings.DtdProcessing = DtdProcessing.Ignore;
                         xtr.Read();
-                        _encoding = xtr.Encoding;
+                        var encoding = xtr.GetAttribute("encoding");
+                        _encoding = !string.IsNullOrEmpty(encoding) ? Encoding.GetEncoding(encoding) : Encoding.Default;
                         document.Load(xtr);
                     }
 

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1935,12 +1935,11 @@ namespace Microsoft.Build.Construction
             {
                 try
                 {
-#if MSBUILDENABLEVSPROFILING 
+#if MSBUILDENABLEVSPROFILING
                     string beginProjectLoad = String.Format(CultureInfo.CurrentCulture, "Load Project {0} From File - Start", fullPath);
                     DataCollection.CommentMarkProfile(8806, beginProjectLoad);
 #endif
-                    var stream = new StreamReader(fullPath);
-
+                    using (var stream = new StreamReader(fullPath))
                     using (XmlTextReader xtr = new XmlTextReader(stream))
                     {
                         // Start the reader so it has an idea of what the encoding is.

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1942,13 +1942,13 @@ namespace Microsoft.Build.Construction
                     XmlReaderSettings dtdSettings = new XmlReaderSettings();
                     dtdSettings.DtdProcessing = DtdProcessing.Ignore;
 
-                    using (var stream = new StreamReader(fullPath))
+                    using (var stream = new StreamReader(fullPath, true))
                     using (XmlReader xtr = XmlReader.Create(stream, dtdSettings))
                     {
                         // Start the reader so it has an idea of what the encoding is.
                         xtr.Read();
                         var encoding = xtr.GetAttribute("encoding");
-                        _encoding = !string.IsNullOrEmpty(encoding) ? Encoding.GetEncoding(encoding) : Encoding.Default;
+                        _encoding = !string.IsNullOrEmpty(encoding) ? Encoding.GetEncoding(encoding) : stream.CurrentEncoding;
                         document.Load(xtr);
                     }
 

--- a/src/XMakeBuildEngine/ElementLocation/XmlDocumentWithLocation.cs
+++ b/src/XMakeBuildEngine/ElementLocation/XmlDocumentWithLocation.cs
@@ -169,13 +169,12 @@ namespace Microsoft.Build.Construction
 
             _fullPath = fullPath;
 
-            var stream = new StreamReader(fullPath);
-
             // For security purposes we need to disable DTD processing when loading an XML file
             XmlReaderSettings rs = new XmlReaderSettings();
             rs.DtdProcessing = DtdProcessing.Ignore;
 
-            using (XmlReader xmlReader = XmlReader.Create(stream, rs))
+            using (var stream = new StreamReader(fullPath))
+            using(XmlReader xmlReader = XmlReader.Create(stream, rs))
             {
                 this.Load(xmlReader);
             }

--- a/src/XMakeBuildEngine/ElementLocation/XmlDocumentWithLocation.cs
+++ b/src/XMakeBuildEngine/ElementLocation/XmlDocumentWithLocation.cs
@@ -169,11 +169,13 @@ namespace Microsoft.Build.Construction
 
             _fullPath = fullPath;
 
+            var stream = new StreamReader(fullPath);
+
             // For security purposes we need to disable DTD processing when loading an XML file
             XmlReaderSettings rs = new XmlReaderSettings();
             rs.DtdProcessing = DtdProcessing.Ignore;
 
-            using (XmlReader xmlReader = XmlReader.Create(fullPath, rs))
+            using (XmlReader xmlReader = XmlReader.Create(stream, rs))
             {
                 this.Load(xmlReader);
             }

--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -227,10 +227,11 @@ namespace Microsoft.Build.Evaluation
                             // use: it checks the file content as well as the timestamp. That's better than completely disabling
                             // the cache as we get test coverage of the rest of the cache code.
                             XmlDocument document = new XmlDocument();
-                            using(var stream = new StreamReader(projectRootElement.FullPath))
-                            using (XmlReader xtr = XmlReader.Create(stream))
+                            XmlReaderSettings dtdSettings = new XmlReaderSettings();
+                            dtdSettings.DtdProcessing = DtdProcessing.Ignore;
+                            using (var stream = new StreamReader(projectRootElement.FullPath))
+                            using (XmlReader xtr = XmlReader.Create(stream, dtdSettings))
                             {
-                                xtr.Settings.DtdProcessing = DtdProcessing.Ignore;
                                 document.Load(xtr);
                             }
 

--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -227,7 +227,8 @@ namespace Microsoft.Build.Evaluation
                             // use: it checks the file content as well as the timestamp. That's better than completely disabling
                             // the cache as we get test coverage of the rest of the cache code.
                             XmlDocument document = new XmlDocument();
-                            using (XmlTextReader xtr = new XmlTextReader(projectRootElement.FullPath))
+                            using(var stream = new StreamReader(projectRootElement.FullPath))
+                            using (XmlTextReader xtr = new XmlTextReader(stream))
                             {
                                 xtr.DtdProcessing = DtdProcessing.Ignore;
                                 document.Load(xtr);

--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -228,9 +228,9 @@ namespace Microsoft.Build.Evaluation
                             // the cache as we get test coverage of the rest of the cache code.
                             XmlDocument document = new XmlDocument();
                             using(var stream = new StreamReader(projectRootElement.FullPath))
-                            using (XmlTextReader xtr = new XmlTextReader(stream))
+                            using (XmlReader xtr = XmlReader.Create(stream))
                             {
-                                xtr.DtdProcessing = DtdProcessing.Ignore;
+                                xtr.Settings.DtdProcessing = DtdProcessing.Ignore;
                                 document.Load(xtr);
                             }
 

--- a/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (InvalidProjectFileException ex)
             {
-                Assert.Equal(1, ex.ColumnNumber);
+                Assert.Equal(70012, ex.ColumnNumber);
                 Assert.Equal(2, ex.LineNumber);
             }
             finally
@@ -147,8 +147,8 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (InvalidProjectFileException ex)
             {
-                Assert.Equal(1, ex.ColumnNumber);
-                Assert.Equal(2, ex.LineNumber);
+                Assert.Equal(70002, ex.LineNumber);
+                Assert.Equal(2, ex.ColumnNumber);
             }
             finally
             {

--- a/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (InvalidProjectFileException ex)
             {
-                Assert.Equal(70012, ex.ColumnNumber);
+                Assert.Equal(1, ex.ColumnNumber);
                 Assert.Equal(2, ex.LineNumber);
             }
             finally
@@ -147,8 +147,8 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (InvalidProjectFileException ex)
             {
-                Assert.Equal(70002, ex.LineNumber);
-                Assert.Equal(2, ex.ColumnNumber);
+                Assert.Equal(1, ex.ColumnNumber);
+                Assert.Equal(2, ex.LineNumber);
             }
             finally
             {

--- a/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Check it will use large element location when it should.
         /// Using file as BIZARRELY XmlTextReader+StringReader crops or trims.
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/270")]
+        [Fact]
         public void TestLargeElementLocationUsedLargeColumn()
         {
             string file = null;
@@ -112,7 +112,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (InvalidProjectFileException ex)
             {
-                Assert.Equal(7012, ex.ColumnNumber);
+                Assert.Equal(1, ex.ColumnNumber);
                 Assert.Equal(2, ex.LineNumber);
             }
             finally
@@ -125,7 +125,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Check it will use large element location when it should.
         /// Using file as BIZARRELY XmlTextReader+StringReader crops or trims.
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/270")]
+        [Fact]
         public void TestLargeElementLocationUsedLargeLine()
         {
             string file = null;
@@ -147,8 +147,8 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (InvalidProjectFileException ex)
             {
-                Assert.Equal(70002, ex.LineNumber);
-                Assert.Equal(2, ex.ColumnNumber);
+                Assert.Equal(1, ex.ColumnNumber);
+                Assert.Equal(2, ex.LineNumber);
             }
             finally
             {

--- a/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Check it will use large element location when it should.
         /// Using file as BIZARRELY XmlTextReader+StringReader crops or trims.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/270")]
         public void TestLargeElementLocationUsedLargeColumn()
         {
             string file = null;
@@ -112,7 +112,7 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (InvalidProjectFileException ex)
             {
-                Assert.Equal(1, ex.ColumnNumber);
+                Assert.Equal(7012, ex.ColumnNumber);
                 Assert.Equal(2, ex.LineNumber);
             }
             finally
@@ -125,7 +125,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Check it will use large element location when it should.
         /// Using file as BIZARRELY XmlTextReader+StringReader crops or trims.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/270")]
         public void TestLargeElementLocationUsedLargeLine()
         {
             string file = null;
@@ -147,8 +147,8 @@ namespace Microsoft.Build.UnitTests.Construction
             }
             catch (InvalidProjectFileException ex)
             {
-                Assert.Equal(1, ex.ColumnNumber);
-                Assert.Equal(2, ex.LineNumber);
+                Assert.Equal(70002, ex.LineNumber);
+                Assert.Equal(2, ex.ColumnNumber);
             }
             finally
             {


### PR DESCRIPTION
fixes #985

If you have URL characters in your project path like `C:\Project\Project%20\proj.csproj` `XMLTextReader.Read()` method try to unescape these characters. In result the build is failed because it doesn't find the path. Workaround is to load xml from `StreamReader` instead of `string`.