### PR TITLE
Fix ResolveSDKFromRegistryAndDisk test on xplat

### DIFF
--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -4068,7 +4068,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Contains("MyAssembly, Version=1.0", targetPlatforms[key].ExtensionSDKs.Keys);
             Assert.True(
                 targetPlatforms[key].Path.Equals(
-                    Path.Combine(_fakeStructureRoot, "MyAssembly", "2.0") + Path.DirectorySeparatorChar,
+                    Path.Combine(_fakeStructureRoot, "MyPlatform", "2.0") + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["MyAssembly, Version=1.0"].Equals(

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -4047,7 +4047,8 @@ namespace Microsoft.Build.UnitTests
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["AnotherAssembly, Version=1.0"].Equals(
                     Path.Combine(
-                        new[] { _fakeStructureRoot, "MyPlatform", "4.0", "ExtensionSDKs", "AnotherAssembly", "1.0" }),
+                        new[] {_fakeStructureRoot, "MyPlatform", "4.0", "ExtensionSDKs", "AnotherAssembly", "1.0"}) +
+                    Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
 
             key = new TargetPlatformSDK("MyPlatform", new Version("3.0"), null);

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -3982,18 +3982,18 @@ namespace Microsoft.Build.UnitTests
             }
 
             TargetPlatformSDK key = new TargetPlatformSDK("Windows", new Version("1.0"), null);
-            Assert.True(targetPlatforms[key].ExtensionSDKs.Count == 2);
+            Assert.Equal(2, targetPlatforms[key].ExtensionSDKs.Count);
             Assert.True(
                 targetPlatforms[key].Path.Equals(
                     Path.Combine(_fakeStructureRoot, "Windows", "1.0") + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=1.0"));
+            Assert.Contains("MyAssembly, Version=1.0", targetPlatforms[key].ExtensionSDKs.Keys);
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["MyAssembly, Version=1.0"].Equals(
                     Path.Combine(new[] { _fakeStructureRoot, "Windows", "v1.0", "ExtensionSDKs", "MyAssembly", "1.0" })
                     + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=2.0"));
+            Assert.Contains("MyAssembly, Version=2.0", targetPlatforms[key].ExtensionSDKs.Keys);
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["MyAssembly, Version=2.0"].Equals(
                     Path.Combine(new[] { _fakeStructureRoot, "Windows", "1.0", "ExtensionSDKs", "MyAssembly", "2.0" })
@@ -4001,38 +4001,39 @@ namespace Microsoft.Build.UnitTests
                     StringComparison.OrdinalIgnoreCase));
 
             key = new TargetPlatformSDK("Windows", new Version("2.0"), null);
-            Assert.True(targetPlatforms[key].ExtensionSDKs.Count == 1);
+            Assert.Equal(1, targetPlatforms[key].ExtensionSDKs.Count);
             Assert.True(
                 targetPlatforms[key].Path.Equals(
                     Path.Combine(_fakeStructureRoot, "Windows", "2.0") + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=3.0"));
+            Assert.Contains("MyAssembly, Version=3.0", targetPlatforms[key].ExtensionSDKs.Keys);
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["MyAssembly, Version=3.0"].Equals(
                     Path.Combine(new[] { _fakeStructureRoot, "Windows", "2.0", "ExtensionSDKs", "MyAssembly", "3.0" })
                     + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
 
+            // This is present in the registry but not on disk.
             key = new TargetPlatformSDK("MyPlatform", new Version("6.0"), null);
-            Assert.True(targetPlatforms.ContainsKey(key));
+            Assert.Contains(key, targetPlatforms.Keys);
             Assert.True(
                 targetPlatforms[key].Path.Equals(
                     Path.Combine(_fakeStructureRoot, "Windows Kits", "6.0") + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
 
             key = new TargetPlatformSDK("MyPlatform", new Version("5.0"), null);
-            Assert.True(targetPlatforms.ContainsKey(key));
-            Assert.Equal(0, targetPlatforms[key].ExtensionSDKs.Count);
+            Assert.Contains(key, targetPlatforms.Keys);
+            Assert.Empty(targetPlatforms[key].ExtensionSDKs);
             Assert.Null(targetPlatforms[key].Path);
 
             key = new TargetPlatformSDK("MyPlatform", new Version("4.0"), null);
-            Assert.True(targetPlatforms[key].ExtensionSDKs.Count == 2);
+            Assert.Equal(2, targetPlatforms[key].ExtensionSDKs.Count);
             Assert.True(
                 targetPlatforms[key].Path.Equals(
                     Path.Combine(_fakeStructureRoot, "SomeOtherPlace", "MyPlatformOtherLocation", "4.0")
                     + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=1.0"));
+            Assert.Contains("MyAssembly, Version=1.0", targetPlatforms[key].ExtensionSDKs.Keys);
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["MyAssembly, Version=1.0"].Equals(
                     Path.Combine(
@@ -4042,7 +4043,7 @@ namespace Microsoft.Build.UnitTests
                                 "MyAssembly", "1.0"
                             }) + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("AnotherAssembly, Version=1.0"));
+            Assert.Contains("AnotherAssembly, Version=1.0", targetPlatforms[key].ExtensionSDKs.Keys);
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["AnotherAssembly, Version=1.0"].Equals(
                     Path.Combine(
@@ -4050,8 +4051,8 @@ namespace Microsoft.Build.UnitTests
                     StringComparison.OrdinalIgnoreCase));
 
             key = new TargetPlatformSDK("MyPlatform", new Version("3.0"), null);
-            Assert.True(targetPlatforms[key].ExtensionSDKs.Count == 1);
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=1.0"));
+            Assert.Equal(1, targetPlatforms[key].ExtensionSDKs.Count);
+            Assert.Contains("MyAssembly, Version=1.0", targetPlatforms[key].ExtensionSDKs.Keys);
             Assert.True(
                 targetPlatforms[key].Path.Equals(
                     Path.Combine(_fakeStructureRoot, "MyPlatform", "3.0") + Path.DirectorySeparatorChar,
@@ -4063,8 +4064,8 @@ namespace Microsoft.Build.UnitTests
                     StringComparison.OrdinalIgnoreCase));
 
             key = new TargetPlatformSDK("MyPlatform", new Version("2.0"), null);
-            Assert.True(targetPlatforms[key].ExtensionSDKs.Count == 1);
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=1.0"));
+            Assert.Equal(1, targetPlatforms[key].ExtensionSDKs.Count);
+            Assert.Contains("MyAssembly, Version=1.0", targetPlatforms[key].ExtensionSDKs.Keys);
             Assert.True(
                 targetPlatforms[key].Path.Equals(
                     Path.Combine(_fakeStructureRoot, "MyAssembly", "2.0") + Path.DirectorySeparatorChar,
@@ -4080,7 +4081,7 @@ namespace Microsoft.Build.UnitTests
                 targetPlatforms[key].Path.Equals(
                     Path.Combine(_fakeStructureRoot, "MyPlatform", "1.0") + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
-            Assert.True(targetPlatforms[key].ExtensionSDKs.Count == 0);
+            Assert.Empty(targetPlatforms[key].ExtensionSDKs);
         }
 #endif
 

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -3895,11 +3895,11 @@ namespace Microsoft.Build.UnitTests
                     StringComparison.OrdinalIgnoreCase));
             Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=1.0"));
             Assert.True(
-                targetPlatforms[key].ExtensionSDKs["FlutterShy, Version=1.0"].Equals(
+                targetPlatforms[key].ExtensionSDKs["MyAssembly, Version=1.0"].Equals(
                     Path.Combine(new[] { _fakeStructureRoot, "Windows", "v1.0", "ExtensionSDKs", "MyAssembly", "1.0" })
                     + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("FlutterShy, Version=2.0"));
+            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=2.0"));
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["MyAssembly, Version=2.0"].Equals(
                     Path.Combine(new[] { _fakeStructureRoot, "Windows", "1.0", "ExtensionSDKs", "MyAssembly", "2.0" })
@@ -3937,7 +3937,7 @@ namespace Microsoft.Build.UnitTests
                     Path.Combine(_fakeStructureRoot, "SomeOtherPlace", "MyPlatformOtherLocation", "4.0")
                     + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
-            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("FlutterShy, Version=1.0"));
+            Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("MyAssembly, Version=1.0"));
             Assert.True(
                 targetPlatforms[key].ExtensionSDKs["MyAssembly, Version=1.0"].Equals(
                     Path.Combine(
@@ -4039,7 +4039,7 @@ namespace Microsoft.Build.UnitTests
                         new[]
                             {
                                 _fakeStructureRoot, "SomeOtherPlace", "MyPlatformOtherLocation", "4.0", "ExtensionSDKs",
-                                "FlutterShy", "1.0"
+                                "MyAssembly", "1.0"
                             }) + Path.DirectorySeparatorChar,
                     StringComparison.OrdinalIgnoreCase));
             Assert.True(targetPlatforms[key].ExtensionSDKs.ContainsKey("AnotherAssembly, Version=1.0"));
@@ -4733,12 +4733,12 @@ namespace Microsoft.Build.UnitTests
                     return new string[] { "MyAssembly" };
                 }
 
-                if (string.Compare(subKey, @"Software\Microsoft\MicrosoftSDKs\Windows\v1.0\ExtensionSDKs\FlutterShy", StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Compare(subKey, @"Software\Microsoft\MicrosoftSDKs\Windows\v1.0\ExtensionSDKs\MyAssembly", StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     return new[] { "v1.1", "1.0", "2.0", "3.0" };
                 }
 
-                if (string.Compare(subKey, @"Software\Microsoft\MicrosoftSDKs\Windows\1.0\ExtensionSDKs\FlutterShy", StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Compare(subKey, @"Software\Microsoft\MicrosoftSDKs\Windows\1.0\ExtensionSDKs\MyAssembly", StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     return new[] { "2.0" };
                 }
@@ -4758,7 +4758,7 @@ namespace Microsoft.Build.UnitTests
                     return new[] { string.Empty };
                 }
 
-                if (string.Compare(subKey, @"Software\Microsoft\MicrosoftSDKs\MyPlatform\4.0\ExtensionSDKs\FlutterShy", StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Compare(subKey, @"Software\Microsoft\MicrosoftSDKs\MyPlatform\4.0\ExtensionSDKs\MyAssembly", StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     return new[] { "1.0" };
                 }
@@ -4781,7 +4781,7 @@ namespace Microsoft.Build.UnitTests
                     return new[] { "MyAssembly" };
                 }
 
-                if (string.Compare(subKey, @"Software\Microsoft\MicrosoftSDKs\Windows\v2.0\ExtensionSDKs\FlutterShy", StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Compare(subKey, @"Software\Microsoft\MicrosoftSDKs\Windows\v2.0\ExtensionSDKs\MyAssembly", StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     return new[] { "3.0" };
                 }

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -3975,7 +3975,7 @@ namespace Microsoft.Build.UnitTests
 
             ToolLocationHelper.GatherSDKListFromDirectory(paths, targetPlatforms);
 
-            if (!NativeMethodsShared.IsWindows)
+            if (NativeMethodsShared.IsWindows)
             {
                 ToolLocationHelper.GatherSDKsFromRegistryImpl(targetPlatforms, "Software\\Microsoft\\MicrosoftSDks", RegistryView.Registry32, RegistryHive.CurrentUser, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, _openBaseKey, new FileExists(File.Exists));
                 ToolLocationHelper.GatherSDKsFromRegistryImpl(targetPlatforms, "Software\\Microsoft\\MicrosoftSDks", RegistryView.Registry32, RegistryHive.LocalMachine, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, _openBaseKey, new FileExists(File.Exists));

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -3874,7 +3874,7 @@ namespace Microsoft.Build.UnitTests
         /// Verify based on a fake directory structure with some good directories and some invalid ones at each level that we 
         /// get the expected set out.
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/799")]
+        [Fact]
         public void ResolveSDKFromRegistry()
         {
             if (!NativeMethodsShared.IsWindows)
@@ -3966,7 +3966,7 @@ namespace Microsoft.Build.UnitTests
         /// get the expected set out. Make sure that when we resolve from both the disk and registry that there are no duplicates
         /// and make sure we get the expected results.
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/799")]
+        [Fact]
         public void ResolveSDKFromRegistryAndDisk()
         {
             Dictionary<TargetPlatformSDK, TargetPlatformSDK> targetPlatforms = new Dictionary<TargetPlatformSDK, TargetPlatformSDK>();

--- a/src/XMakeTasks/UnitTests/GetInstalledSDKLocations_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GetInstalledSDKLocations_Tests.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Build.UnitTests.GetInstalledSDKLocation_Tests
 
                 Assert.True(extensionSDKs.ContainsKey("MyAssembly, Version=1.0"));
                 Assert.True(
-                    extensionSDKs["FlutterShy, Version=1.0"].Equals(
+                    extensionSDKs["MyAssembly, Version=1.0"].Equals(
                         Path.Combine(
                             new[] { _fakeSDKStructureRoot, "Windows", "v1.0", "ExtensionSDKs", "MyAssembly", "1.0" })
                         + Path.DirectorySeparatorChar,
@@ -362,7 +362,7 @@ namespace Microsoft.Build.UnitTests.GetInstalledSDKLocation_Tests
                         StringComparison.OrdinalIgnoreCase));
                 Assert.True(extensionSDKs.ContainsKey("MyAssembly, Version=3.0"));
                 Assert.True(
-                    extensionSDKs["FlutterShy, Version=3.0"].Equals(
+                    extensionSDKs["MyAssembly, Version=3.0"].Equals(
                         Path.Combine(
                             new[] { _fakeSDKStructureRoot, "Windows", "2.0", "ExtensionSDKs", "MyAssembly", "3.0" })
                         + Path.DirectorySeparatorChar,
@@ -384,7 +384,7 @@ namespace Microsoft.Build.UnitTests.GetInstalledSDKLocation_Tests
                         StringComparison.OrdinalIgnoreCase));
                 Assert.True(extensionSDKs.ContainsKey("MyAssembly, Version=6.0"));
                 Assert.True(
-                    extensionSDKs["FlutterShy, Version=6.0"].Equals(
+                    extensionSDKs["MyAssembly, Version=6.0"].Equals(
                         Path.Combine(
                             new[] { _fakeSDKStructureRoot2, "Windows", "2.0", "ExtensionSDKs", "MyAssembly", "6.0" })
                         + Path.DirectorySeparatorChar,
@@ -428,7 +428,7 @@ namespace Microsoft.Build.UnitTests.GetInstalledSDKLocation_Tests
 
                 Assert.True(extensionSDKs.ContainsKey("MyAssembly, Version=1.0"));
                 Assert.True(
-                    extensionSDKs["FlutterShy, Version=1.0"].Equals(
+                    extensionSDKs["MyAssembly, Version=1.0"].Equals(
                         Path.Combine(
                             new[] { _fakeSDKStructureRoot, "Windows", "v1.0", "ExtensionSDKs", "MyAssembly", "1.0" })
                         + Path.DirectorySeparatorChar,
@@ -450,7 +450,7 @@ namespace Microsoft.Build.UnitTests.GetInstalledSDKLocation_Tests
 
                 Assert.True(extensionSDKs.ContainsKey("MyAssembly, Version=4.0"));
                 Assert.True(
-                    extensionSDKs["FlutterShy, Version=4.0"].Equals(
+                    extensionSDKs["MyAssembly, Version=4.0"].Equals(
                         Path.Combine(
                             new[] { _fakeSDKStructureRoot2, "Windows", "v1.0", "ExtensionSDKs", "MyAssembly", "4.0" })
                         + Path.DirectorySeparatorChar,


### PR DESCRIPTION
There were several minor test-only problems that caused this test to fail, which is why it was disabled while trying to figure out #799.

Most of the line changes were just a bulk replace--you might like to look at the commits after the first one.