### PR TITLE
Add common targets and extensibility x-targeting targets

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
@@ -11,6 +11,122 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+  ============================================================
+                                       DispatchToInnerBuilds
+
+     Builds this project with /t:$(InnerTarget) /p:TargetFramework=X for each
+     value X in $(TargetFrameworks)
+
+     [IN]
+     $(TargetFrameworks) - Semicolon delimited list of target frameworks.
+     $(InnerTargets) - The targets to build for each target framework
+
+     [OUT]
+     @(InnerOutput) - The combined output items of the inner targets across
+                      all target frameworks..
+  ============================================================
+  -->
+  <Target Name="DispatchToInnerBuilds" Returns="@(InnerOutput)">
+    <ItemGroup>
+      <_TargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Condition="'$(TargetFrameworks)' != '' "
+             Targets="$(InnerTargets)"
+             Properties="TargetFramework=%(_TargetFramework.Identity)">
+      <Output ItemName="InnerOutput" TaskParameter="TargetOutputs" />
+    </MSBuild>
+  </Target>
+
+  <!--
+  ============================================================
+                                       Build
+
+   Cross-targeting version of Build.
+
+   [IN]
+   $(TargetFrameworks) - Semicolon delimited list of target frameworks.
+
+   $(InnerTargets)     - The targets to build for each target framework. Defaults
+                         to 'Build' if unset, but allows override to support
+                         `msbuild /p:InnerTargets=X;Y;Z` which will build X, Y,
+                         and Z targets for each target framework.
+
+   [OUT]
+   @(InnerOutput) - The combined output items of the inner targets across
+                    all builds.
+  ============================================================
+  -->
+  <Target Name="Build" DependsOnTargets="_SetBuildInnerTarget;DispatchToInnerBuilds" />
+
+  <Target Name="_SetBuildInnerTarget" Returns="@(InnerOutput)">
+    <PropertyGroup  Condition="'$(InnerTargets)' == ''">
+      <InnerTargets>Build</InnerTargets>
+    </PropertyGroup>
+  </Target>
+
+
+  <!--
+  ============================================================
+                                       Clean
+
+   Cross-targeting version of clean.
+  ============================================================
+  -->
+  <Target Name="Clean" DependsOnTargets="_SetCleanInnerTarget;DispatchToInnerBuilds" />
+  <Target Name="_SetCleanInnerTarget">
+    <PropertyGroup>
+      <InnerTargets>Clean</InnerTargets>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+  ============================================================
+                                       Rebuild
+
+   Cross-targeting version of rebuild.
+  ============================================================
+  -->
+  <Target Name="Rebuild" DependsOnTargets="_SetRebuildInnerTarget;DispatchToInnerBuilds" />
+  <Target Name="_SetRebuildInnerTarget">
+    <PropertyGroup>
+      <InnerTargets>Rebuild</InnerTargets>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    This will import NuGet restore targets, which is a special case separate from the package -> project extension 
+    mechanism below. For obvious reasons,  we need restore to work before any package assets are available.
+
+    TODO: https://github.com/Microsoft/msbuild/issues/1061: This needs to be generalized with less coupling to nuget, 
+          but we can't blindly import everything in Microsoft.Common.targets\ImportAfter as some things will not be
+          prepared to be inserted in to a cross-targeting build 
+  -->
+  <PropertyGroup>
+    <ImportByWildcardAfterMicrosoftCommonTargets Condition="'$(ImportByWildcardAfterMicrosoftCommonTargets)' == ''">true</ImportByWildcardAfterMicrosoftCommonTargets>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter\*.NuGet.*.targets" 
+          Condition="'$(ImportByWildcardAfterMicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter')"/>
+
+  <!--
+    Import project extensions which usually come from packages.  Package management systems will create a file at:
+      $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.targets
+
+    Each package management system should use a unique moniker to avoid collisions.  It is a wild-card iport so the package
+    management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
+
+    This is the same import that would happen in an inner (non-cross targeting) build. Package management systems are responsible for generating 
+    appropriate conditions based on $(IsCrossTargetingBuild) to pull in only those package targets that are meant to participate in a cross-targeting 
+    build.
+  -->
+  <PropertyGroup>
+    <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.targets" Condition="'$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+
+  <!-- TODO: https://github.com/Microsoft/msbuild/issues/1062: Remove this temporary hook when possible. -->
   <Import Project="$(CoreCrossTargetingTargetsPath)" 
           Condition="'$(CoreCrossTargetingTargetsPath)' != '' and Exists('$(CoreCrossTargetingTargetsPath)')" />
 </Project>


### PR DESCRIPTION
1. Move build,clean,rebuild targets and dispatch helper up from SDK targets
2. Pull in nuget restore targets
3. Pull in package-provided targets

@srivatsn @rainersigwald @AndyGerlicher