### PR TITLE
Fix some build warnings

### DIFF
--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -17,7 +17,6 @@ using Microsoft.Win32;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using UtilitiesDotNetFrameworkArchitecture = Microsoft.Build.Utilities.DotNetFrameworkArchitecture;
 using SharedDotNetFrameworkArchitecture = Microsoft.Build.Shared.DotNetFrameworkArchitecture;
-using Microsoft.Win32;
 using System.Collections.ObjectModel;
 using Microsoft.Build.Tasks.AssemblyFoldersFromConfig;
 

--- a/src/XMakeBuildEngine/UnitTests/Construction/XmlReaderWithoutLocation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/XmlReaderWithoutLocation_Tests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 get { return _wrappedReader.BaseURI; }
             }
 
-            public void Close()
+            public new void Close()
             {
                 _wrappedReader.Dispose();
             }

--- a/src/XMakeCommandLine/UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
+++ b/src/XMakeCommandLine/UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
@@ -35,7 +35,6 @@
     <Compile Include="..\..\Shared\VersionUtilities.cs">
       <Link>VersionUtilities.cs</Link>
     </Compile>
-    <Compile Include="..\AssemblyResources.cs" />
     <Compile Include="..\..\Shared\UnitTests\MockEngine.cs" />
     <Compile Include="..\..\Shared\UnitTests\MockLogger.cs" />
     <Compile Include="..\..\Shared\UnitTests\ObjectModelHelpers.cs" />


### PR DESCRIPTION
- Duplicate namespace declaration in ToolLocationHelper
- Add new or override to XmlReaderNoIXmlLineInfo.Close()
- warning CS0436: The type 'AssemblyResources' in 'D:\MSBuild2\src\XMakeCommandLine\UnitTests\..\A
ssemblyResources.cs' conflicts with the imported type 'AssemblyResources' in 'MSBuild, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Usi
ng the type defined in 'D:\MSBuild2\src\XMakeCommandLine\UnitTests\..\AssemblyResources.cs'. [D:\MSBuild2\src\XMakeCommandLine\UnitTests\Microsoft.Build.Comman
dLine.UnitTests.csproj]