### PR TITLE
ON HOLD - Don't discard implicit references from build element cache for each build

### DIFF
--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
@@ -413,7 +413,7 @@ namespace Microsoft.Build.Execution
                         config.ResultsNodeId = Scheduler.InvalidNodeId;
                     }
 
-                    _buildParameters.ProjectRootElementCache.ScavengeCollectedEntries();
+                    _buildParameters.ProjectRootElementCache.SetImplicitReferencesToAutoReload();
                 }
 
                 // Set up the logging service.

--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
@@ -413,7 +413,7 @@ namespace Microsoft.Build.Execution
                         config.ResultsNodeId = Scheduler.InvalidNodeId;
                     }
 
-                    _buildParameters.ProjectRootElementCache.DiscardImplicitReferences();
+                    _buildParameters.ProjectRootElementCache.ScavengeCollectedEntries();
                 }
 
                 // Set up the logging service.

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -247,6 +247,11 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
+        /// See comments for <see cref="ProjectRootElementCache.SetImplicitReferencesToAutoReload"/> 
+        /// </summary>
+        internal bool AutoReloadFromDisk { get; set; }
+
+        /// <summary>
         /// Event raised after this project is renamed
         /// </summary>
         internal event RenameHandlerDelegate OnAfterProjectRename;

--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -437,6 +437,18 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Remove any entries from the dictionary that represent keys
+        /// that have been garbage collected.
+        /// </summary>
+        internal void ScavengeCollectedEntries()
+        {
+            lock (_locker)
+            {
+                _weakCache.Scavenge();
+            }
+        }
+
+        /// <summary>
         /// Forces a removal of a project root element from the weak cache if it is present.
         /// </summary>
         /// <param name="projectRootElement">The project root element to remove.</param>


### PR DESCRIPTION
Fixes #1068.  With this change, instead of discarding implicit references, the cache will simply remove any entries from the weak dictionary where the value has been garbage collected.  Discarding implicit references for each build doesn't make sense for large solutions, as the implicit references will include the .props and .targets files that are likely to be shared by multiple projects.

On a test machine, this reduced the time until Visual Studio finishes initializing projects in the Chromium solution by about 25% (from 19.5 to 14.5 minutes).
