### PR TITLE
Make FileMatcher more friendly with forward and backward slashes

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Build.Shared
 
         private static readonly char[] s_wildcardCharacters = { '*', '?' };
         private static readonly char[] s_wildcardAndSemicolonCharacters = { '*', '?', ';' };
-        internal static readonly char[] directorySeparatorCharacters = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        // on OSX both System.IO.Path separators are '/'
+        internal static readonly char[] directorySeparatorCharacters = { '/', '\\' };
         internal static readonly GetFileSystemEntries s_defaultGetFileSystemEntries = new GetFileSystemEntries(GetAccessibleFileSystemEntries);
         private static readonly DirectoryExists s_defaultDirectoryExists = new DirectoryExists(Directory.Exists);
 
@@ -1452,7 +1454,7 @@ namespace Microsoft.Build.Shared
             // The double trim fixes https://github.com/Microsoft/msbuild/issues/917
             // System.IO does not leave trailing slashes in directory enumerations.
             // Since this string will be matched against System.IO directory enumerations, both need to agree on trailing slashes
-            result.BaseDirectory = fixedDirectoryPart.TrimEnd(Path.AltDirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar);
+            result.BaseDirectory = fixedDirectoryPart.TrimEnd('/', '\\');
             result.RemainingWildcardDirectory = wildcardDirectoryPart;
 
             return SearchAction.RunSearch;

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -26,15 +26,16 @@ namespace Microsoft.Build.Shared
         private const string dotdot = "..";
 
         private static readonly string s_directorySeparator = new string(Path.DirectorySeparatorChar, 1);
-        private static readonly string s_altDirectorySeparator = new string(Path.AltDirectorySeparatorChar, 1);
 
         private static readonly string s_thisDirectory = "." + s_directorySeparator;
 
         private static readonly char[] s_wildcardCharacters = { '*', '?' };
         private static readonly char[] s_wildcardAndSemicolonCharacters = { '*', '?', ';' };
 
-        // on OSX both System.IO.Path separators are '/'
+        // on OSX both System.IO.Path separators are '/', so we have to use the literals
         internal static readonly char[] directorySeparatorCharacters = { '/', '\\' };
+        internal static readonly string[] directorySeparatorStrings = directorySeparatorCharacters.Select(c => c.ToString()).ToArray();
+
         internal static readonly GetFileSystemEntries s_defaultGetFileSystemEntries = new GetFileSystemEntries(GetAccessibleFileSystemEntries);
         private static readonly DirectoryExists s_defaultDirectoryExists = new DirectoryExists(Directory.Exists);
 
@@ -983,8 +984,10 @@ namespace Microsoft.Build.Shared
             /*
              *  Call out our special matching characters.
              */
-            matchFileExpression.Replace(s_directorySeparator, "<:dirseparator:>");
-            matchFileExpression.Replace(s_altDirectorySeparator, "<:dirseparator:>");
+            foreach (var separator in directorySeparatorStrings)
+            {
+                matchFileExpression.Replace(separator, "<:dirseparator:>");
+            }
 
             /*
              * Capture the leading \\ in UNC paths, so that the doubled slash isn't

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -24,8 +24,11 @@ namespace Microsoft.Build.Shared
     {
         private const string recursiveDirectoryMatch = "**";
         private const string dotdot = "..";
+
         private static readonly string s_directorySeparator = new string(Path.DirectorySeparatorChar, 1);
         private static readonly string s_altDirectorySeparator = new string(Path.AltDirectorySeparatorChar, 1);
+
+        private static readonly string s_thisDirectory = "." + s_directorySeparator;
 
         private static readonly char[] s_wildcardCharacters = { '*', '?' };
         private static readonly char[] s_wildcardAndSemicolonCharacters = { '*', '?', ';' };
@@ -170,7 +173,7 @@ namespace Microsoft.Build.Shared
             try
             {
                 // look in current directory if no path specified
-                string dir = ((path.Length == 0) ? ".\\" : path);
+                string dir = ((path.Length == 0) ? s_thisDirectory : path);
 
                 // get all files in specified directory, unless a file-spec has been provided
                 string[] files = (filespec == null)
@@ -188,7 +191,7 @@ namespace Microsoft.Build.Shared
                 // IDE, which expects just the filename if it is in the current
                 // directory.  But only do this if the original path requested
                 // didn't itself contain a ".\".
-                else if (!path.StartsWith(".\\", StringComparison.Ordinal))
+                else if (!path.StartsWith(s_thisDirectory, StringComparison.Ordinal))
                 {
                     RemoveInitialDotSlash(files);
                 }
@@ -228,11 +231,11 @@ namespace Microsoft.Build.Shared
 
                 if (pattern == null)
                 {
-                    directories = Directory.GetDirectories((path.Length == 0) ? ".\\" : path);
+                    directories = Directory.GetDirectories((path.Length == 0) ? s_thisDirectory : path);
                 }
                 else
                 {
-                    directories = Directory.GetDirectories((path.Length == 0) ? ".\\" : path, pattern);
+                    directories = Directory.GetDirectories((path.Length == 0) ? s_thisDirectory : path, pattern);
                 }
 
                 // Subdirectories in the current directory are coming back with a ".\"
@@ -240,7 +243,7 @@ namespace Microsoft.Build.Shared
                 // IDE, which expects just the filename if it is in the current
                 // directory.  But only do this if the original path requested
                 // didn't itself contain a ".\".
-                if (!path.StartsWith(".\\", StringComparison.Ordinal))
+                if (!path.StartsWith(s_thisDirectory, StringComparison.Ordinal))
                 {
                     RemoveInitialDotSlash(directories);
                 }
@@ -528,7 +531,7 @@ namespace Microsoft.Build.Shared
         {
             for (int i = 0; i < paths.Length; i++)
             {
-                if (paths[i].StartsWith(".\\", StringComparison.Ordinal))
+                if (paths[i].StartsWith(s_thisDirectory, StringComparison.Ordinal))
                 {
                     paths[i] = paths[i].Substring(2);
                 }
@@ -1127,8 +1130,6 @@ namespace Microsoft.Build.Shared
 
             return matchFileExpression.ToString();
         }
-
-
 
         /// <summary>
         /// Given a filespec, get the information needed for file matching. 

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -691,9 +691,9 @@ namespace Microsoft.Build.UnitTests
         public void ExcludePattern()
         {
 
-            MatchDriverWithForwardAndBackwardSlashes(
+            MatchDriverWithDifferentSlashes(
                 @"**\*.cs",     //  Include Pattern
-                new string[]    //  Exclude patterns
+                new[]    //  Exclude patterns
                 {
                     @"bin\**"
                 },
@@ -703,7 +703,7 @@ namespace Microsoft.Build.UnitTests
                 new string[]    //  Non matching files
                 {
                 },
-                new string[]    //  Non matching files that shouldn't be touched
+                new[]    //  Non matching files that shouldn't be touched
                 {
                     @"bin\foo.cs",
                     @"bin\bar\foo.cs",
@@ -711,22 +711,22 @@ namespace Microsoft.Build.UnitTests
                 }
             );
 
-            MatchDriverWithForwardAndBackwardSlashes(
+            MatchDriverWithDifferentSlashes(
                 @"**\*.cs",     //  Include Pattern
-                new string[]    //  Exclude patterns
+                new[]    //  Exclude patterns
                 {
                     @"bin\**"
                 },
-                new string[]    //  Matching files
+                new[]    //  Matching files
                 {
                     "a.cs",
                     @"b\b.cs",
                 },
-                new string[]    //  Non matching files
+                new[]    //  Non matching files
                 {
                     @"b\b.txt"
                 },
-                new string[]    //  Non matching files that shouldn't be touched
+                new[]    //  Non matching files that shouldn't be touched
                 {
                     @"bin\foo.cs",
                     @"bin\bar\foo.cs",
@@ -734,24 +734,24 @@ namespace Microsoft.Build.UnitTests
                 }
             );
 
-            MatchDriverWithForwardAndBackwardSlashes(
+            MatchDriverWithDifferentSlashes(
                 @"**\*.cs",     //  Include Pattern
-                new string[]    //  Exclude patterns
+                new[]    //  Exclude patterns
                 {
                     @"bin\**"
                 },
-                new string[]    //  Matching files
+                new[]    //  Matching files
                 {
                     @"foo.cs",
                     @"Properties\AssemblyInfo.cs",
                     @"Foo\Bar\Baz\Buzz.cs"
                 },
-                new string[]    //  Non matching files
+                new[]    //  Non matching files
                 {
                     @"foo.txt",
                     @"Foo\foo.txt",
                 },
-                new string[]    //  Non matching files that shouldn't be touched
+                new[]    //  Non matching files that shouldn't be touched
                 {
                     @"bin\foo.cs",
                     @"bin\bar\foo.cs",
@@ -763,20 +763,20 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ExcludeSpecificFiles()
         {
-            MatchDriverWithForwardAndBackwardSlashes(
+            MatchDriverWithDifferentSlashes(
                 @"**\*.cs",     //  Include Pattern
-                new string[]    //  Exclude patterns
+                new[]    //  Exclude patterns
                 {
                     @"Program_old.cs",
                     @"Properties\AssemblyInfo_old.cs"
                 },
-                new string[]    //  Matching files
+                new[]    //  Matching files
                 {
                     @"foo.cs",
                     @"Properties\AssemblyInfo.cs",
                     @"Foo\Bar\Baz\Buzz.cs"
                 },
-                new string[]    //  Non matching files
+                new[]    //  Non matching files
                 {
                     @"Program_old.cs",
                     @"Properties\AssemblyInfo_old.cs"
@@ -790,29 +790,29 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ExcludePatternAndSpecificFiles()
         {
-            MatchDriverWithForwardAndBackwardSlashes(
+            MatchDriverWithDifferentSlashes(
                 @"**\*.cs",     //  Include Pattern
-                new string[]    //  Exclude patterns
+                new[]    //  Exclude patterns
                 {
                     @"bin\**",
                     @"Program_old.cs",
                     @"Properties\AssemblyInfo_old.cs"
 
                 },
-                new string[]    //  Matching files
+                new[]    //  Matching files
                 {
                     @"foo.cs",
                     @"Properties\AssemblyInfo.cs",
                     @"Foo\Bar\Baz\Buzz.cs"
                 },
-                new string[]    //  Non matching files
+                new[]    //  Non matching files
                 {
                     @"foo.txt",
                     @"Foo\foo.txt",
                     @"Program_old.cs",
                     @"Properties\AssemblyInfo_old.cs"
                 },
-                new string[]    //  Non matching files that shouldn't be touched
+                new[]    //  Non matching files that shouldn't be touched
                 {
                     @"bin\foo.cs",
                     @"bin\bar\foo.cs",
@@ -821,68 +821,72 @@ namespace Microsoft.Build.UnitTests
             );
         }
 
-        [Fact]
-        public void ExcludeComplexPattern()
+        [Theory]
+        [InlineData(
+            @"**\*.cs", // Include Pattern
+            new[] // Exclude patterns
+            {
+                @"**\bin\**\*.cs",
+                @"src\Common\**",
+            },
+            new[] // Matching files
+            {
+                @"foo.cs",
+                @"src\Framework\Properties\AssemblyInfo.cs",
+                @"src\Framework\Foo\Bar\Baz\Buzz.cs"
+            },
+            new[] // Non matching files
+            {
+                @"foo.txt",
+                @"src\Framework\Readme.md",
+                @"src\Common\foo.cs",
+
+                // Ideally these would be untouchable
+                @"src\Framework\bin\foo.cs",
+                @"src\Framework\bin\Debug",
+                @"src\Framework\bin\Debug\foo.cs",
+            },
+            new[] // Non matching files that shouldn't be touched
+            {
+                @"src\Common\Properties\",
+                @"src\Common\Properties\AssemblyInfo.cs",
+            }
+            )]
+        [InlineData(
+            @"src\**\proj\**\*.cs", // Include Pattern
+            new[] // Exclude patterns
+            {
+                @"src\**\proj\**\none\**\*",
+            },
+            new[] // Matching files
+            {
+                @"src\proj\m1.cs",
+                @"src\proj\a\m2.cs",
+                @"src\b\proj\m3.cs",
+                @"src\c\proj\d\m4.cs",
+            },
+            new[] // Non matching files
+            {
+                @"nm1.cs",
+                @"a\nm2.cs",
+                @"src\nm3.cs",
+                @"src\a\nm4.cs",
+
+                // Ideally these would be untouchable
+                @"src\proj\none\nm5.cs",
+                @"src\proj\a\none\nm6.cs",
+                @"src\b\proj\none\nm7.cs",
+                @"src\c\proj\d\none\nm8.cs",
+                @"src\e\proj\f\none\g\nm8.cs",
+            },
+            new string[] // Non matching files that shouldn't be touched
+            {
+            }
+            )]
+        // patterns with excludes that ideally would prune entire recursive subtrees (files in pruned tree aren't touched at all) but the exclude pattern is too complex for that to work with the current logic
+        public void ExcludeComplexPattern(string include, string[] exclude, string[] matching, string[] nonMatching, string[] untouchable)
         {
-            MatchDriverWithForwardAndBackwardSlashes(
-                @"**\*.cs",     //  Include Pattern
-                new string[]    //  Exclude patterns
-                {
-                    @"**\bin\**\*.cs",
-                    @"src\Common\**",
-                },
-                new string[]    //  Matching files
-                {
-                    @"foo.cs",
-                    @"src\Framework\Properties\AssemblyInfo.cs",
-                    @"src\Framework\Foo\Bar\Baz\Buzz.cs"
-                },
-                new string[]    //  Non matching files
-                {
-                    @"foo.txt",
-                    @"src\Framework\Readme.md",
-                    @"src\Common\foo.cs",
-
-                    //  Ideally these would be in the files that aren't touched at all, but the exclude pattern is too complex for that to work with the current logic
-                    @"src\Framework\bin\foo.cs",
-                    @"src\Framework\bin\Debug",
-                    @"src\Framework\bin\Debug\foo.cs",
-                },
-                new string[]    //  Non matching files that shouldn't be touched
-                {
-                }
-            );
-
-            MatchDriverWithForwardAndBackwardSlashes(
-                @"**\*.cs",     //  Include Pattern
-                new string[]    //  Exclude patterns
-                {
-                    @"**\bin\**\*.cs",
-                    @"src\Common\**",
-                },
-                new string[]    //  Matching files
-                {
-                    @"foo.cs",
-                    @"src\Framework\Properties\AssemblyInfo.cs",
-                    @"src\Framework\Foo\Bar\Baz\Buzz.cs"
-                },
-                new string[]    //  Non matching files
-                {
-                    @"foo.txt",
-                    @"src\Framework\Readme.md",
-                    @"src\Common\foo.cs",
-
-                    //  Ideally these would be in the files that aren't touched at all, but the exclude pattern is too complex for that to work with the current logic
-                    @"src\Framework\bin\foo.cs",
-                    @"src\Framework\bin\Debug",
-                    @"src\Framework\bin\Debug\foo.cs",
-                },
-                new string[]    //  Non matching files that shouldn't be touched
-                {
-                    @"src\Common\Properties\",
-                    @"src\Common\Properties\AssemblyInfo.cs",
-                }
-            );
+            MatchDriverWithDifferentSlashes(include, exclude, matching, nonMatching, untouchable);
         }
 
 
@@ -993,7 +997,7 @@ namespace Microsoft.Build.UnitTests
                         }
 
                         // Does the candidate directory match the requested path?
-                        if (String.Compare(path, candidateDirectoryName, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (FileUtilities.PathsEqual(path, candidateDirectoryName))
                         {
                             // Match the basic *.* or null. These both match any file.
                             if
@@ -1156,7 +1160,7 @@ namespace Microsoft.Build.UnitTests
                 string normalized = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
                 // Replace leading UNC.
-                if (normalized.Substring(0, 2) == @"\\")
+                if (normalized.StartsWith(@"\\"))
                 {
                     normalized = "<:UNC:>" + normalized.Substring(2);
                 }
@@ -1298,7 +1302,7 @@ namespace Microsoft.Build.UnitTests
         /// 
         /// To preserve current MSBuild behaviour, it only does so if the path is not rooted. Rooted paths do not support forward slashes (as observed on MSBuild 14.0.25420.1)
         /// </summary>
-        private static void MatchDriverWithForwardAndBackwardSlashes
+        private static void MatchDriverWithDifferentSlashes
             (
             string filespec,
             string[] excludeFilespecs,

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1440,5 +1440,14 @@ namespace Microsoft.Build.UnitTests
                 Directory.Delete(root);
             }
         }
+
+        /// <summary>
+        /// Used for file matching tests
+        /// MSBuild does not accept forward slashes on rooted paths, so those are returned unchanged
+        /// </summary>
+        internal static string ToForwardSlash(string path) =>
+            Path.IsPathRooted(path)
+                ? path
+                : path.Replace("\\", "/");
     }
 }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1448,6 +1448,6 @@ namespace Microsoft.Build.UnitTests
         internal static string ToForwardSlash(string path) =>
             Path.IsPathRooted(path)
                 ? path
-                : path.Replace("\\", "/");
+                : path.ToSlash();
     }
 }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Build.UnitTests
             Assert.True(false, "Didn't throw " + exception.ToString());
         }
 
-        public static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string>[] expectedDirectMetadataPerItem)
+        public static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string>[] expectedDirectMetadataPerItem, bool normalizeSlashes = false)
         {
             Assert.Equal(expectedItems.Length, items.Count);
 
@@ -141,15 +141,28 @@ namespace Microsoft.Build.UnitTests
 
             for (int i = 0; i < expectedItems.Length; i++)
             {
-                Assert.Equal(expectedItems[i], items[i].EvaluatedInclude);
+                if(!normalizeSlashes)
+                {
+                    Assert.Equal(expectedItems[i], items[i].EvaluatedInclude);
+                }
+                else
+                {
+                    Assert.Equal(NormalizeSlashes(expectedItems[i]), NormalizeSlashes(items[i].EvaluatedInclude));
+                }
+                
                 AssertItemHasMetadata(expectedDirectMetadataPerItem[i], items[i]);
             }
+        }
+
+        internal static string NormalizeSlashes(string path)
+        {
+            return path.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
         }
 
         /// <summary>
         /// Asserts that the list of items has the specified evaluated includes.
         /// </summary>
-        internal static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string> expectedDirectMetadata = null)
+        internal static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string> expectedDirectMetadata = null, bool normalizeSlashes = false)
         {
             if (expectedDirectMetadata == null)
             {
@@ -164,7 +177,7 @@ namespace Microsoft.Build.UnitTests
                 metadata[i] = expectedDirectMetadata;
             }
 
-            AssertItems(expectedItems, items, metadata);
+            AssertItems(expectedItems, items, metadata, normalizeSlashes);
         }
 
         /// <summary>
@@ -1236,15 +1249,42 @@ namespace Microsoft.Build.UnitTests
 
             for (var i = 0; i < files.Length; i++)
             {
-                var fullPath = Path.Combine(rootDirectory, files[i]);
+                // On Unix there is the risk of creating one file with '\' in its name instead of directories.
+                // Therefore split the arguments into path fragments and recompose the path.
+                var fileFragments = SplitPathIntoFragments(files[i]);
+                var rootDirectoryFragments = SplitPathIntoFragments(rootDirectory);
+                var pathFragments = rootDirectoryFragments.Concat(fileFragments);
 
-                Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+                var fullPath = Path.Combine(pathFragments.ToArray());
 
-                File.WriteAllText(fullPath, String.Empty);
+                var directoryName = Path.GetDirectoryName(fullPath);
+
+                Directory.CreateDirectory(directoryName);
+                Assert.True(Directory.Exists(directoryName));
+
+                File.WriteAllText(fullPath, string.Empty);
+                Assert.True(File.Exists(fullPath));
+
                 result[i] = fullPath;
             }
 
             return result;
+        }
+
+        private static string[] SplitPathIntoFragments(string path)
+        {
+            // Both Path.AltDirectorSeparatorChar and Path.DirectorySeparator char return '/' on OSX, 
+            // which renders them useless for the following case where I want to split a path that may contain either separator
+            var splits = path.Split('/', '\\');
+
+            // if the path is rooted then the first split is either empty (Unix) or 'c:' (Windows)
+            // in this case the root must be restored back to '/' (Unix) or 'c:\' (Windows)
+            if (Path.IsPathRooted(path))
+            {
+                splits[0] = Path.GetPathRoot(path);
+            }
+
+            return splits;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/UnitTests/TargetsFile_Test.cs
+++ b/src/XMakeBuildEngine/UnitTests/TargetsFile_Test.cs
@@ -867,7 +867,7 @@ namespace Microsoft.Build.UnitTests
         public void NoLinkMetadataSynthesisWhenDefinedInProject()
         {
             string[] files = null;
-            string outputPath = Path.GetTempPath() + "\\" + Guid.NewGuid().ToString("N");
+            string outputPath = Path.Combine(Path.GetTempPath(),Guid.NewGuid().ToString("N"));
 
             try
             {
@@ -929,7 +929,7 @@ namespace Microsoft.Build.UnitTests
         public void SynthesizeLinkMetadataForItemsOnWhitelist()
         {
             string[] files = null;
-            string outputPath = Path.GetTempPath() + "\\" + Guid.NewGuid().ToString("N");
+            string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             string directoryToDelete = null;
 
             try
@@ -1008,7 +1008,7 @@ namespace Microsoft.Build.UnitTests
         public void DontSynthesizeLinkMetadataIfPropertyNotSet()
         {
             string[] files = null;
-            string outputPath = Path.GetTempPath() + "\\" + Guid.NewGuid().ToString("N");
+            string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
             string directoryToDelete = null;
 
             try

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -527,9 +527,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             new[] { "aab", "aaxb", @"dir\abb", @"dir\abxb" })]
         public void IncludeExcludeWithEscapedCharacters(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude)
         {
-            //todo run the test twice with slashes and back-slashes when fixing https://github.com/Microsoft/msbuild/issues/724
-            var formattedProjectContents = string.Format(projectContents, includeString, excludeString);
-            Helpers.AssertItemEvaluation(formattedProjectContents, inputFiles, expectedInclude);
+            TestIncludeExclude(projectContents, includeString, excludeString, inputFiles, expectedInclude);
         }
 
         [Theory]
@@ -597,10 +595,27 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             })]
         public void ExcludeVectorWithWildCards(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude)
         {
-            //todo run the test twice with slashes and back-slashes when fixing https://github.com/Microsoft/msbuild/issues/724
-            var formattedProjectContents = string.Format(projectContents, includeString, excludeString);
-            Helpers.AssertItemEvaluation(formattedProjectContents, inputFiles, expectedInclude);
+            TestIncludeExclude(projectContents, includeString, excludeString, inputFiles, expectedInclude);
         }
+
+        private static void TestIncludeExclude(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude)
+        {
+            Action<string, string> runTest = (include, exclude) =>
+            {
+                var formattedProjectContents = string.Format(projectContents, include, exclude);
+                Helpers.AssertItemEvaluation(formattedProjectContents, inputFiles, expectedInclude);
+            };
+
+            var includeWithForwardSlash = ToForwardSlash(includeString);
+            var excludeWithForwardSlash = ToForwardSlash(excludeString);
+
+            runTest(includeString, excludeString);
+            runTest(includeWithForwardSlash, excludeWithForwardSlash);
+            runTest(includeString, excludeWithForwardSlash);
+            runTest(includeWithForwardSlash, excludeString);
+        }
+
+        private static string ToForwardSlash(string s) => s.Replace("\\", "/");
 
         /// <summary>
         /// Expression like @(x) should clone metadata, but metadata should still point at the original XML objects

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -606,16 +606,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 Helpers.AssertItemEvaluation(formattedProjectContents, inputFiles, expectedInclude);
             };
 
-            var includeWithForwardSlash = ToForwardSlash(includeString);
-            var excludeWithForwardSlash = ToForwardSlash(excludeString);
+            var includeWithForwardSlash = Helpers.ToForwardSlash(includeString);
+            var excludeWithForwardSlash = Helpers.ToForwardSlash(excludeString);
 
             runTest(includeString, excludeString);
             runTest(includeWithForwardSlash, excludeWithForwardSlash);
             runTest(includeString, excludeWithForwardSlash);
             runTest(includeWithForwardSlash, excludeString);
         }
-
-        private static string ToForwardSlash(string s) => s.Replace("\\", "/");
 
         /// <summary>
         /// Expression like @(x) should clone metadata, but metadata should still point at the original XML objects

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -2135,10 +2135,11 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
         private static List<ProjectItem> GetItemsFromFragmentWithGlobs(out string rootDir, string itemGroupFragment, params string[] globFiles)
         {
-            var projectFile = ObjectModelHelpers.CreateFileInTempProjectDirectory($"{Guid.NewGuid()}.proj", ObjectModelHelpers.FormatProjectContentsWithItemGroupFragment(itemGroupFragment));
-            rootDir = Path.GetDirectoryName(projectFile);
+            var formattedProjectContents = ObjectModelHelpers.FormatProjectContentsWithItemGroupFragment(itemGroupFragment);
 
-            Helpers.CreateFilesInDirectory(rootDir, globFiles);
+            string projectFile;
+            string[] createdFiles;
+            rootDir = Helpers.CreateProjectInTempDirectoryWithFiles(formattedProjectContents, globFiles, out projectFile, out createdFiles);
 
             return Helpers.MakeList(new Project(projectFile).GetItems("i"));
         }


### PR DESCRIPTION
Fixes #724 

While excludes with slashes currently work crossplatform, they mostly work out of accident. This PR makes FileMatcher work with both slashes and backslashes. Also wrote more tests.