### PR TITLE
GetItemProvenance(ProjectItem) now finds only the elements that might affect that item

### DIFF
--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -1075,8 +1075,7 @@ namespace Microsoft.Build.Evaluation
         /// </returns>
         public List<GlobResult> GetAllGlobs()
         {
-            ReevaluateForPostMortemAnalysisIfNecessary();
-            return GetAllGlobs(_data.EvaluatedItemElements);
+            return GetAllGlobs(GetEvaluatedItemElements());
         }
 
         /// <summary>
@@ -1090,8 +1089,7 @@ namespace Microsoft.Build.Evaluation
                 return new List<GlobResult>();
             }
 
-            ReevaluateForPostMortemAnalysisIfNecessary();
-            return GetAllGlobs(GetItemElementsByType(_data.EvaluatedItemElements, itemType));
+            return GetAllGlobs(GetItemElementsByType(GetEvaluatedItemElements(), itemType));
         }
 
         private List<GlobResult> GetAllGlobs(List<ProjectItemElement> projectItemElements)
@@ -1165,8 +1163,7 @@ namespace Microsoft.Build.Evaluation
         /// </returns>
         public List<ProvenanceResult> GetItemProvenance(string itemToMatch)
         {
-            ReevaluateForPostMortemAnalysisIfNecessary();
-            return GetItemProvenance(itemToMatch, _data.EvaluatedItemElements);
+            return GetItemProvenance(itemToMatch, GetEvaluatedItemElements());
         }
 
         /// <summary>
@@ -1176,8 +1173,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="itemType">The item type to constrain the search in</param>
         public List<ProvenanceResult> GetItemProvenance(string itemToMatch, string itemType)
         {
-            ReevaluateForPostMortemAnalysisIfNecessary();
-            return GetItemProvenance(itemToMatch, GetItemElementsByType(_data.EvaluatedItemElements, itemType));
+            return GetItemProvenance(itemToMatch, GetItemElementsByType(GetEvaluatedItemElements(), itemType));
         }
 
         /// <summary>
@@ -1195,8 +1191,7 @@ namespace Microsoft.Build.Evaluation
                 return new List<ProvenanceResult>();
             }
 
-            ReevaluateForPostMortemAnalysisIfNecessary();
-            var itemElementsAbove = GetItemElementsThatMightAffectItem(_data.EvaluatedItemElements, item);
+            var itemElementsAbove = GetItemElementsThatMightAffectItem(GetEvaluatedItemElements(), item);
 
             return GetItemProvenance(item.EvaluatedInclude, itemElementsAbove);
         }
@@ -1208,15 +1203,15 @@ namespace Microsoft.Build.Evaluation
         /// 
         /// Using this method avoids storing extra data in memory when its not needed.
         /// </summary>
-        private void ReevaluateForPostMortemAnalysisIfNecessary()
+        private List<ProjectItemElement> GetEvaluatedItemElements()
         {
-            if (_loadSettings.HasFlag(ProjectLoadSettings.RecordEvaluatedItemElements))
+            if (!_loadSettings.HasFlag(ProjectLoadSettings.RecordEvaluatedItemElements))
             {
-                return;
+                _loadSettings = _loadSettings | ProjectLoadSettings.RecordEvaluatedItemElements;
+                Reevaluate(LoggingService, _loadSettings);
             }
 
-            _loadSettings = _loadSettings | ProjectLoadSettings.RecordEvaluatedItemElements;
-            Reevaluate(LoggingService, _loadSettings);
+            return _data.EvaluatedItemElements;
         }
 
         private static IEnumerable<ProjectItemElement> GetItemElementsThatMightAffectItem(List<ProjectItemElement> evaluatedItemElements, ProjectItem item)

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -2659,14 +2659,17 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 yield return new object[]
                 {
                     @"
-                    <A Include=`a;b`/>
+                    <A Include=`a;b;a`/>
                     <A Update=`a`/>
                     <A Update=`b`/>
                     <A Include=`a;b`/>
                     ",
                     "a",
-                    1, // item 'a' from last include
+                    2, // item 'a' from last include
                     new ProvenanceResultTupleList()
+                    {
+                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1)
+                    }
                 };
 
                 // Nothing matches
@@ -2676,11 +2679,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     <A Include=`a;b;c`/>
                     <A Update=`c;*ab`/>
                     <A Remove=`b`/>
-                    <A Include=`a`/>
+                    <A Include=`a;a`/>
                     ",
                     "a",
                     0, // item 'a' from first include
                     new ProvenanceResultTupleList()
+                    {
+                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1)
+                    }
                 };
 
                 yield return new object[]
@@ -2688,7 +2694,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     @"
                     <A Remove=`a`/>
 
-                    <A Include=`a;b;c`/>
+                    <A Include=`a;b;c;a`/>
                     <A Update=`a`/>
                     <A Update=`b`/>
                     <B Update=`a`/>
@@ -2700,16 +2706,17 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     <B Update=`a`/>
                     <A Remove=`b`/>
 
-                    <A Include=`a`/>
+                    <A Include=`a;a`/>
                     <A Update=`a;a*`/>
                     <A Update=`b`/>
                     <B Update=`a`/>
                     <A Remove=`b`/>
                     ",
                     "a",
-                    1, // item 'a' from second include
+                    2, // item 'a' from second include
                     new ProvenanceResultTupleList
                     {
+                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1),
                         Tuple.Create("A", Operation.Update, Provenance.StringLiteral, 2),
                         Tuple.Create("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2)
                     }
@@ -2722,7 +2729,6 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void GetItemProvenanceByProjectItem(string items, string itemValue, int itemPosition, ProvenanceResultTupleList expected)
         {
             var formattedProject = string.Format(ProjectWithItemGroup, items);
-
             AssertProvenanceResult(expected, formattedProject, itemValue, itemPosition);
         }
 


### PR DESCRIPTION
CPS needs the overload to also include the include element that produced the item. 