### PR TITLE
Update NuGet packages to include satellite assemblies

### DIFF
--- a/src/nuget/MSBuild.nuspec
+++ b/src/nuget/MSBuild.nuspec
@@ -27,5 +27,21 @@
   <files>
     <!--<file src="_._" target="lib\net46" />-->
     <file src="MSBuild.exe" target="runtimes\any\native" />
+  
+    <!-- Satellite assemblies -->
+    <file src="cs\MSBuild.resources.dll" target="runtimes\any\native\cs" />
+    <file src="de\MSBuild.resources.dll" target="runtimes\any\native\de" />
+    <file src="en\MSBuild.resources.dll" target="runtimes\any\native\en" />
+    <file src="es\MSBuild.resources.dll" target="runtimes\any\native\es" />
+    <file src="fr\MSBuild.resources.dll" target="runtimes\any\native\fr" />
+    <file src="it\MSBuild.resources.dll" target="runtimes\any\native\it" />
+    <file src="ja\MSBuild.resources.dll" target="runtimes\any\native\ja" />
+    <file src="ko\MSBuild.resources.dll" target="runtimes\any\native\ko" />
+    <file src="pl\MSBuild.resources.dll" target="runtimes\any\native\pl" />
+    <file src="pt\MSBuild.resources.dll" target="runtimes\any\native\pt" />
+    <file src="ru\MSBuild.resources.dll" target="runtimes\any\native\ru" />
+    <file src="tr\MSBuild.resources.dll" target="runtimes\any\native\tr" />
+    <file src="zh-Hans\MSBuild.resources.dll" target="runtimes\any\native\zh-Hans" />
+    <file src="zh-Hant\MSBuild.resources.dll" target="runtimes\any\native\zh-Hant" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -23,5 +23,21 @@
   </metadata>
   <files>
     <file src="Microsoft.Build.Tasks.Core.dll" target="lib\net46" />
+
+    <!-- Satellite assemblies -->
+    <file src="cs\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\cs" />
+    <file src="de\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\de" />
+    <file src="en\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\en" />
+    <file src="es\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\es" />
+    <file src="fr\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\fr" />
+    <file src="it\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\it" />
+    <file src="ja\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\ja" />
+    <file src="ko\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\ko" />
+    <file src="pl\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\pl" />
+    <file src="pt\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\pt" />
+    <file src="ru\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\ru" />
+    <file src="tr\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\tr" />
+    <file src="zh-Hans\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\zh-Hans" />
+    <file src="zh-Hant\Microsoft.Build.Tasks.Core.resources.dll" target="lib\net46\zh-Hant" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.Utilities.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Utilities.Core.nuspec
@@ -23,5 +23,21 @@
   </metadata>
   <files>
     <file src="Microsoft.Build.Utilities.Core.dll" target="lib\net46" />
+
+    <!-- Satellite assemblies -->
+    <file src="cs\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\cs" />
+    <file src="de\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\de" />
+    <file src="en\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\en" />
+    <file src="es\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\es" />
+    <file src="fr\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\fr" />
+    <file src="it\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\it" />
+    <file src="ja\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\ja" />
+    <file src="ko\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\ko" />
+    <file src="pl\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\pl" />
+    <file src="pt\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\pt" />
+    <file src="ru\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\ru" />
+    <file src="tr\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\tr" />
+    <file src="zh-Hans\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\zh-Hans" />
+    <file src="zh-Hant\Microsoft.Build.Utilities.Core.resources.dll" target="lib\net46\zh-Hant" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -23,5 +23,21 @@
   </metadata>
   <files>
     <file src="Microsoft.Build.dll" target="lib\net46" />
+
+    <!-- Satellite assemblies -->
+    <file src="cs\Microsoft.Build.resources.dll" target="lib\net46\cs" />
+    <file src="de\Microsoft.Build.resources.dll" target="lib\net46\de" />
+    <file src="en\Microsoft.Build.resources.dll" target="lib\net46\en" />
+    <file src="es\Microsoft.Build.resources.dll" target="lib\net46\es" />
+    <file src="fr\Microsoft.Build.resources.dll" target="lib\net46\fr" />
+    <file src="it\Microsoft.Build.resources.dll" target="lib\net46\it" />
+    <file src="ja\Microsoft.Build.resources.dll" target="lib\net46\ja" />
+    <file src="ko\Microsoft.Build.resources.dll" target="lib\net46\ko" />
+    <file src="pl\Microsoft.Build.resources.dll" target="lib\net46\pl" />
+    <file src="pt\Microsoft.Build.resources.dll" target="lib\net46\pt" />
+    <file src="ru\Microsoft.Build.resources.dll" target="lib\net46\ru" />
+    <file src="tr\Microsoft.Build.resources.dll" target="lib\net46\tr" />
+    <file src="zh-Hans\Microsoft.Build.resources.dll" target="lib\net46\zh-Hans" />
+    <file src="zh-Hant\Microsoft.Build.resources.dll" target="lib\net46\zh-Hant" />
   </files>
 </package>


### PR DESCRIPTION
Update our NuGet packages to include the satellite assemblies for all
supported languages. This only covers assemblies that we are currently
included in NuGet packacges for which we also produce satellite
assemblies. Notably, we ship Microsoft.Build.Engine.dll and
Microsoft.Build.Conversion.Core.dll in NuGet packages but we do not yet
have localization setup for those.