### PR TITLE
Update nuspec references to include System.AppContext

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -19,6 +19,7 @@
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
         <dependency id="System.Resources.Reader" version="4.0.0" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.AppContext" version="4.1.0" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Collections.Concurrent" version="4.0.12" />
         <dependency id="System.Collections.Immutable" version="1.2.0" />

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -18,6 +18,7 @@
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="System.Resources.Reader" version="4.0.0" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.AppContext" version="4.1.0" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Collections.Concurrent" version="4.0.12" />
         <dependency id="System.Collections.NonGeneric" version="4.0.1" />


### PR DESCRIPTION
This was part of c09995d8911e3e64a6d33df18a3084099d1b6c07 but it went in just after the logic to automatically update these.