### PR TITLE
Updating folder xaml to enable folder properties in CPS based projects

### DIFF
--- a/src/XMakeTasks/XamlRules/Folder.xaml
+++ b/src/XMakeTasks/XamlRules/Folder.xaml
@@ -6,11 +6,11 @@
   PageTemplate="generic"
   Description="Folder Properties"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
-    <Rule.DataSource>
-        <DataSource Persistence="ProjectFileFolderItems" HasConfigurationCondition="False" ItemType="Folder" />
-    </Rule.DataSource>
+  <Rule.DataSource>
+    <DataSource Persistence="ProjectFileFolderItems" HasConfigurationCondition="False" ItemType="Folder" />
+  </Rule.DataSource>
 
-    <StringProperty Name="Identity" Visible="false" ReadOnly="true" Category="Misc" />
-    <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" Description="Location of the folder"/>
-    <StringProperty Name="FolderName" DisplayName="Folder Name" ReadOnly="true" Category="Misc" Description="Name of this folder"/>
+  <StringProperty Name="Identity" Visible="false" ReadOnly="true" Category="Misc" />
+  <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" Description="Location of the folder"/>
+  <StringProperty Name="FolderName" DisplayName="Folder Name" ReadOnly="true" Category="Misc" Description="Name of this folder"/>
 </Rule>

--- a/src/XMakeTasks/XamlRules/Folder.xaml
+++ b/src/XMakeTasks/XamlRules/Folder.xaml
@@ -1,20 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright, Microsoft Corporation, All rights reserved.-->
 <Rule
   Name="Folder"
   DisplayName="General"
   PageTemplate="generic"
-  Description="Empty folder placeholders"
+  Description="Folder Properties"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectInstance" HasConfigurationCondition="False" ItemType="Folder" />
-  </Rule.DataSource>
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFileFolderItems" HasConfigurationCondition="False" ItemType="Folder" />
+    </Rule.DataSource>
 
-  <StringProperty Name="Identity" Visible="false" ReadOnly="true" Category="Misc" />
-  <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" />
-  <StringProperty Name="FileNameAndExtension" DisplayName="Folder Name" ReadOnly="true" Category="Misc">
-      <StringProperty.DataSource>
-            <DataSource Persistence="ProjectInstance" ItemType="Folder" PersistedName="FileNameAndExtension" />
-      </StringProperty.DataSource>
-  </StringProperty>
+    <StringProperty Name="Identity" Visible="false" ReadOnly="true" Category="Misc" />
+    <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" Description="Location of the folder"/>
+    <StringProperty Name="FolderName" DisplayName="Folder Name" ReadOnly="true" Category="Misc" Description="Name of this folder"/>
 </Rule>


### PR DESCRIPTION
Updating folder xaml to enable folder properties in CPS based projects by using a specialized data source that can handle implicit folder includes besides explicit folder includes.

This change should not be integrated in Preview 5 as it requires the new data source implementation to be present (otherwise CPS based projects will fail to load).