### PR TITLE
Pull in DesignTime.targets in the crosstargeting build

### DIFF
--- a/setup/files.swr
+++ b/setup/files.swr
@@ -26,12 +26,14 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)Microsoft.Common.targets
   file source=$(X86BinPath)Microsoft.Common.tasks
   file source=$(X86BinPath)Microsoft.CSharp.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.CSharp.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.CSharp.targets
   file source=$(X86BinPath)Microsoft.NetFramework.CurrentVersion.props
   file source=$(X86BinPath)Microsoft.NetFramework.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.NetFramework.props
   file source=$(X86BinPath)Microsoft.NetFramework.targets
   file source=$(X86BinPath)Microsoft.VisualBasic.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.VisualBasic.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.VisualBasic.targets
   file source=$(X86BinPath)MSBuild.rsp
   file source=$(X86BinPath)Workflow.targets

--- a/setup/files.swr
+++ b/setup/files.swr
@@ -147,12 +147,14 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)Microsoft.Common.targets
   file source=$(X86BinPath)Microsoft.Common.tasks
   file source=$(X86BinPath)Microsoft.CSharp.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.CSharp.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.CSharp.targets
   file source=$(X86BinPath)Microsoft.NetFramework.CurrentVersion.props
   file source=$(X86BinPath)Microsoft.NetFramework.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.NetFramework.props
   file source=$(X86BinPath)Microsoft.NetFramework.targets
   file source=$(X86BinPath)Microsoft.VisualBasic.CurrentVersion.targets
+  file source=$(X86BinPath)Microsoft.VisualBasic.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.VisualBasic.targets
   file source=$(X86BinPath)MSBuild.rsp
   file source=$(X86BinPath)Workflow.targets

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -678,12 +678,14 @@
     </Content>
     <Content Include="Microsoft.Common.CrossTargeting.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <SubType>Designer</SubType>
     </Content>
     <Content Include="Microsoft.Common.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Microsoft.CSharp.CurrentVersion.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Microsoft.CSharp.CrossTargeting.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Microsoft.CSharp.targets">
@@ -702,6 +704,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Microsoft.VisualBasic.CurrentVersion.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Microsoft.VisualBasic.CrossTargeting.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Microsoft.VisualBasic.targets">
@@ -844,8 +849,10 @@
     </DataFile>
     <DataFile Include="Microsoft.CSharp.targets" />
     <DataFile Include="Microsoft.CSharp.CurrentVersion.targets" />
+    <DataFile Include="Microsoft.CSharp.CrossTargeting.targets" />
     <DataFile Include="Microsoft.VisualBasic.targets" />
     <DataFile Include="Microsoft.VisualBasic.CurrentVersion.targets" />
+    <DataFile Include="Microsoft.VisualBasic.CrossTargeting.targets" />
     <CopyFile Include="@(DataFile)">
       <DestFolder>$(SuiteBinPath)</DestFolder>
     </CopyFile>

--- a/src/XMakeTasks/Microsoft.CSharp.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.CSharp.CrossTargeting.targets
@@ -1,0 +1,23 @@
+<!--
+***********************************************************************************************
+Microsoft.CSharp.CrossTargeting.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+ 
+  <Import Project="Microsoft.Common.CrossTargeting.targets" />
+
+  <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
+  <PropertyGroup>
+     <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
+  </PropertyGroup>
+  <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
+
+</Project>

--- a/src/XMakeTasks/Microsoft.CSharp.targets
+++ b/src/XMakeTasks/Microsoft.CSharp.targets
@@ -19,7 +19,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    <!-- 
         We are doing a cross-targeting build if there is no list of target frameworks specified
         nor is there a current target framework being built individually. In that case, this import is
-        redirected to Microsoft.Common.CrossTargeting.targets.
+        redirected to Microsoft.CSharp.CrossTargeting.targets.
    -->
    <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
       <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
@@ -51,7 +51,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </When>
       <When Condition="'$(IsCrossTargetingBuild)' == 'true'">
          <PropertyGroup>
-            <CSharpTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets</CSharpTargetsPath>
+            <CSharpTargetsPath>$(MSBuildToolsPath)\Microsoft.CSharp.CrossTargeting.targets</CSharpTargetsPath>
           </PropertyGroup>
       </When>
       <Otherwise>

--- a/src/XMakeTasks/Microsoft.VisualBasic.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.VisualBasic.CrossTargeting.targets
@@ -1,0 +1,23 @@
+<!--
+***********************************************************************************************
+Microsoft.VisualBasic.CrossTargeting.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+ 
+  <Import Project="Microsoft.Common.CrossTargeting.targets" />
+
+  <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
+  <PropertyGroup>
+     <VisualBasicDesignTimeTargetsPath Condition="'$(VisualBasicDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.VisualBasic.DesignTime.targets</VisualBasicDesignTimeTargetsPath>
+  </PropertyGroup>
+  <Import Project="$(VisualBasicDesignTimeTargetsPath)" Condition="'$(VisualBasicDesignTimeTargetsPath)' != '' and Exists('$(VisualBasicDesignTimeTargetsPath)')" />
+
+</Project>

--- a/src/XMakeTasks/Microsoft.VisualBasic.targets
+++ b/src/XMakeTasks/Microsoft.VisualBasic.targets
@@ -20,7 +20,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- 
        We are doing a cross-targeting build if there is no list of target frameworks specified
        nor is there a current target framework being built individually. In that case, this import is
-       redirected to Microsoft.Common.CrossTargeting.targets.
+       redirected to Microsoft.VisualBasic.CrossTargeting.targets.
    -->
    <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
       <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
@@ -52,7 +52,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </When>
     <When Condition="'$(IsCrossTargetingBuild)' == 'true'">
       <PropertyGroup>
-        <VisualBasicTargetsPath>$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets</VisualBasicTargetsPath>
+        <VisualBasicTargetsPath>$(MSBuildToolsPath)\Microsoft.VisualBasic.CrossTargeting.targets</VisualBasicTargetsPath>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
When VS is installed it lays down a DesignTime.targets which tells the project system about the project (capabilities, msbuild rules etc.). This is pulled in by the common targets and so is available in the inner build. However it is also needed in the outer build to open a cross-targeting project in VS. When a project is opened, the CPS project system needs information like the project's capabilities, rules etc to initialize itself and without the design time targets that blows up. 

This change simply adds C# and VB cross-targeting targets and imports the designtime targets (if they exist).

@nguerrera @rainersigwald @cdmihai @AndyGerlicher 