### PR TITLE
Change base path for CompillerToolsDir to NuGet packages folder.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -327,7 +327,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetCoreBuild)' != 'true'">
-    <CompilerToolsDir>$([System.IO.Path]::Combine($(ToolPackagesDir)Microsoft.Net.Compilers, $(CompilerToolsVersion), "tools"))$([System.IO.Path]::DirectorySeparatorChar)</CompilerToolsDir>
+    <NuGetCacheDir Condition="'$(OsEnvironment)'=='Windows_NT'">$([System.IO.Path]::Combine($(USERPROFILE), '.nuget', 'packages'))</NuGetCacheDir>
+    <NuGetCacheDir Condition="'$(OsEnvironment)'!='Windows_NT'">$([System.IO.Path]::Combine($(HOME), '.nuget', 'packages'))</NuGetCacheDir>
+    <CompilerToolsDir>$([System.IO.Path]::Combine($(NuGetCacheDir), Microsoft.Net.Compilers, $(CompilerToolsVersion), "tools"))$([System.IO.Path]::DirectorySeparatorChar)</CompilerToolsDir>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetCoreSurface)' == 'true'">


### PR DESCRIPTION
By default NuGet restore packages from .nuget/project.json to
HomeDirectory/.nuget/packages but CompilerToolsDir expect compiler package in
solution packages folder. I change it behaviour to find package in right
place. It's fix unresolved reference to Microsoft.Build.Tasks.CodeAnalysis
in projects.