### PR TITLE
Change the MSBuildProjectExtension mechanism to look for projectname …

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
@@ -111,7 +111,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     Import project extensions which usually come from packages.  Package management systems will create a file at:
-      $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.targets
+      $(MSBuildProjectExtensionsPath)\$(MSBuildProjectName).<SomethingUnique>.targets
 
     Each package management system should use a unique moniker to avoid collisions.  It is a wild-card iport so the package
     management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
@@ -124,7 +124,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.targets" Condition="'$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectName).*.targets" Condition="'$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
 
   <!-- TODO: https://github.com/Microsoft/msbuild/issues/1062: Remove this temporary hook when possible. -->
   <Import Project="$(CoreCrossTargetingTargetsPath)" 

--- a/src/XMakeTasks/Microsoft.Common.props
+++ b/src/XMakeTasks/Microsoft.Common.props
@@ -33,7 +33,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!-- 
         Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
-          $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.props
+          $(MSBuildProjectExtensionsPath)\$(MSBuildProjectName).<SomethingUnique>.props
           
         Each package management system should use a unique moniker to avoid collisions.  It is a wild-card import so the package
         management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
@@ -56,7 +56,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.props" Condition="'$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectName).*.props" Condition="'$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
 
   <!-- 
         Import wildcard "ImportBefore" props files if we're actually in a 12.0+ project (rather than a project being

--- a/src/XMakeTasks/Microsoft.Common.targets
+++ b/src/XMakeTasks/Microsoft.Common.targets
@@ -115,7 +115,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
       Prepare to import project extensions which usually come from packages.  Package management systems will create a file at:
-          $(MSBuildProjectExtensionsPath)\$(MSBuildProjectFile).<SomethingUnique>.targets
+          $(MSBuildProjectExtensionsPath)\$(MSBuildProjectName).<SomethingUnique>.targets
           
         Each package management system should use a unique moniker to avoid collisions.  It is a wild-card import so the package
         management system can write out multiple files but the order of the import is alphabetic because MSBuild sorts the list.
@@ -124,7 +124,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.targets" Condition="'$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectName).*.targets" Condition="'$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
 
   <PropertyGroup>
     <ImportDirectoryBuildTargets Condition="'$(ImportDirectoryBuildTargets)' == ''">true</ImportDirectoryBuildTargets>

--- a/src/XMakeTasks/UnitTests/ProjectExtensionsImportTestBase.cs
+++ b/src/XMakeTasks/UnitTests/ProjectExtensionsImportTestBase.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Build.UnitTests
     public abstract class ProjectExtensionsImportTestBase : IDisposable
     {
         protected readonly string _projectRelativePath = Path.Combine("src", "foo", "foo.csproj");
+        protected readonly string _projectName = "foo";
 
         protected ProjectExtensionsImportTestBase()
         {

--- a/src/XMakeTasks/UnitTests/ProjectExtensionsPropsImportTest.cs
+++ b/src/XMakeTasks/UnitTests/ProjectExtensionsPropsImportTest.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Build.UnitTests
     /// </summary>
     sealed public class ProjectExtensionsPropsImportTest : ProjectExtensionsImportTestBase
     {
-        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.props");
+        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", $"{_projectName}.custom.props");
 
-        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.props");
+        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "obj", $"{_projectName}.custom.props");
 
         protected override string PropertyNameToEnableImport => "ImportProjectExtensionProps";
 

--- a/src/XMakeTasks/UnitTests/ProjectExtensionsTargetsImportTest.cs
+++ b/src/XMakeTasks/UnitTests/ProjectExtensionsTargetsImportTest.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Build.UnitTests
     /// </summary>
     sealed public class ProjectExtensionsTargetsImportTest : ProjectExtensionsImportTestBase
     {
-        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.targets");
+        protected override string CustomImportProjectPath => Path.Combine(ObjectModelHelpers.TempProjectDir, "obj", $"{_projectName}.custom.targets");
 
-        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "obj", $"{Path.GetFileName(_projectRelativePath)}.custom.targets");
+        protected override string ImportProjectPath => Path.Combine(Path.GetDirectoryName(_projectRelativePath), "obj", $"{_projectName}.custom.targets");
 
         protected override string PropertyNameToEnableImport => "ImportProjectExtensionTargets";
 


### PR DESCRIPTION
…instead of projectfile

Using the projectfile means the file it imports is obj\foo.csproj.nuget.g.targets. It seems better to import obj\foo.nuget.g.targets (which is currently what nuget generates)