### PR TITLE
Support to remove unnecessary XML in project file

### DIFF
--- a/src/Shared/EncodingStringWriter.cs
+++ b/src/Shared/EncodingStringWriter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Shared
+{
+    /// <summary>
+    /// StringWriter class that allows Encoding to be specified. In the standard StringWriter
+    /// class only UTF16 is allowed.
+    /// </summary>
+    internal class EncodingStringWriter : StringWriter
+    {
+        /// <summary>
+        /// Default ctor (Encoding = UTF8)
+        /// </summary>
+        public EncodingStringWriter() : this(null)
+        { }
+
+        public EncodingStringWriter(Encoding encoding) : base(CultureInfo.InvariantCulture)
+        {
+            Encoding = encoding ?? Encoding.UTF8;
+        }
+
+        /// <summary>
+        /// Overload to specify encoding.
+        /// </summary>
+        public override Encoding Encoding { get; }
+    }
+}

--- a/src/Shared/ProjectWriter.cs
+++ b/src/Shared/ProjectWriter.cs
@@ -112,9 +112,8 @@ namespace Microsoft.Build.Shared
             }
 
             // don't write an XML declaration unless the project already has one or has non-default encoding
-            _writeXmlDeclaration =
-                ((projectRootElementDeclaration != null) ||
-                ((_documentEncoding != Encoding.UTF8) && (_documentEncoding != null)));
+            _writeXmlDeclaration = (projectRootElementDeclaration != null) ||
+                                   (_documentEncoding != null && !Equals(_documentEncoding, Encoding.UTF8));
         }
 
         /// <summary>
@@ -166,12 +165,25 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        /// <summary>
+        /// Override method in order to omit the xml declaration tag in certain cases. The tag will be written if:
+        ///  - The tag was present in the file/stream loaded.
+        ///  - The Encoding is specified and not default (UTF8)
+        /// </summary>
+        public override void WriteStartDocument()
+        {
+            if (_writeXmlDeclaration)
+            {
+                base.WriteStartDocument();
+            }
+        }
+
         #endregion
 
         // indicates whether an XML declaration e.g. <?xml version="1.0"?> will be written at the start of the project
         private bool _writeXmlDeclaration;
 
         // encoding of the document, if specified when constructing
-        private Encoding _documentEncoding = null;
+        private readonly Encoding _documentEncoding;
     }
 }

--- a/src/XMakeBuildEngine/Construction/ProjectElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectElement.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Build.Construction
             }
 
             // Ensure the element name itself matches.
-            this.ReplaceElement(XmlUtilities.RenameXmlElement(this.XmlElement, element.XmlElement.Name, XMakeAttributes.defaultXmlNamespace));
+            this.ReplaceElement(XmlUtilities.RenameXmlElement(this.XmlElement, element.XmlElement.Name, XmlElement.NamespaceURI));
 
             // Copy over the attributes from the template element.
             foreach (XmlAttribute attribute in element.XmlElement.Attributes)

--- a/src/XMakeBuildEngine/Construction/ProjectExtensionsElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectExtensionsElement.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Construction
                         return;
                     }
 
-                    idElement = XmlDocument.CreateElement(name, XMakeAttributes.defaultXmlNamespace);
+                    idElement = XmlDocument.CreateElement(name, XmlElement.NamespaceURI);
                     XmlElement.AppendChild(idElement);
                 }
 

--- a/src/XMakeBuildEngine/Construction/ProjectItemElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectItemElement.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Build.Construction
 
             // Because the element was created from our special XmlDocument, we know it's
             // an XmlElementWithLocation.
-            XmlElementWithLocation newElement = (XmlElementWithLocation)XmlUtilities.RenameXmlElement(XmlElement, newItemType, XMakeAttributes.defaultXmlNamespace);
+            XmlElementWithLocation newElement = (XmlElementWithLocation)XmlUtilities.RenameXmlElement(XmlElement, newItemType, XmlElement.NamespaceURI);
 
             ReplaceElement(newElement);
         }

--- a/src/XMakeBuildEngine/Construction/ProjectMetadataElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectMetadataElement.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.Construction
 
             // Because the element was created from our special XmlDocument, we know it's
             // an XmlElementWithLocation.
-            XmlElementWithLocation newElement = (XmlElementWithLocation)XmlUtilities.RenameXmlElement(XmlElement, newName, XMakeAttributes.defaultXmlNamespace);
+            XmlElementWithLocation newElement = (XmlElementWithLocation)XmlUtilities.RenameXmlElement(XmlElement, newName, XmlElement.NamespaceURI);
 
             ReplaceElement(newElement);
         }

--- a/src/XMakeBuildEngine/Construction/ProjectPropertyElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectPropertyElement.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Build.Construction
 
             // Because the element was created from our special XmlDocument, we know it's
             // an XmlElementWithLocation.
-            XmlElementWithLocation newElement = (XmlElementWithLocation)XmlUtilities.RenameXmlElement(XmlElement, newName, XMakeAttributes.defaultXmlNamespace);
+            XmlElementWithLocation newElement = (XmlElementWithLocation)XmlUtilities.RenameXmlElement(XmlElement, newName, XmlElement.NamespaceURI);
 
             ReplaceElement(newElement);
         }

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -197,12 +197,12 @@ namespace Microsoft.Build.Construction
             XmlReaderSettings xrs = new XmlReaderSettings();
             xrs.DtdProcessing = DtdProcessing.Ignore;
             
-            var emptryProjectFile = string.Format(EmptyProjectFileContent,
+            var emptyProjectFile = string.Format(EmptyProjectFileContent,
                 (projectFileOptions & NewProjectFileOptions.IncludeXmlDeclaration) != 0 ? EmptyProjectFileXmlDeclaration : string.Empty,
                 (projectFileOptions & NewProjectFileOptions.IncludeToolsVersion) != 0 ? EmptyProjectFileToolsVersion : string.Empty,
                 (projectFileOptions & NewProjectFileOptions.IncludeXmlNamespace) != 0 ? EmptyProjectFileXmlNamespace : string.Empty);
 
-            using (XmlReader xr = XmlReader.Create(new StringReader(emptryProjectFile), xrs))
+            using (XmlReader xr = XmlReader.Create(new StringReader(emptyProjectFile), xrs))
             {
                 document.Load(xr);
             }

--- a/src/XMakeBuildEngine/Construction/Solution/ProjectInSolution.cs
+++ b/src/XMakeBuildEngine/Construction/Solution/ProjectInSolution.cs
@@ -305,11 +305,8 @@ namespace Microsoft.Build.Construction
 
                 if (mainProjectElement != null && mainProjectElement.LocalName == "Project")
                 {
-                    if (String.Compare(mainProjectElement.NamespaceURI, XMakeAttributes.defaultXmlNamespace, StringComparison.OrdinalIgnoreCase) == 0)
-                    {
-                        _canBeMSBuildProjectFile = true;
-                        return _canBeMSBuildProjectFile;
-                    }
+                    _canBeMSBuildProjectFile = true;
+                    return _canBeMSBuildProjectFile;
                 }
             }
             // catch all sorts of exceptions - if we encounter any problems here, we just assume the project file is not

--- a/src/XMakeBuildEngine/Definition/NewProjectFileOptions.cs
+++ b/src/XMakeBuildEngine/Definition/NewProjectFileOptions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Flags to control options when creating a new, in memory, project.
+    /// </summary>
+    [Flags]
+    public enum NewProjectFileOptions
+    {
+        /// <summary>
+        /// Do not include any options.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Include the XML declaration element.
+        /// </summary>
+        IncludeXmlDeclaration = 1,
+
+        /// <summary>
+        /// Include the ToolsVersion attribute on the Project element.
+        /// </summary>
+        IncludeToolsVersion = 2,
+
+        /// <summary>
+        /// Include the default MSBuild namespace on the Project element.
+        /// </summary>
+        IncludeXmlNamespace = 4,
+
+        /// <summary>
+        /// Include all file options.
+        /// </summary>
+        IncludeAllOptions = ~0
+    }
+}

--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -33,43 +33,6 @@ using System.Globalization;
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
-    /// Flags for controlling the project load.
-    /// </summary>
-    /// <remarks>
-    /// This is a "flags" enum, allowing future settings to be added
-    /// in an additive, non breaking fashion.
-    /// </remarks>
-    [Flags]
-    [SuppressMessage("Microsoft.Design", "CA1008:EnumsShouldHaveZeroValue", Justification = "Public API.  'Default' is roughly equivalent to 'None'. ")]
-    public enum ProjectLoadSettings
-    {
-        /// <summary>
-        /// Normal load. This is the default.
-        /// </summary>
-        Default = 0,
-
-        /// <summary>
-        /// Ignore nonexistent targets files when evaluating the project
-        /// </summary>
-        IgnoreMissingImports = 1,
-
-        /// <summary>
-        /// Record imports including duplicate, but not circular, imports on the ImportsIncludingDuplicates property
-        /// </summary>
-        RecordDuplicateButNotCircularImports = 2,
-
-        /// <summary>
-        /// Throw an exception and stop the evaluation of a project if any circular imports are detected
-        /// </summary>
-        RejectCircularImports = 4,
-
-        /// <summary>
-        /// Record the item elements that got evaluated
-        /// </summary>
-        RecordEvaluatedItemElements = 8
-    }
-
-    /// <summary>
     /// Represents an evaluated project with design time semantics.
     /// Always backed by XML; can be built directly, or an instance can be cloned off to add virtual items/properties and build.
     /// Edits to this project always update the backing XML.
@@ -108,11 +71,6 @@ namespace Microsoft.Build.Evaluation
         /// Used such that even after unload and reload, the evaluation counter changes.
         /// </summary>
         private static int s_globalEvaluationCounter;
-
-        /// <summary>
-        /// Locking object.
-        /// </summary>
-        private static object s_locker = new Object();
 
         /// <summary>
         /// Backing data; stored in a nested class so it can be passed to the Evaluator to fill
@@ -170,12 +128,27 @@ namespace Microsoft.Build.Evaluation
         private RenameHandlerDelegate _renameHandler;
 
         /// <summary>
+        /// Default project template options (include all features).
+        /// </summary>
+        internal const NewProjectFileOptions DefaultNewProjectTemplateOptions = NewProjectFileOptions.IncludeAllOptions;
+
+        /// <summary>
         /// Construct an empty project, evaluating with the global project collection's
         /// global properties and default tools version.
         /// Project will be added to the global project collection when it is named.
         /// </summary>
         public Project()
-            : this(ProjectRootElement.Create(ProjectCollection.GlobalProjectCollection))
+            : this(DefaultNewProjectTemplateOptions)
+        {
+        }
+
+        /// <summary>
+        /// Construct an empty project, evaluating with the global project collection's
+        /// global properties and default tools version.
+        /// Project will be added to the global project collection when it is named.
+        /// </summary>
+        public Project(NewProjectFileOptions newProjectFileOptions)
+            : this(ProjectRootElement.Create(ProjectCollection.GlobalProjectCollection, newProjectFileOptions))
         {
         }
 
@@ -190,13 +163,34 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Construct an empty project, evaluating with the specified project collection's
+        /// global properties and default tools version.
+        /// Project will be added to the specified project collection when it is named.
+        /// </summary>
+        public Project(ProjectCollection projectCollection, NewProjectFileOptions newProjectFileOptions)
+            : this(ProjectRootElement.Create(projectCollection, newProjectFileOptions), null, null, projectCollection)
+        {
+        }
+
+        /// <summary>
         /// Construct an empty project, evaluating with the specified project collection and
         /// the specified global properties and default tools version, either of which may be null.
         /// Project will be added to the specified project collection when it is named.
         /// </summary>
         /// <param name="globalProperties">Global properties to evaluate with. May be null in which case the containing project collection's global properties will be used.</param>
         public Project(IDictionary<string, string> globalProperties, string toolsVersion, ProjectCollection projectCollection)
-            : this(ProjectRootElement.Create(projectCollection), globalProperties, toolsVersion, projectCollection)
+            : this(ProjectRootElement.Create(projectCollection, DefaultNewProjectTemplateOptions), globalProperties, toolsVersion, projectCollection)
+        {
+        }
+
+        /// <summary>
+        /// Construct an empty project, evaluating with the specified project collection and
+        /// the specified global properties and default tools version, either of which may be null.
+        /// Project will be added to the specified project collection when it is named.
+        /// </summary>
+        /// <param name="globalProperties">Global properties to evaluate with. May be null in which case the containing project collection's global properties will be used.</param>
+        public Project(IDictionary<string, string> globalProperties, string toolsVersion, ProjectCollection projectCollection, NewProjectFileOptions newProjectFileOptions)
+            : this(ProjectRootElement.Create(projectCollection, newProjectFileOptions), globalProperties, toolsVersion, projectCollection)
         {
         }
 

--- a/src/XMakeBuildEngine/Definition/ProjectLoadSettings.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectLoadSettings.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Flags for controlling the project load.
+    /// </summary>
+    /// <remarks>
+    /// This is a "flags" enum, allowing future settings to be added
+    /// in an additive, non breaking fashion.
+    /// </remarks>
+    [Flags]
+    [SuppressMessage("Microsoft.Design", "CA1008:EnumsShouldHaveZeroValue", Justification = "Public API.  'Default' is roughly equivalent to 'None'. ")]
+    public enum ProjectLoadSettings
+    {
+        /// <summary>
+        /// Normal load. This is the default.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Ignore nonexistent targets files when evaluating the project
+        /// </summary>
+        IgnoreMissingImports = 1,
+
+        /// <summary>
+        /// Record imports including duplicate, but not circular, imports on the ImportsIncludingDuplicates property
+        /// </summary>
+        RecordDuplicateButNotCircularImports = 2,
+
+        /// <summary>
+        /// Throw an exception and stop the evaluation of a project if any circular imports are detected
+        /// </summary>
+        RejectCircularImports = 4,
+
+        /// <summary>
+        /// Record the item elements that got evaluated
+        /// </summary>
+        RecordEvaluatedItemElements = 8
+    }
+}

--- a/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
@@ -162,9 +162,7 @@ namespace Microsoft.Build.Construction
             ProjectErrorUtilities.VerifyThrowInvalidProject(element.LocalName == XMakeElements.project, element.Location, "UnrecognizedElement", element.Name);
 
             // If a namespace was specified it must be the default MSBuild namespace.
-            if (element.Prefix.Length > 0 ||
-                (!string.Equals(element.NamespaceURI, XMakeAttributes.defaultXmlNamespace,
-                     StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(element.NamespaceURI)))
+            if (!ProjectXmlUtilities.VerifyValidProjectNamespace(element))
             {
                 ProjectErrorUtilities.ThrowInvalidProject(element.Location, "ProjectMustBeInMSBuildXmlNamespace",
                     XMakeAttributes.defaultXmlNamespace);

--- a/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
@@ -161,9 +161,17 @@ namespace Microsoft.Build.Construction
             ProjectErrorUtilities.VerifyThrowInvalidProject(element.Name != XMakeElements.visualStudioProject, element.Location, "ProjectUpgradeNeeded", _project.FullPath);
             ProjectErrorUtilities.VerifyThrowInvalidProject(element.LocalName == XMakeElements.project, element.Location, "UnrecognizedElement", element.Name);
 
-            if (element.Prefix.Length > 0 || !String.Equals(element.NamespaceURI, XMakeAttributes.defaultXmlNamespace, StringComparison.OrdinalIgnoreCase))
+            // If a namespace was specified it must be the default MSBuild namespace.
+            if (element.Prefix.Length > 0 ||
+                (!string.Equals(element.NamespaceURI, XMakeAttributes.defaultXmlNamespace,
+                     StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(element.NamespaceURI)))
             {
-                ProjectErrorUtilities.ThrowInvalidProject(element.Location, "ProjectMustBeInMSBuildXmlNamespace", XMakeAttributes.defaultXmlNamespace);
+                ProjectErrorUtilities.ThrowInvalidProject(element.Location, "ProjectMustBeInMSBuildXmlNamespace",
+                    XMakeAttributes.defaultXmlNamespace);
+            }
+            else
+            {
+                _project.XmlNamespace = element.NamespaceURI;
             }
 
             ParseProjectElement(element);

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -34,6 +34,9 @@
     <Compile Include="..\Shared\BuildEnvironmentHelper.cs">
       <Link>SharedUtilities\BuildEnvironmentHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\EncodingStringWriter.cs">
+      <Link>SharedUtilities\EncodingStringWriter.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -163,8 +166,10 @@
     <Compile Include="Collections\RetrievableEntryHashSet\HashHelpers.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Definition\NewProjectFileOptions.cs" />
     <Compile Include="Definition\ProjectCollectionChangedEventArgs.cs" />
     <Compile Include="Definition\ProjectImportPathMatch.cs" />
+    <Compile Include="Definition\ProjectLoadSettings.cs" />
     <Compile Include="Evaluation\ItemSpec.cs" />
     <Compile Include="Evaluation\ItemsAndMetadataPair.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.cs" />
@@ -646,20 +651,16 @@
     </Compile>
     <!-- Win32 RC Files -->
     <RCResourceFile Include="native.rc" />
-
     <!-- Resource Files -->
-
     <EmbeddedResource Include="Resources\Strings.resx">
       <LogicalName>$(AssemblyName).Strings.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-
     <EmbeddedResource Include="..\Shared\Resources\Strings.shared.resx">
       <Link>Resources\Strings.shared.resx</Link>
       <SubType>Designer</SubType>
       <LogicalName>$(AssemblyName).Strings.shared.resources</LogicalName>
     </EmbeddedResource>
-
     <!-- Assemblies Files we depend on -->
     <!-- Be conservative when adding references... adding System.Xml.Linq can add .47 sec cold start time to our launch time, or 80 ms to warm start time -->
     <Reference Include="System" />

--- a/src/XMakeBuildEngine/Resources/Strings.resx
+++ b/src/XMakeBuildEngine/Resources/Strings.resx
@@ -695,7 +695,7 @@
     <value>Done Building Project "{0}" (default targets) -- FAILED.</value>
   </data>
   <data name="ProjectMustBeInMSBuildXmlNamespace" UESanitized="false" Visibility="Public">
-    <value>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</value>
+    <value>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namspace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</value>
     <comment>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</comment>
   </data>

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/MSBuild_Tests.cs
@@ -1595,7 +1595,7 @@ namespace Microsoft.Build.UnitTests
                 Project project = new Project(projectFile2);
                 MockLogger logger = new MockLogger();
 
-                project.Build(logger);
+                Assert.True(project.Build(logger));
 
                 logger.AssertLogContains("[foo.out]");
             }
@@ -1631,7 +1631,7 @@ namespace Microsoft.Build.UnitTests
                 Project project = new Project(projectFile2);
                 MockLogger logger = new MockLogger();
 
-                project.Build(logger);
+                Assert.True(project.Build(logger));
 
                 logger.AssertLogContains("[foo.out]");
             }

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
@@ -203,6 +203,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             }
            );
         }
+
         /// <summary>
         /// Valid Xml, invalid namespace on the root
         /// </summary>
@@ -211,14 +212,11 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             Assert.Throws<InvalidProjectFileException>(() =>
             {
-                string content = @"
-                    <Project xmlns='XXX'/>
-                ";
-
+                var content = @"<Project xmlns='XXX'/>";
                 ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-            }
-           );
+            });
         }
+
         /// <summary>
         /// Invalid root tag
         /// </summary>

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/DefinitionEditing_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/DefinitionEditing_Tests.cs
@@ -613,7 +613,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </ItemGroup>
 </Project>");
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
         }
 
         /// <summary>
@@ -648,7 +648,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </ItemGroup>
 </Project>");
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
         }
 
         /// <summary>
@@ -893,7 +893,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </ItemGroup>
 </Project>");
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
         }
 
         /// <summary>
@@ -1208,7 +1208,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </ItemGroup>
 </Project>");
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
         }
 
         /// <summary>
@@ -1805,7 +1805,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </ItemGroup>
 </Project>");
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
 
             project.ReevaluateIfNecessary();
 

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/EditingElementsReferencedByOrReferences_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/EditingElementsReferencedByOrReferences_Tests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </ItemGroup>
 </Project>";
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
 
             project.ReevaluateIfNecessary();
             IEnumerable<ProjectItem> items = project.GetItems("I");
@@ -82,7 +82,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </ItemGroup>
 </Project>";
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </ItemGroup>
 </Project>";
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     </I>
   </ItemGroup>
 </Project>";
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     </I>
   </ItemGroup>
 </Project>";
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
 
             project.ReevaluateIfNecessary();
             item1 = project.GetItems("I").Where(i => i.EvaluatedInclude == "X").First();
@@ -262,7 +262,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     <I Include=""Y"" />
   </ItemGroup>
 </Project>";
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
 
             project.ReevaluateIfNecessary();
             item1 = project.GetItems("I").Where(i => i.EvaluatedInclude == "X").First();
@@ -300,7 +300,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     </I>
   </ItemGroup>
 </Project>";
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
 
             project.ReevaluateIfNecessary();
             item = project.GetItems("I").First();
@@ -334,7 +334,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
   </PropertyGroup>
 </Project>";
 
-            Helpers.VerifyAssertProjectContent(expected, project.Xml);
+            Helpers.VerifyAssertProjectContent(expected, project.Xml, false);
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectMetadata_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectMetadata_Tests.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Xml;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Shared;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests.OM.Definition
@@ -61,7 +62,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             Assert.Equal(true, project.IsDirty);
 
-            StringWriter writer = new StringWriter();
+            StringWriter writer = new EncodingStringWriter();
             projectXml.Save(writer);
 
             string expected = ObjectModelHelpers.CleanupFileContents(@"

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Engine.OM.UnitTests.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
@@ -2068,7 +2069,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             project.RemoveItems(project.GetItems("j").Take(2));
             Assert.Equal(3, project.Items.Count());
 
-            StringWriter writer = new StringWriter();
+            StringWriter writer = new EncodingStringWriter();
             project.Save(writer);
 
             string projectExpectedContents = ObjectModelHelpers.CleanupFileContents(@"

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -30,6 +30,9 @@
     <Compile Include="..\..\Shared\Constants.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\..\Shared\EncodingStringWriter.cs">
+      <Link>EncodingStringWriter.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/XMakeBuildEngine/Xml/ProjectXmlUtilities.cs
+++ b/src/XMakeBuildEngine/Xml/ProjectXmlUtilities.cs
@@ -94,10 +94,13 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static void VerifyThrowProjectValidNamespace(XmlElementWithLocation element)
         {
+            // If a namespace was specified it must be the default MSBuild namespace.
             if (element.Prefix.Length > 0 ||
-                !String.Equals(element.NamespaceURI, XMakeAttributes.defaultXmlNamespace, StringComparison.OrdinalIgnoreCase))
+                (!string.Equals(element.NamespaceURI, XMakeAttributes.defaultXmlNamespace,
+                     StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(element.NamespaceURI)))
             {
-                ProjectErrorUtilities.ThrowInvalidProject(element.Location, "CustomNamespaceNotAllowedOnThisChildElement", element.Name, element.ParentNode.Name);
+                ProjectErrorUtilities.ThrowInvalidProject(element.Location,
+                    "CustomNamespaceNotAllowedOnThisChildElement", element.Name, element.ParentNode.Name);
             }
         }
 

--- a/src/XMakeBuildEngine/Xml/ProjectXmlUtilities.cs
+++ b/src/XMakeBuildEngine/Xml/ProjectXmlUtilities.cs
@@ -95,13 +95,27 @@ namespace Microsoft.Build.Internal
         internal static void VerifyThrowProjectValidNamespace(XmlElementWithLocation element)
         {
             // If a namespace was specified it must be the default MSBuild namespace.
-            if (element.Prefix.Length > 0 ||
-                (!string.Equals(element.NamespaceURI, XMakeAttributes.defaultXmlNamespace,
-                     StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(element.NamespaceURI)))
+            if (!VerifyValidProjectNamespace(element))
             {
                 ProjectErrorUtilities.ThrowInvalidProject(element.Location,
-                    "CustomNamespaceNotAllowedOnThisChildElement", element.Name, element.ParentNode.Name);
+                    "CustomNamespaceNotAllowedOnThisChildElement", element.Name, element.ParentNode?.Name);
             }
+        }
+
+        /// <summary>
+        /// Verify that if a namespace is specified it matches the default MSBuild namespace.
+        /// </summary>
+        /// <param name="element">Element to check namespace.</param>
+        /// <returns>True when the namespace is in the MSBuild namespace or no namespace.</returns>
+        internal static bool VerifyValidProjectNamespace(XmlElementWithLocation element)
+        {
+            return
+                // Prefix must be empty
+                element.Prefix.Length == 0 &&
+
+                // Namespace must equal to the MSBuild namespace or empty
+                (string.Equals(element.NamespaceURI, XMakeAttributes.defaultXmlNamespace,
+                     StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(element.NamespaceURI));
         }
 
         /// <summary>


### PR DESCRIPTION
This change ended up being somewhat more involved than I had originally hoped, and I wish I would have made the changes atomically in separate commits but I didn't have time to go back and do that after the fact. Most of the complexity revolves around mismatch between what the intent of the code appeared to be and what it actually did. The biggest example being `_writeXmlDeclaration` which was calculated but not used. To get the behavior I wanted (not writing the XML declaration when `UTF8`), this had to be fixed. But of course unit tests were expecting the old behavior so many helper methods had to be changed. We also have a fair bit of complexity because we derive from XmlDocument base classes so we can't use many of the static Create methods that were likely added later that add functionality to make a lot of this much easier (i.e. `XmlWriterSettings.OmitXmlDeclaration` or `XmlWriterSettings.Encoding`).

* Added support for NewProjectFileOptions to specify which features should
  appear in a new in-memory project file. Default will include all options
  as it did in previous versions.

* In ProjectWriter.cs, there seemed to be intent to only write an XML
  declaration in certain cases, but it was not implemented. Added support
  to omit the XML declaration when the encoding is not the default (UTF8)
  and loaded project did not declare it.

* Removed requirements that the namespace be present. Changed calls to
  XmlDocument to use the namespace loaded from the document, which can now
  be the default MSBuild namespace or empty.

* Changed the RawXml method in ProjectRootElement.cs to use UTF8 by
  default. This appeared to be the intent in both the code
  (s_defaultEncoding == UTF8) and in the default XML declaration tag.
  However, StringWriter does not support an encoding other than UTF16.
  This caused the XML declaration to always be written as UTF16. This
  had a somewhat cascading effect on tests that use this method and
  no longer get an XML declaration tag. However, I believe that this is
  closer to the original intent as the input did not specify an xml
  declaration nor any indication that UTF16 should be used.

Resolves #699