### PR TITLE
Only record extra Evaluator data when needed

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -1642,7 +1642,7 @@ namespace Microsoft.Build.Evaluation
 
                 if (conditionResult)
                 {
-                    _data.EvaluatedItemElements.Add(itemElement);
+                    RecordEvaluatedItemElement(itemElement);
                 }
 
                 return;
@@ -1660,7 +1660,7 @@ namespace Microsoft.Build.Evaluation
 
         private void EvaluateItemElementUpdate(ProjectItemElement itemElement)
         {
-            _data.EvaluatedItemElements.Add(itemElement);
+            RecordEvaluatedItemElement(itemElement);
 
             var expandedItemSet =
                 new HashSet<string>(
@@ -1734,7 +1734,7 @@ namespace Microsoft.Build.Evaluation
             // FINALLY: Add the items to the project
             if (itemConditionResult && itemGroupConditionResult)
             {
-                _data.EvaluatedItemElements.Add(itemElement);
+                RecordEvaluatedItemElement(itemElement);
 
                 foreach (I item in items)
                 {
@@ -2622,6 +2622,14 @@ namespace Microsoft.Build.Evaluation
             else
             {
                 return _data.Directory;
+            }
+        }
+
+        private void RecordEvaluatedItemElement(ProjectItemElement itemElement)
+        {
+            if (_loadSettings.HasFlag(ProjectLoadSettings.RecordEvaluatedItemElements))
+            {
+                _data.EvaluatedItemElements.Add(itemElement);
             }
         }
 

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -2536,6 +2536,41 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Fact]
+        public void GetItemProvenanceShouldReturnTheSameResultsIfProjectIsReevaluated()
+        {
+            var projectContents =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`*.foo`/>
+                    <B Include=`1.foo;2.foo` Exclude=`*.foo`/>
+                    <C Include=`2` Exclude=`*.bar`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
+                Tuple.Create("B", Operation.Exclude, Provenance.Glob, 1)
+            };
+
+            // Create a project. The initial evaluation does not record the information needed for GetItemProvenance
+            var project = ObjectModelHelpers.CreateInMemoryProject(projectContents);
+
+            // Since GetItemProvenance does not have the required evaluator data (evaluated item elements), it internally reevaluates the project to collect it
+            var provenanceResult = project.GetItemProvenance("2.foo");
+            AssertProvenanceResult(expected, provenanceResult);
+
+            // Dirty the xml to force another reevaluation.
+            project.AddItem("new", "new value");
+            project.ReevaluateIfNecessary();
+
+            // Assert that provenance returns the same result and that no data duplication happened
+            provenanceResult = project.GetItemProvenance("2.foo");
+            AssertProvenanceResult(expected, provenanceResult);
+        }
+
+        [Fact]
         public void GetItemProvenanceShouldHandleComplexGlobExclusion()
         {
             var project =


### PR DESCRIPTION
This saves memory. Otherwise, the extra list tips over the memory sensitive GC aware code from the ProjectCollection cache (and potentially other special MSBuild caches) leading to a lot of GC calls and thus performance hits.