### PR TITLE
NuGet package containing the MSBuild runtime

### DIFF
--- a/build/NuGetPackages/CreateNuGetPackages.proj
+++ b/build/NuGetPackages/CreateNuGetPackages.proj
@@ -57,6 +57,7 @@
       <NuspecProperties Include="licenseUrl=$(NuGetPackageLicenseUrl)"/>
       <NuspecProperties Include="projectUrl=$(NuGetPackageProjectUrl))"/>
       <NuspecProperties Include="iconUrl=$(NuGetPackageIconUrl)"/>
+      <NuspecProperties Include="targetMSBuildToolsVersion=$(TargetMSBuildToolsVersion)"/>
     </ItemGroup>
 
     <MakeDir Directories="$(PackagesOutDir)" />

--- a/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$id$</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <iconUrl>$iconUrl$</iconUrl>
+    <description>This package contains the runtime of MSBuild.  Reference this package only if your application needs to load projects or execute in-process builds.</description>
+    <tags>MSBuild</tags>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <contentFiles>
+      <files include="**" buildAction="None" copyToOutput="true" flatten="false" />
+    </contentFiles>
+    <dependencies>
+      <group targetFramework="netstandard1.5">
+        <dependency id="Microsoft.Build" version="[$version$]" />
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="Microsoft.Build.Tasks.Core" version="[$version$]" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
+      </group>
+      <group targetFramework="net46">
+        <dependency id="Microsoft.Build" version="[$version$]" />
+        <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="Microsoft.Build.Tasks.Core" version="[$version$]" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <!--
+      contentFiles\any\net46
+    -->
+    <file src="$configuration$\Output\MSBuild.exe" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\MSBuild.exe.config" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.Common.CrossTargeting.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.Common.CurrentVersion.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.Common.overridetasks" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.Common.props" target="contentFiles\any\net46\$targetMSBuildToolsVersion$\" />
+    <file src="$configuration$\Output\Microsoft.Common.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.Common.tasks" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.CSharp.CurrentVersion.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.CSharp.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.Data.Entity.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.NETFramework.CurrentVersion.props" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.NETFramework.CurrentVersion.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.NETFramework.props" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.NETFramework.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.ServiceModel.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.VisualBasic.CurrentVersion.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.VisualBasic.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.VisualStudioVersion.v11.Common.props" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.VisualStudioVersion.v12.Common.props" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.VisualStudioVersion.v14.Common.props" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.WinFx.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.WorkflowBuildExtensions.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Microsoft.Xaml.targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Workflow.Targets" target="contentFiles\any\net46\" />
+    <file src="$configuration$\Output\Workflow.VisualBasic.Targets" target="contentFiles\any\net46\" />
+
+    <!--
+      contentFiles\any\netcoreapp1.0
+    -->
+    <file src="$configuration$-NetCore\Output\MSBuild.exe" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.Common.CrossTargeting.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.Common.CurrentVersion.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.Common.overridetasks" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.Common.props" target="contentFiles\any\netcoreapp1.0\$targetMSBuildToolsVersion$\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.Common.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.Common.tasks" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.CSharp.CurrentVersion.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.CSharp.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.NETFramework.CurrentVersion.props" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.NETFramework.CurrentVersion.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.NETFramework.props" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.NETFramework.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.VisualBasic.CurrentVersion.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.VisualBasic.targets" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.VisualStudioVersion.v11.Common.props" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.VisualStudioVersion.v12.Common.props" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\Microsoft.VisualStudioVersion.v14.Common.props" target="contentFiles\any\netcoreapp1.0\" />
+  </files>
+</package>


### PR DESCRIPTION
I copied most of the <file /> items from the existing `.nuspec` and was able to add in the "shim" ones for full framework only.

Projects that reference this package will be able to use the MSBuild runtime to do project evaluation and in-proc builds provided they have all of the other props, targets, and executables needed.

Fixes #1039, #882, and #872.  Also fixes #1000 indirectly but the user will need to reference this package instead.