### PR TITLE
Fix bad dependency in Microsoft.Build.Tasks.Core package

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -19,7 +19,7 @@
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Collections.NonGeneric" version="4.0.1" />
-        <dependency id="System.Resources.Reader" version="4.0.1" />
+        <dependency id="System.Resources.Reader" version="4.0.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Runtime.Serialization.Xml" version="4.1.0" />
         <dependency id="System.Xml.XmlDocument" version="4.0.1" />


### PR DESCRIPTION
System.Resources.Reader should be 4.0.0 which it is for the other packages.