### PR TITLE
GetItemProvenance(ProjectItem) now finds only the elements that might affect that item

### DIFF
--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -1085,20 +1085,6 @@ namespace Microsoft.Build.Evaluation
             return GetAllGlobs(GetItemElementsByType(_data.EvaluatedItemElements, itemType));
         }
 
-        /// <summary>
-        /// Overload of <see cref="Project.GetAllGlobs()"/>
-        /// </summary>
-        /// <param name="item">Confine search to item elements appearing above this item, inclusively.</param>
-        public List<GlobResult> GetAllGlobs(ProjectItem item)
-        {
-            if (item == null)
-            {
-                return new List<GlobResult>();
-            }
-
-            return GetAllGlobs(GetItemElementsAboveItem(_data.EvaluatedItemElements, item));
-        }
-
         private List<GlobResult> GetAllGlobs(List<ProjectItemElement> projectItemElements)
         {
             return projectItemElements.SelectMany(GetAllGlobs).ToList();
@@ -1223,17 +1209,6 @@ namespace Microsoft.Build.Evaluation
         private static List<ProjectItemElement> GetItemElementsByType(IEnumerable<ProjectItemElement> itemElements, string itemType)
         {
             return itemElements.Where(i => i.ItemType.Equals(itemType)).ToList();
-        }
-
-        private static List<ProjectItemElement> GetItemElementsAboveItem(IEnumerable<ProjectItemElement> itemElements, ProjectItem item)
-        {
-            var itemElementsAbove = itemElements
-                .Where(i => i.ItemType.Equals(item.ItemType))
-                .TakeWhile(i => i != item.Xml)
-                .ToList();
-
-            itemElementsAbove.Add(item.Xml);
-            return itemElementsAbove;
         }
 
         private List<ProvenanceResult> GetItemProvenance(string itemToMatch, IEnumerable<ProjectItemElement> projectItemElements )

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -59,6 +59,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             Assert.Equal(0, ProjectCollection.GlobalProjectCollection.GlobalProperties.Count);
         }
 
+        private static readonly string ProjectWithItemGroup =
+@"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+{0}
+                  </ItemGroup>
+                </Project>
+            ";
+
         /// <summary>
         /// Since when the project file is saved it may be intented we want to make sure the indent charachters do not affect the evaluation against empty. 
         /// We test here newline, tab, and carriage return.
@@ -2608,27 +2616,79 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             AssertProvenanceResult(new ProvenanceResultTupleList(), project, "1.foo", "NotExistant");
         }
 
-        [Fact]
-        public void GetItemProvenanceByProjectItem()
+        public static IEnumerable<Object[]> GetItemProvenanceByProjectItemTestData
         {
-            var project =
-            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
-                  <ItemGroup>
-                    <A Include=`*.foo;1.foo`/>
-                    <B Include=`1;2;3;*.foo` Exclude=`*.foo;1.foo`/>
-                    <B Include=`*.foo;1.foo`/>
-                    <C Include=`2;3` Exclude=`2`/>
-                  </ItemGroup>
-                </Project>
-            ";
-
-            var expected = new ProvenanceResultTupleList
+            get
             {
-                Tuple.Create("B", Operation.Exclude, Provenance.Glob | Provenance.StringLiteral, 2),
-                Tuple.Create("B", Operation.Include, Provenance.Glob | Provenance.StringLiteral, 2)
-            };
+                // Provenance for an item in the last element. Nothing matches
+                yield return new object[]
+                {
+                    @"
+                    <A Include=`a;b`/>
+                    <A Update=`a`/>
+                    <A Update=`b`/>
+                    <A Include=`a;b`/>
+                    ",
+                    "a",
+                    1, // item 'a' from last include
+                    new ProvenanceResultTupleList()
+                };
 
-            AssertProvenanceResult(expected, project, "1.foo", 1);
+                // Nothing matches
+                yield return new object[]
+                {
+                    @"
+                    <A Include=`a;b;c`/>
+                    <A Update=`c;*ab`/>
+                    <A Remove=`b`/>
+                    <A Include=`a`/>
+                    ",
+                    "a",
+                    0, // item 'a' from first include
+                    new ProvenanceResultTupleList()
+                };
+
+                yield return new object[]
+                {
+                    @"
+                    <A Remove=`a`/>
+
+                    <A Include=`a;b;c`/>
+                    <A Update=`a`/>
+                    <A Update=`b`/>
+                    <B Update=`a`/>
+                    <A Remove=`b`/>
+
+                    <A Include=`a;b`/>
+                    <A Update=`a;a`/>
+                    <A Update=`b`/>
+                    <B Update=`a`/>
+                    <A Remove=`b`/>
+
+                    <A Include=`a`/>
+                    <A Update=`a;a*`/>
+                    <A Update=`b`/>
+                    <B Update=`a`/>
+                    <A Remove=`b`/>
+                    ",
+                    "a",
+                    1, // item 'a' from second include
+                    new ProvenanceResultTupleList
+                    {
+                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral, 2),
+                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2)
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetItemProvenanceByProjectItemTestData))]
+        public void GetItemProvenanceByProjectItem(string items, string itemValue, int itemPosition, ProvenanceResultTupleList expected)
+        {
+            var formattedProject = string.Format(ProjectWithItemGroup, items);
+
+            AssertProvenanceResult(expected, formattedProject, itemValue, itemPosition);
         }
 
         [Fact]

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -3010,8 +3010,6 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             AssertGlobResult(expected, project, "");
             AssertGlobResult(expected, project, null);
-
-            AssertGlobResult(expected, project, null, 2);
         }
 
         [Fact]
@@ -3060,29 +3058,6 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             AssertGlobResult(expected, project, "A");
             AssertGlobResult(new GlobResultList(), project, "NotExistant");
-        }
-
-        [Fact]
-        public void GetAllGlobsShouldFindGlobsByProjectItem()
-        {
-            var project =
-                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
-                  <ItemGroup>
-                    <A Include=`*.1` Exclude=`1`/>
-                    <A Include=`*.2;marker` Exclude=`2`/>
-                    <B Include=`a;**;b;c;*` Exclude=`B`/>
-                    <A Include=`*.3;` Exclude=`3`/>
-                  </ItemGroup>
-                </Project>
-                ";
-
-            var expected = new GlobResultList
-            {
-                Tuple.Create("A", "*.1", new[] { "1" }.ToImmutableHashSet()),
-                Tuple.Create("A", "*.2", new[] { "2" }.ToImmutableHashSet()),
-            };
-
-            AssertGlobResult(expected, project, "marker", 0);
         }
 
         [Fact]
@@ -3138,15 +3113,6 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         private static void AssertGlobResult(GlobResultList expected, string project, string itemType)
         {
             var globs = ObjectModelHelpers.CreateInMemoryProject(project).GetAllGlobs(itemType) ;
-            AssertGlobResultsEqual(expected, globs);
-        }
-        private static void AssertGlobResult(GlobResultList expected, string project, string itemValue, int position)
-        {
-            Project p;
-            ProjectItem item;
-            GetProjectAndItemAtPosition(project, itemValue, position, out p, out item);
-
-            var globs = p.GetAllGlobs(item);
             AssertGlobResultsEqual(expected, globs);
         }
 


### PR DESCRIPTION
Addresses: #919 

Also removed the GetAllGlobs(ProjectItem) overload since the CPS team has no use for it