### PR TITLE
Traversal targets for cross-targeting

### DIFF
--- a/setup/files.swr
+++ b/setup/files.swr
@@ -17,7 +17,7 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngen=yes
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
-  file source=$(X86BinPath)Microsoft.Common.Traversal.targets
+  file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
   file source=$(X86BinPath)Microsoft.Common.targets
   file source=$(X86BinPath)Microsoft.Common.tasks
@@ -136,7 +136,7 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngen=yes
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
-  file source=$(X86BinPath)Microsoft.Common.Traversal.targets
+  file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
   file source=$(X86BinPath)Microsoft.Common.targets
   file source=$(X86BinPath)Microsoft.Common.tasks

--- a/setup/files.swr
+++ b/setup/files.swr
@@ -17,6 +17,7 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngen=yes
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.Common.Traversal.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
   file source=$(X86BinPath)Microsoft.Common.targets
   file source=$(X86BinPath)Microsoft.Common.tasks
@@ -135,6 +136,7 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngen=yes
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.Common.Traversal.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
   file source=$(X86BinPath)Microsoft.Common.targets
   file source=$(X86BinPath)Microsoft.Common.tasks

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -676,7 +676,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Microsoft.Common.Traversal.targets">
+    <Content Include="Microsoft.Common.CrossTargeting.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
@@ -828,7 +828,7 @@
     <DataFile Include="Microsoft.Common.CurrentVersion.targets">
       <SubType>Designer</SubType>
     </DataFile>
-    <DataFile Include="Microsoft.Common.Traversal.targets">
+    <DataFile Include="Microsoft.Common.CrossTargeting.targets">
       <SubType>Designer</SubType>
     </DataFile>
     <DataFile Include="Microsoft.NETFramework.targets" />

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -676,6 +676,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
+    <Content Include="Microsoft.Common.Traversal.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="Microsoft.Common.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -822,6 +826,9 @@
       <SubType>Designer</SubType>
     </DataFile>
     <DataFile Include="Microsoft.Common.CurrentVersion.targets">
+      <SubType>Designer</SubType>
+    </DataFile>
+    <DataFile Include="Microsoft.Common.Traversal.targets">
       <SubType>Designer</SubType>
     </DataFile>
     <DataFile Include="Microsoft.NETFramework.targets" />

--- a/src/XMakeTasks/Microsoft.CSharp.targets
+++ b/src/XMakeTasks/Microsoft.CSharp.targets
@@ -17,12 +17,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <!-- 
-        We are doing a cross-targeting traversal build if there is no list of target frameworks specified
+        We are doing a cross-targeting build if there is no list of target frameworks specified
         nor is there a current target framework being built individually. In that case, this import is
-        redirected to Microsoft.Common.Traversal.targets.
+        redirected to Microsoft.Common.CrossTargeting.targets.
    -->
    <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
-      <IsTraversalBuild>true</IsTraversalBuild>
+      <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
    </PropertyGroup>
 
    <!--
@@ -49,9 +49,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             <CscToolPath Condition="'$(CscToolPath)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">$(MsBuildFrameworkToolsPath)</CscToolPath>
          </PropertyGroup>
       </When>
-      <When Condition="'$(IsTraversalBuild)' == 'true'">
+      <When Condition="'$(IsCrossTargetingBuild)' == 'true'">
          <PropertyGroup>
-            <CSharpTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.Traversal.targets</CSharpTargetsPath>
+            <CSharpTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets</CSharpTargetsPath>
           </PropertyGroup>
       </When>
       <Otherwise>

--- a/src/XMakeTasks/Microsoft.CSharp.targets
+++ b/src/XMakeTasks/Microsoft.CSharp.targets
@@ -17,6 +17,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <!-- 
+        We are doing a cross-targeting traversal build if there is no list of target frameworks specified
+        nor is there a current target framework being built individually. In that case, this import is
+        redirected to Microsoft.Common.Traversal.targets.
+   -->
+   <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
+      <IsTraversalBuild>true</IsTraversalBuild>
+   </PropertyGroup>
+
+   <!--
         In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed 
         as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead 
         just used whatever ToolsVersion was in the project file if it existed on the machine, and 
@@ -39,6 +48,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                  MSBuildToolsPath, which would be incorrect in this case -->
             <CscToolPath Condition="'$(CscToolPath)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">$(MsBuildFrameworkToolsPath)</CscToolPath>
          </PropertyGroup>
+      </When>
+      <When Condition="'$(IsTraversalBuild)' == 'true'">
+         <PropertyGroup>
+            <CSharpTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.Traversal.targets</CSharpTargetsPath>
+          </PropertyGroup>
       </When>
       <Otherwise>
          <PropertyGroup>

--- a/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
@@ -1,6 +1,6 @@
 ﻿<!--
 ***********************************************************************************************
-Microsoft.Common.Traversal.targets
+Microsoft.Common.CrossTargeting.targets
 
 WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
           created a backup copy.  Incorrect changes to this file will make it
@@ -11,6 +11,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(CoreTraversalTargetsPath)" 
-          Condition="'$(CoreTraversalTargetsPath)' != '' and Exists('$(CoreTraversalTargetsPath)')" />
+  <Import Project="$(CoreCrossTargetingTargetsPath)" 
+          Condition="'$(CoreCrossTargetingTargetsPath)' != '' and Exists('$(CoreCrossTargetingTargetsPath)')" />
 </Project>

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1508,8 +1508,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Targets="GetTargetFrameworkProperties"
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(TargetFrameworkMoniker)"
-        Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '$(BuildingProject)' == 'true'"
-        ContinueOnError="$(ContinueOnError)"
+        ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 
       <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkConfiguration" />

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1511,17 +1511,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 
-      <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkConfiguration" />
+      <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>
 
     <ItemGroup>
       <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.Identity)' == '%(Identity)'">
-        <SetTargetFramework>$(_ProjectReferenceTargetFrameworkConfiguration)</SetTargetFramework>
+        <SetTargetFramework>$(_ProjectReferenceTargetFrameworkProperties)</SetTargetFramework>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
 
     <PropertyGroup>
-      <_ProjectReferenceTargetFrameworkConfiguration />
+      <_ProjectReferenceTargetFrameworkProperties />
     </PropertyGroup>
   </Target>
 

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -886,12 +886,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Target Name="BuildGenerateSources" DependsOnTargets="BuildGenerateSourcesTraverse;$(BuildGenerateSourcesAction)" />
 
-  <Target Name="BuildGenerateSourcesTraverse" DependsOnTargets="AssignProjectConfiguration;_SplitProjectReferencesByFileExistence">
+  <Target Name="BuildGenerateSourcesTraverse" DependsOnTargets="PrepareProjectReferences">
     <MSBuild
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="BuildGenerateSources"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework);"
         Condition="'$(BuildPassReferences)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != '' and '%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true'"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -911,12 +911,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Target Name="BuildCompile" DependsOnTargets="BuildCompileTraverse;$(BuildCompileAction)" />
 
-  <Target Name="BuildCompileTraverse" DependsOnTargets="AssignProjectConfiguration;_SplitProjectReferencesByFileExistence">
+  <Target Name="BuildCompileTraverse" DependsOnTargets="PrepareProjectReferences">
     <MSBuild
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="BuildCompile"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         Condition="'$(BuildPassReferences)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''  and '%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true'"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -936,12 +936,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Target Name="BuildLink" DependsOnTargets="BuildLinkTraverse;$(BuildLinkAction)" />
 
-  <Target Name="BuildLinkTraverse" DependsOnTargets="AssignProjectConfiguration;_SplitProjectReferencesByFileExistence" >
+  <Target Name="BuildLinkTraverse" DependsOnTargets="PrepareProjectReferences" >
     <MSBuild
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="BuildLink"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         Condition="'$(BuildPassReferences)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''  and '%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true'"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -1490,6 +1490,82 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <!--
+    ====================================================================================
+                                        _GetProjectReferenceTargetFrameworkProperties
+
+    Builds the GetTargetFrameworkProperties target of all existent project references,
+    passing $(TargetFrameworkMoniker) as $(ReferringTargetFramework) and sets the
+    SetTargetFramework metadata of the project reference to the value that is returned.
+
+    This allows a cross-targeting project to select how it should be configured to
+    build against the most appropriate target for the referring target framework.
+
+    ======================================================================================
+  -->
+  <Target Name="_GetProjectReferenceTargetFrameworkProperties" Outputs="%(_MSBuildProjectReferenceExistent.Identity)">
+    <MSBuild
+        Projects="%(_MSBuildProjectReferenceExistent.Identity)"
+        Targets="GetTargetFrameworkProperties"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(TargetFrameworkMoniker)"
+        Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '$(BuildingProject)' == 'true'"
+        ContinueOnError="$(ContinueOnError)"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+
+      <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkConfiguration" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.Identity)' == '%(Identity)'">
+        <SetTargetFramework>$(_ProjectReferenceTargetFrameworkConfiguration)</SetTargetFramework>
+      </_MSBuildProjectReferenceExistent>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_ProjectReferenceTargetFrameworkConfiguration />
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    ============================================================
+                                    GetTargetFrameworkProperties
+
+    Overrridden by cross-targeting projects to return the set of
+    properties (in the form "key1=value1;...keyN=valueN") needed
+    to build it with the best target for the referring project's
+    target framework.
+
+    The referring project's $(TargetFrameworkMoniker) is passed 
+    in as $(ReferringTargetFramework)
+  -->
+  <Target Name="GetTargetFrameworkProperties" />
+
+  <!--
+    ============================================================
+                                        PrepareProjectReferences
+
+    Prepares project references for consumption by other targets.
+
+        [IN]
+        @(ProjectReference) - The list of project references.
+
+        [OUT]
+        @(ProjectReferenceWithConfiguration)   - Project references with apporpriate metadata
+        @(_MSBuildProjectReferenceExistent)    - Subset of @(ProjectReferenceWithConfiguration) that exist 
+                                                 with added SetTargetFramework metadata for cross-targeting
+        @(_MSBuildProjectReferenceNonExistent) - Subset of  @(ProjectReferenceWithConfiguration) that do not exist
+    ============================================================
+  -->
+  <PropertyGroup>
+    <PrepareProjectReferencesDependsOn>
+      AssignProjectConfiguration;
+      _SplitProjectReferencesByFileExistence;
+      _GetProjectReferenceTargetFrameworkProperties
+    </PrepareProjectReferencesDependsOn>
+  </PropertyGroup>
+  <Target Name="PrepareProjectReferences" DependsOnTargets="$(PrepareProjectReferencesDependsOn)" />
+
+  <!--
     ============================================================
                                         ResolveProjectReferences
 
@@ -1516,7 +1592,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Target
       Name="ResolveProjectReferences"
-      DependsOnTargets="AssignProjectConfiguration;_SplitProjectReferencesByFileExistence"
+      DependsOnTargets="PrepareProjectReferences"
       Returns="@(_ResolvedNativeProjectReferencePaths);@(_ResolvedProjectReferencePaths)">
 
     <!--
@@ -1531,7 +1607,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="GetTargetPath"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildProjectReferences)' != 'true') and '$(VisualStudioVersion)' != '10.0' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -1558,7 +1634,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="%(_MSBuildProjectReferenceExistent.Targets);GetTargetPath"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildProjectReferences)' != 'true') and '$(VisualStudioVersion)' == '10.0' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -1575,7 +1651,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="%(_MSBuildProjectReferenceExistent.Targets)"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform);  %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '$(BuildingInsideVisualStudio)' != 'true' and '$(BuildProjectReferences)' == 'true' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="$(ContinueOnError)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -1592,7 +1668,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="GetNativeManifest"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '$(BuildingProject)' == 'true' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="$(ContinueOnError)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -2117,10 +2193,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
      </ItemGroup>
    </Target>
 
-  <Target Name="GetReferenceTargetPlatformMonikers" DependsOnTargets="AssignProjectConfiguration;_SplitProjectReferencesByFileExistence">
+  <Target Name="GetReferenceTargetPlatformMonikers" DependsOnTargets="PrepareProjectReferences">
     <MSBuild
       Projects="@(_MSBuildProjectReferenceExistent)"
-      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
       Targets="GetTargetPathWithTargetPlatformMoniker"
       BuildInParallel="$(BuildInParallel)"
       ContinueOnError="!$(BuildingProject)"
@@ -4012,7 +4088,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <GetCopyToOutputDirectoryItemsDependsOn>
       AssignTargetPaths;
-      _SplitProjectReferencesByFileExistence
+      _SplitProjectReferencesByFileExistence;
+      _GetProjectReferenceTargetFrameworkProperties
     </GetCopyToOutputDirectoryItemsDependsOn>
   </PropertyGroup>
   <Target
@@ -4036,7 +4113,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="GetCopyToOutputDirectoryItems"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         Condition="'@(_MSBuildProjectReferenceExistent)' != '' and '$(_GetChildProjectCopyToOutputDirectoryItems)' == 'true' and '%(_MSBuildProjectReferenceExistent.Private)' != 'false' and '$(UseCommonOutputDirectory)' != 'true'"
         ContinueOnError="$(ContinueOnError)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -4554,7 +4631,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target
       Name="CleanReferencedProjects"
-      DependsOnTargets="AssignProjectConfiguration; _SplitProjectReferencesByFileExistence">
+      DependsOnTargets="PrepareProjectReferences">
 
     <!--
         When building the project directly from the command-line, clean those referenced projects
@@ -4564,7 +4641,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <MSBuild
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="Clean"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         BuildInParallel="$(BuildInParallel)"
         Condition="'$(BuildingInsideVisualStudio)' != 'true' and '$(BuildProjectReferences)' == 'true' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="$(ContinueOnError)"

--- a/src/XMakeTasks/Microsoft.Common.Traversal.targets
+++ b/src/XMakeTasks/Microsoft.Common.Traversal.targets
@@ -1,0 +1,16 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Common.Traversal.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(CoreTraversalTargetsPath)" 
+          Condition="'$(CoreTraversalTargetsPath)' != '' and Exists('$(CoreTraversalTargetsPath)')" />
+</Project>

--- a/src/XMakeTasks/Microsoft.VisualBasic.targets
+++ b/src/XMakeTasks/Microsoft.VisualBasic.targets
@@ -18,12 +18,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- 
-       We are doing a cross-targeting traversal build if there is no list of target frameworks specified
+       We are doing a cross-targeting build if there is no list of target frameworks specified
        nor is there a current target framework being built individually. In that case, this import is
-       redirected to Microsoft.Common.Traversal.targets.
+       redirected to Microsoft.Common.CrossTargeting.targets.
    -->
    <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
-      <IsTraversalBuild>true</IsTraversalBuild>
+      <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
    </PropertyGroup>
 
    <!--
@@ -50,9 +50,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <VbcToolPath Condition="'$(VbcToolPath)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">$(MsBuildFrameworkToolsPath)</VbcToolPath>
       </PropertyGroup>
     </When>
-    <When Condition="'$(IsTraversalBuild)' == 'true'">
+    <When Condition="'$(IsCrossTargetingBuild)' == 'true'">
       <PropertyGroup>
-        <VisualBasicTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.Traversal.targets</VisualBasicTargetsPath>
+        <VisualBasicTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets</VisualBasicTargetsPath>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/XMakeTasks/Microsoft.VisualBasic.targets
+++ b/src/XMakeTasks/Microsoft.VisualBasic.targets
@@ -18,6 +18,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- 
+       We are doing a cross-targeting traversal build if there is no list of target frameworks specified
+       nor is there a current target framework being built individually. In that case, this import is
+       redirected to Microsoft.Common.Traversal.targets.
+   -->
+   <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
+      <IsTraversalBuild>true</IsTraversalBuild>
+   </PropertyGroup>
+
+   <!--
         In VS 2010 SP1 and VS 2012, both supported for asset compatibility, the MSBuild installed 
         as part of them did not enforce using the local ToolsVersion (4.0) in all cases, but instead 
         just used whatever ToolsVersion was in the project file if it existed on the machine, and 
@@ -39,6 +48,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- Same condition as in .NET 4.5 VB targets so that we can override the behavior where it defaults to 
              MSBuildToolsPath, which would be incorrect in this case -->
         <VbcToolPath Condition="'$(VbcToolPath)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">$(MsBuildFrameworkToolsPath)</VbcToolPath>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(IsTraversalBuild)' == 'true'">
+      <PropertyGroup>
+        <VisualBasicTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.Traversal.targets</VisualBasicTargetsPath>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
This implements the portion of cross-targeting that we agreed must happen first in msbuild proper and as soon as possible to uncover any unforseen breaking impact on existing projects.

1. Redirect Microsoft.VisualBasic/CSharp.targets to new Microsoft.Common.Traversal.targets if $(TargetFrameworks) is set, but $(TargetFramework) is empty.
2. Implement the protocol where every project will pass its TFM down to project references and get the properties that configure the destination to the best compatible target.
3. For now, the common traversal targets just import based on a variable that we will set in a props hook, but ultimately some general logic should probably be live there, and there should be a way for arbitrary nuget packages to participate. This needs design we have not yet done so going with a minimal, unblocking start.