### PR TITLE
Update resource fallback behavior

### DIFF
--- a/src/Framework/AssemblyInfo.cs
+++ b/src/Framework/AssemblyInfo.cs
@@ -52,7 +52,13 @@ using System.Windows.Markup;
 
 #if (LOCALIZED_BUILD)
 // Needed for the "hub-and-spoke model to locate and retrieve localized resources": https://msdn.microsoft.com/en-us/library/21a15yht(v=vs.110).aspx
+// We want "en" to require a satellite assembly for debug builds in order to flush out localization
+// issues, but we want release builds to work without it.
+#if (DEBUG)
 [assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.Satellite)]
+#else
+[assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.MainAssembly)]
+#endif
 #endif
 
 [assembly: CLSCompliant(true)]

--- a/src/Utilities/AssemblyInfo.cs
+++ b/src/Utilities/AssemblyInfo.cs
@@ -21,7 +21,13 @@ using System.Runtime.InteropServices;
 
 #if (LOCALIZED_BUILD)
 // Needed for the "hub-and-spoke model to locate and retrieve localized resources": https://msdn.microsoft.com/en-us/library/21a15yht(v=vs.110).aspx
+// We want "en" to require a satellite assembly for debug builds in order to flush out localization
+// issues, but we want release builds to work without it.
+#if (DEBUG)
 [assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.Satellite)]
+#else
+[assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.MainAssembly)]
+#endif
 #endif
 
 [assembly: CLSCompliant(true)]

--- a/src/XMakeBuildEngine/AssemblyInfo.cs
+++ b/src/XMakeBuildEngine/AssemblyInfo.cs
@@ -32,7 +32,13 @@ using System.Runtime.InteropServices;
 
 #if (LOCALIZED_BUILD)
 // Needed for the "hub-and-spoke model to locate and retrieve localized resources": https://msdn.microsoft.com/en-us/library/21a15yht(v=vs.110).aspx
+// We want "en" to require a satellite assembly for debug builds in order to flush out localization
+// issues, but we want release builds to work without it.
+#if (DEBUG)
 [assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.Satellite)]
+#else
+[assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.MainAssembly)]
+#endif
 #endif
 
 [assembly: CLSCompliant(true)]

--- a/src/XMakeCommandLine/AssemblyInfo.cs
+++ b/src/XMakeCommandLine/AssemblyInfo.cs
@@ -17,7 +17,13 @@ using System.Runtime.InteropServices;
 
 #if (LOCALIZED_BUILD)
 // Needed for the "hub-and-spoke model to locate and retrieve localized resources": https://msdn.microsoft.com/en-us/library/21a15yht(v=vs.110).aspx
+// We want "en" to require a satellite assembly for debug builds in order to flush out localization
+// issues, but we want release builds to work without it.
+#if (DEBUG)
 [assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.Satellite)]
+#else
+[assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.MainAssembly)]
+#endif
 #endif
 
 [assembly: CLSCompliant(true)]

--- a/src/XMakeTasks/AssemblyInfo.cs
+++ b/src/XMakeTasks/AssemblyInfo.cs
@@ -23,7 +23,13 @@ using System.Runtime.CompilerServices;
 
 #if (LOCALIZED_BUILD)
 // Needed for the "hub-and-spoke model to locate and retrieve localized resources": https://msdn.microsoft.com/en-us/library/21a15yht(v=vs.110).aspx
+// We want "en" to require a satellite assembly for debug builds in order to flush out localization
+// issues, but we want release builds to work without it.
+#if (DEBUG)
 [assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.Satellite)]
+#else
+[assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.MainAssembly)]
+#endif
 #endif
 
 [assembly: CLSCompliant(true)]


### PR DESCRIPTION
Currently localized builds depend on resources for all cultures, including en.
This means that if you don't have satellite assemblies for en, you won't be
able to load resources at all.

We want to keep this behavior for localized *debug* builds since it will help
us flush out problems related to localization and how we layout our satellite
assemblies on disk. For *release* builds, however, we want en to fall back to
resources in the main assembly. This allows the MSBuild binaries to be used
even without satellite assemblies installed.