### PR TITLE
Set AutoUnifyAssemblyReferences only if it hasn't already been set

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -318,9 +318,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <GenerateBindingRedirectsOutputType Condition="'$(OutputType)'=='exe' or '$(OutputType)'=='winexe'">true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(AutoUnifyAssemblyReferences)' == ''">
     <AutoUnifyAssemblyReferences>true</AutoUnifyAssemblyReferences>
     <AutoUnifyAssemblyReferences Condition="'$(GenerateBindingRedirectsOutputType)' == 'true' and '$(AutoGenerateBindingRedirects)' != 'true'">false</AutoUnifyAssemblyReferences>
+  </PropertyGroup>
+  <PropertyGroup>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">obj\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
     <CleanFile Condition="'$(CleanFile)'==''">$(MSBuildProjectFile).FileListAbsolute.txt</CleanFile>


### PR DESCRIPTION
For .NET Core projects, we want to pass AutoUnify=true to the RAR task. That gets set through the AutoUnifyAssemblyReferences property which derives it value from the AutoGenerateBindingRedirects property. It’s odd to have AutoGenerateBindingRedirects=true in the NETCore.props given binding redirects don’t mean anything in .NETCore. This change makes it so that we can set AutoUnifyAssemblyReferences in the props file.

/cc @rainersigwald @cdmihai @AndyGerlicher 