### PR TITLE
Disable warning when legacy installed SDKs not found.

### DIFF
--- a/src/XMakeTasks/GetInstalledSDKLocations.cs
+++ b/src/XMakeTasks/GetInstalledSDKLocations.cs
@@ -129,6 +129,11 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
+        /// When set to true, the task will produce a warning if there were no SDKs found.
+        /// </summary>
+        public bool WarnWhenNoSDKsFound { get; set; } = true;
+
+        /// <summary>
         /// Set of items that represent all of the installed SDKs found in the SDKDirectory and SDKRegistry roots.
         /// The itemspec is the SDK install location. There is a piece of metadata called SDKName which contains the name of the SDK.
         /// </summary>
@@ -201,7 +206,10 @@ namespace Microsoft.Build.Tasks
             }
             else
             {
-                Log.LogWarningWithCodeFromResources("GetInstalledSDKs.NoSDksFound");
+                if (WarnWhenNoSDKsFound)
+                {
+                    Log.LogWarningWithCodeFromResources("GetInstalledSDKs.NoSDksFound", TargetPlatformIdentifier, TargetPlatformVersion);
+                }
             }
 
             InstalledSDKs = outputItems.ToArray();

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -2065,6 +2065,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
            TargetPlatformVersion="$(TargetPlatformVersionWindows81)"
            TargetPlatformIdentifier="$(TargetPlatformIdentifierWindows81)"
            Condition="'@(SDKReference)' != '' and '$(SupportWindows81SDKs)' == 'true' and '$(TargetPlatformIdentifierWindows81)' != '' and '$(TargetPlatformVersionWindows81)' != ''"
+           WarnWhenNoSDKsFound="false"
            >
       <Output TaskParameter="InstalledSDKs" ItemName="InstalledSDKLocations"/>
     </GetInstalledSDKLocations>
@@ -2076,6 +2077,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
            TargetPlatformVersion="$(TargetPlatformVersionWindowsPhone81)"
            TargetPlatformIdentifier="$(TargetPlatformIdentifierWindowsPhone81)"
            Condition="'@(SDKReference)' != '' and '$(SupportWindowsPhone81SDKs)' == 'true' and '$(TargetPlatformIdentifierWindowsPhone81)' != '' and '$(TargetPlatformVersionWindowsPhone81)' != ''"
+           WarnWhenNoSDKsFound="false"
            >
       <Output TaskParameter="InstalledSDKs" ItemName="InstalledSDKLocations"/>
     </GetInstalledSDKLocations>

--- a/src/XMakeTasks/Resources/Strings.resx
+++ b/src/XMakeTasks/Resources/Strings.resx
@@ -2494,8 +2494,8 @@
     <comment>{StrBegin="MSB3784: "} TargetPlatformVersion and TargetPlatformIdentifier root are property names and should not be localized</comment>
    </data>
   <data name="GetInstalledSDKs.NoSDksFound" xml:space="preserve">
-    <value>MSB3785: No SDKs were found. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</value>
-    <comment>{StrBegin="MSB3785: "} "SDKReference" referrs to SDKReference items in the project file and should not be localized.</comment>
+    <value>MSB3785: No SDKs were found for TargetPlatform = {0} v{1}. SDKReference items will not be resolved. If your application requires these references there may be compilation errors.</value>
+    <comment>{StrBegin="MSB3785: "} "SDKReference" refers to SDKReference items in the project file and should not be localized.</comment>
    </data>
   <data name="GetInstalledSDKs.CouldNotGetSDKList" xml:space="preserve">
     <value>MSB3786: There was a problem retrieving the installed SDKs on the machine. {0}</value>


### PR DESCRIPTION
 - Added optional parameter 'WarnOnNoSDKsFound' to GetInstalledSDKLocations
   task. Default to previous behavior (true).
 - Disabled warnings from the Microsoft Common props when Windows / Windows
   Phone 8.1 SDKs are not found. For Dev15 this is a typical case for many
   users and today a clean build produces two warnings.
 - Added the platform identifier and version to the warning message.
   Output will look like:
     "No SDKs were found for TargetPlatform = WindowsPhoneApp v8.1"