### PR TITLE
Fix to copy reference project satellite assemblies on Unix.

### DIFF
--- a/src/XMakeTasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/XMakeTasks/AssemblyDependency/ReferenceTable.cs
@@ -921,7 +921,7 @@ namespace Microsoft.Build.Tasks
                     return;
                 }
 
-                string[] subDirectories = _getDirectories(reference.DirectoryName, "*.");
+                string[] subDirectories = _getDirectories(reference.DirectoryName, "*");
                 string sateliteFilename = reference.FileNameWithoutExtension + ".resources.dll";
 
                 foreach (string subDirectory in subDirectories)

--- a/src/XMakeTasks/SystemState.cs
+++ b/src/XMakeTasks/SystemState.cs
@@ -504,7 +504,7 @@ namespace Microsoft.Build.Tasks
             // Only cache the *. pattern. This is by far the most common pattern
             // and generalized caching would require a call to Path.Combine which
             // is a string-copy.
-            if (pattern == "*.")
+            if (pattern == "*")
             {
                 object cached = instanceLocalDirectories[path];
                 if (cached == null)


### PR DESCRIPTION
Example ProjectA depends on ProjectB. Building ProjectA should copy all the satellite assemblies from ProjectB. This was working on windows but not on Unix.

There seems to be a behavior difference between Unix and Windows when using the search pattern `"*."` to get all the sub-directories. I have filed issue to track that - https://github.com/dotnet/corefx/issues/11943.
Meanwhile workaround that issue using "*" search pattern.

cc @rainersigwald @cdmihai 