### PR TITLE
FinalOutputPath should always be FullPath for consistency

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -5253,7 +5253,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
   <ItemGroup Condition="'$(DocumentationFile)'!='' and '$(OutputType)' != 'winmdobj'">
     <DocumentationProjectOutputGroupOutput Include="@(DocFileItem->'%(FullPath)')">
-      <FinalOutputPath>@(FinalDocFile)</FinalOutputPath>
+      <FinalOutputPath>@(FinalDocFile->'%(FullPath)')</FinalOutputPath>
       <IsKeyOutput>true</IsKeyOutput>
       <TargetPath>@(DocFileItem->'%(Filename)%(Extension)')</TargetPath>
     </DocumentationProjectOutputGroupOutput>


### PR DESCRIPTION
Just like BuiltProjectOutputGroupOutput and DebugSymbolsProjectOutputGroupOutput