### PR TITLE
Update BuildEnvironmentHelper to locate .NET Core app directory

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -77,7 +77,12 @@ namespace Microsoft.Build.Shared
                 ()=> TryFromFolder(msbuildFromVisualStudioRoot, runningTests, runningInVisualStudio, visualStudioPath),
 
                 // Try from the current directory
-                () => TryFromFolder(currentDirectory, runningTests, runningInVisualStudio, visualStudioPath)
+                () => TryFromFolder(currentDirectory, runningTests, runningInVisualStudio, visualStudioPath),
+
+#if !CLR2COMPATIBILITY // Assemblies compiled against anything older than .NET 4.0 won't have a System.AppContext
+                // Try the base directory that the assembly resolver uses to probe for assemblies.
+                () => TryFromFolder(AppContext.BaseDirectory, runningTests, runningInVisualStudio, visualStudioPath)
+#endif
             };
 
             foreach (var location in possibleLocations)

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -64,12 +64,12 @@ namespace Microsoft.Build.Shared
 
             var possibleLocations = new Func<BuildEnvironment>[]
             {
+                // Check explicit %MSBUILD_EXE_PATH% environment variable.
+                () => TryFromEnvironmentVariable(runningTests, runningInVisualStudio, visualStudioPath),
+
                 // See if we're running from MSBuild.exe
                 () => TryFromCurrentProcess(processNameCommandLine, runningTests, runningInVisualStudio, visualStudioPath),
                 () => TryFromCurrentProcess(processNameCurrentProcess, runningTests, runningInVisualStudio, visualStudioPath),
-
-                // Check explicit %MSBUILD_EXE_PATH% environment variable.
-                () => TryFromEnvironmentVariable(runningTests, runningInVisualStudio, visualStudioPath),
 
                 // Try from our current executing assembly (e.g. path to Microsoft.Build.dll)
                 () => TryFromFolder(Path.GetDirectoryName(executingAssembly), runningTests, runningInVisualStudio, visualStudioPath),
@@ -77,15 +77,15 @@ namespace Microsoft.Build.Shared
                 // Try based on the Visual Studio Root
                 ()=> TryFromFolder(msbuildFromVisualStudioRoot, runningTests, runningInVisualStudio, visualStudioPath),
 
-                // Try from the current directory
-                () => TryFromFolder(currentDirectory, runningTests, runningInVisualStudio, visualStudioPath),
-
 #if !CLR2COMPATIBILITY // Assemblies compiled against anything older than .NET 4.0 won't have a System.AppContext
                 // Try the base directory that the assembly resolver uses to probe for assemblies.
                 // Under certain scenarios the assemblies are loaded from spurious locations like the NuGet package cache
                 // but the toolset files are copied to the app's directory via "contentFiles".
-                () => TryFromFolder(appContextBaseDirectory, runningTests, runningInVisualStudio, visualStudioPath)
+                () => TryFromFolder(appContextBaseDirectory, runningTests, runningInVisualStudio, visualStudioPath),
 #endif
+
+                // Try from the current directory
+                () => TryFromFolder(currentDirectory, runningTests, runningInVisualStudio, visualStudioPath),
             };
 
             foreach (var location in possibleLocations)

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Build.Shared
 
 #if !CLR2COMPATIBILITY // Assemblies compiled against anything older than .NET 4.0 won't have a System.AppContext
                 // Try the base directory that the assembly resolver uses to probe for assemblies.
+                // Under certain scenarios the assemblies are loaded from spurious locations like the NuGet package cache
+                // but the toolset files are copied to the app's directory via "contentFiles".
                 () => TryFromFolder(AppContext.BaseDirectory, runningTests, runningInVisualStudio, visualStudioPath)
 #endif
             };

--- a/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Engine.UnitTests
                 var msBuildConfig = Path.Combine(path, "msbuild.exe.config");
 
                 Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", env.MSBuildExePath);
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull, ReturnNull);
 
                 Assert.Equal(path, BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
                 Assert.Equal(msBuildPath, BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyBuildEnviroment())
             {
                 // All we know about is path to msbuild.exe as the command-line arg[0]
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull, ReturnNull);
 
                 Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
                 Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyBuildEnviroment())
             {
                 // All we know about is path to msbuild.exe as the current process
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull);
 
                 Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
                 Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyBuildEnviroment())
             {
                 // All we know about is path to DevEnv.exe
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, ReturnNull, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, ReturnNull, ReturnNull, ReturnNull);
 
                 Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
                 Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
@@ -117,7 +117,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyBuildEnviroment())
             {
                 // We only know we're in msbuild.exe, we should still be able to attempt to find Visual Studio
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull, ReturnNull);
 
                 Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
             }
@@ -129,7 +129,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyBuildEnviroment())
             {
                 // We only know we're in amd64\msbuild.exe, we should still be able to attempt to find Visual Studio
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, ReturnNull, ReturnNull);
 
                 Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
             }
@@ -151,7 +151,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (var env = new EmptyBuildEnviroment())
             {
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, () => env.MSBuildExePath, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, () => env.MSBuildExePath, ReturnNull, ReturnNull);
 
                 Assert.True(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
                 Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
@@ -163,7 +163,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (var env = new EmptyBuildEnviroment())
             {
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.BlendPath, ReturnNull, () => env.MSBuildExePath, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.BlendPath, ReturnNull, () => env.MSBuildExePath, ReturnNull, ReturnNull);
 
                 Assert.True(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
                 Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
@@ -189,7 +189,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyBuildEnviroment())
             {
                 Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", env.MSBuildExePath64);
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull, ReturnNull);
 
                 Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
                 Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
@@ -201,7 +201,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (new EmptyBuildEnviroment())
             {
-                Assert.Throws<InvalidOperationException>(() => BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull));
+                Assert.Throws<InvalidOperationException>(() => BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull, ReturnNull));
             }
         }
 


### PR DESCRIPTION
In .NET Core, the AppContext.BaseDirectory can be used to locate the application's dependencies.

Related to #1039 