### PR TITLE
Fix to copy generated satellite assemblies (in .NetCore) from intermediate to output folder

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -3327,7 +3327,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <ItemGroup>
       <IntermediateSatelliteAssembliesWithTargetPath Include="$(IntermediateOutputPath)%(EmbeddedResource.Culture)\$(TargetName).resources.dll"
-                                                     Condition="'%(EmbeddedResource.Culture)' != '' and '$(MSBuildRuntimeType)' != 'Core'">
+                                                     Condition="'%(EmbeddedResource.Culture)' != ''">
         <Culture>%(EmbeddedResource.Culture)</Culture>
         <TargetPath>%(EmbeddedResource.Culture)\$(TargetName).resources.dll</TargetPath>
       </IntermediateSatelliteAssembliesWithTargetPath>


### PR DESCRIPTION
Remove the runtime check to copy the satellite assemblies in .net core. I am currently working on a [fix](https://github.com/dotnet/sdk/pull/122) to generate satellite assemblies on .Net Core. This fix is required to make sure that the generated assemblies are copied from `obj` to `bin` folder.


cc @cdmihai @eerhardt