### PR TITLE
Use property-format string in Import search paths

### DIFF
--- a/src/Shared/INodePacketTranslator.cs
+++ b/src/Shared/INodePacketTranslator.cs
@@ -291,13 +291,6 @@ namespace Microsoft.Build.BackEnd
             where T : class, INodePacketTranslatable;
 
         /// <summary>
-        /// Translates a dictionary of type { string, List {string} }
-        /// </summary>
-        /// <param name="dictionary">The dictionary to be translated.</param>
-        /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
-        void TranslateDictionaryList(ref Dictionary<string, List<string>> dictionary, IEqualityComparer<string> comparer);
-
-        /// <summary>
         /// Translates the boolean that says whether this value is null or not
         /// </summary>
         /// <param name="value">The object to test.</param>

--- a/src/Shared/NodePacketTranslator.cs
+++ b/src/Shared/NodePacketTranslator.cs
@@ -472,32 +472,6 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
-
-            /// <summary>
-            /// Translates a dictionary of type { string, List {string} }
-            /// </summary>
-            /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
-            public void TranslateDictionaryList(ref Dictionary<string, List<string>> dictionary, IEqualityComparer<string> comparer)
-            {
-                if (!TranslateNullable(dictionary))
-                {
-                    return;
-                }
-
-                int count = _reader.ReadInt32();
-                dictionary = new Dictionary<string, List<string>>(count, comparer);
-
-                for (int i = 0; i < count; i++)
-                {
-                    string key = null;
-                    Translate(ref key);
-                    List<string> value = null;
-                    Translate(ref value);
-                    dictionary[key] = value;
-                }
-            }
-
             /// <summary>
             /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
             /// </summary>
@@ -973,30 +947,6 @@ namespace Microsoft.Build.BackEnd
                     Translate(ref key);
                     T value = pair.Value;
                     Translate(ref value, valueFactory);
-                }
-            }
-
-            /// <summary>
-            /// Translates a dictionary of type { string, List {string} }
-            /// </summary>
-            /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
-            public void TranslateDictionaryList(ref Dictionary<string, List<string>> dictionary, IEqualityComparer<string> comparer)
-            {
-                if (!TranslateNullable(dictionary))
-                {
-                    return;
-                }
-
-                int count = dictionary.Count;
-                _writer.Write(count);
-
-                foreach (KeyValuePair<string, List<string>> pair in dictionary)
-                {
-                    string key = pair.Key;
-                    Translate(ref key);
-                    List<string> value = pair.Value;
-                    Translate(ref value);
                 }
             }
 

--- a/src/XMakeBuildEngine/Definition/ProjectImportPathMatch.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectImportPathMatch.cs
@@ -3,39 +3,60 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
-    /// Struct representing a reference to a project import path with property fall-back
+    /// Class representing a reference to a project import path with property fall-back
     /// </summary>
-    internal struct ProjectImportPathMatch
+    internal class ProjectImportPathMatch : INodePacketTranslatable
     {
         /// <summary>
         /// ProjectImportPathMatch instance representing no fall-back
         /// </summary>
         public static readonly ProjectImportPathMatch None = new ProjectImportPathMatch(string.Empty, new List<string>());
 
-        internal ProjectImportPathMatch(string propertyName, IEnumerable<string> searchPaths)
+        internal ProjectImportPathMatch(string propertyName, List<string> searchPaths)
         {
             PropertyName = propertyName;
             SearchPaths = searchPaths;
             MsBuildPropertyFormat = $"$({PropertyName})";
         }
 
+        public ProjectImportPathMatch(INodePacketTranslator translator)
+        {
+            ((INodePacketTranslatable)this).Translate(translator);
+        }
+
         /// <summary>
         /// String representation of the property reference - eg. "MSBuildExtensionsPath32"
         /// </summary>
-        public string PropertyName { get; }
+        public string PropertyName;
 
         /// <summary>
         /// Returns the corresponding property name - eg. "$(MSBuildExtensionsPath32)"
         /// </summary>
-        public string MsBuildPropertyFormat { get; }
+        public string MsBuildPropertyFormat;
 
         /// <summary>
         /// Enumeration of the search paths for the property.
         /// </summary>
-        public IEnumerable<string> SearchPaths { get; }
+        public List<string> SearchPaths;
+
+        public void Translate(INodePacketTranslator translator)
+        {
+            translator.Translate(ref PropertyName);
+            translator.Translate(ref MsBuildPropertyFormat);
+            translator.Translate(ref SearchPaths);
+        }
+
+        /// <summary>
+        /// Factory for serialization.
+        /// </summary>
+        internal static ProjectImportPathMatch FactoryForDeserialization(INodePacketTranslator translator)
+        {
+            return new ProjectImportPathMatch(translator);
+        }
     }
 }

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Cached values of tools version -> project import search paths table
         /// </summary>
-        private readonly Dictionary<string, Dictionary<string, List<string>>> _projectImportSearchPathsCache;
+        private readonly Dictionary<string, Dictionary<string, ProjectImportPathMatch>> _projectImportSearchPathsCache;
 
         /// <summary>
         /// Default constructor
@@ -67,7 +67,7 @@ namespace Microsoft.Build.Evaluation
         {
             ErrorUtilities.VerifyThrowArgumentNull(readApplicationConfiguration, "readApplicationConfiguration");
             _readApplicationConfiguration = readApplicationConfiguration;
-            _projectImportSearchPathsCache = new Dictionary<string, Dictionary<string, List<string>>>(StringComparer.OrdinalIgnoreCase);
+            _projectImportSearchPathsCache = new Dictionary<string, Dictionary<string, ProjectImportPathMatch>>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -195,9 +195,9 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Returns a map of project property names / list of search paths for the specified toolsVersion and os
         /// </summary>
-        protected override Dictionary<string, List<string>> GetProjectImportSearchPathsTable(string toolsVersion, string os)
+        protected override Dictionary<string, ProjectImportPathMatch> GetProjectImportSearchPathsTable(string toolsVersion, string os)
         {
-            Dictionary<string, List<string>> kindToPathsCache;
+            Dictionary<string, ProjectImportPathMatch> kindToPathsCache;
             var key = toolsVersion + ":" + os;
             if (_projectImportSearchPathsCache.TryGetValue(key, out kindToPathsCache))
             {
@@ -205,7 +205,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             // Read and populate the map
-            kindToPathsCache = new Dictionary<string, List<string>>();
+            kindToPathsCache = new Dictionary<string, ProjectImportPathMatch>();
             _projectImportSearchPathsCache[key] = kindToPathsCache;
 
             ToolsetElement toolsetElement = ConfigurationSection.Toolsets.GetElement(toolsVersion);
@@ -223,9 +223,9 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Returns a list of the search paths for a given search path property collection
         /// </summary>
-        private Dictionary<string, List<string>> ComputeDistinctListOfSearchPaths(ToolsetElement.PropertyElementCollection propertyCollection)
+        private Dictionary<string, ProjectImportPathMatch> ComputeDistinctListOfSearchPaths(ToolsetElement.PropertyElementCollection propertyCollection)
         {
-            var pathsTable = new Dictionary<string, List<string>>();
+            var pathsTable = new Dictionary<string, ProjectImportPathMatch>();
 
             foreach (ToolsetElement.PropertyElement property in propertyCollection)
             {
@@ -239,7 +239,7 @@ namespace Microsoft.Build.Evaluation
                     property.Value.Split(new[] {_separatorForExtensionsPathSearchPaths},
                         StringSplitOptions.RemoveEmptyEntries).Distinct();
 
-                pathsTable.Add(property.Name, paths.ToList());
+                pathsTable.Add(property.Name, new ProjectImportPathMatch(property.Name, paths.ToList()));
             }
 
             return pathsTable;

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
         /// </summary>
-        protected abstract Dictionary<string, List<string>> GetProjectImportSearchPathsTable(string toolsVersion, string os);
+        protected abstract Dictionary<string, ProjectImportPathMatch> GetProjectImportSearchPathsTable(string toolsVersion, string os);
 
         /// <summary>
         /// Reads all the toolsets and populates the given ToolsetCollection with them

--- a/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
@@ -292,9 +292,9 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
         /// </summary>
-        protected override Dictionary<string, List<string>> GetProjectImportSearchPathsTable(string toolsVersion, string os)
+        protected override Dictionary<string, ProjectImportPathMatch> GetProjectImportSearchPathsTable(string toolsVersion, string os)
         {
-            return new Dictionary<string, List<string>>();
+            return new Dictionary<string, ProjectImportPathMatch>();
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -566,7 +566,7 @@ namespace Microsoft.Build.UnitTests.Definition
             string defaultOverrideToolsVersion = null;
             string defaultToolsVersion = reader.ReadToolsets(toolsets, new PropertyDictionary<ProjectPropertyInstance>(), new PropertyDictionary<ProjectPropertyInstance>(), true, out msbuildOverrideTasksPath, out defaultOverrideToolsVersion);
 
-            Dictionary<string, List<string>> pathsTable = toolsets["2.0"].ImportPropertySearchPathsTable;
+            Dictionary<string, ProjectImportPathMatch> pathsTable = toolsets["2.0"].ImportPropertySearchPathsTable;
 #if XPLAT
             if (NativeMethodsShared.IsWindows)
 #endif
@@ -587,15 +587,15 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
         }
 
-        private void CheckPathsTable(Dictionary<string, List<string>> pathsTable, string kind, string[] expectedPaths)
+        private void CheckPathsTable(Dictionary<string, ProjectImportPathMatch> pathsTable, string kind, string[] expectedPaths)
         {
             Assert.True(pathsTable.ContainsKey(kind));
             var paths = pathsTable[kind];
-            Assert.Equal(paths.Count, expectedPaths.Length);
+            Assert.Equal(paths.SearchPaths.Count, expectedPaths.Length);
 
-            for (int i = 0; i < paths.Count; i ++)
+            for (int i = 0; i < paths.SearchPaths.Count; i ++)
             {
-                Assert.Equal(paths[i], expectedPaths[i]);
+                Assert.Equal(paths.SearchPaths[i], expectedPaths[i]);
             }
         }
 

--- a/src/XMakeBuildEngine/UnitTests/Definition/Toolset_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/Toolset_Tests.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Build.UnitTests.Definition
             subToolsets.Add("dogfood", new SubToolset("dogfood", subToolsetProperties));
 
             Toolset t = new Toolset("4.0", "c:\\bar", buildProperties, environmentProperties, globalProperties,
-                subToolsets, "c:\\foo", "4.0", new Dictionary<string, List<string>>
+                subToolsets, "c:\\foo", "4.0", new Dictionary<string, ProjectImportPathMatch>
                 {
-                    ["MSBuildExtensionsPath"] = new List<string> {@"c:\foo"}
+                    ["MSBuildExtensionsPath"] = new ProjectImportPathMatch("MSBuildExtensionsPath", new List<string> {@"c:\foo"})
                 });
 
             ((INodePacketTranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
@@ -142,7 +142,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             Assert.NotNull(t2.ImportPropertySearchPathsTable);
             Assert.Equal(1, t2.ImportPropertySearchPathsTable.Count);
-            Assert.Equal(@"c:\foo", t2.ImportPropertySearchPathsTable["MSBuildExtensionsPath"][0]);
+            Assert.Equal(@"c:\foo", t2.ImportPropertySearchPathsTable["MSBuildExtensionsPath"].SearchPaths[0]);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1056 by using `ProjectImportPathMatch`'s already-precomputed string
field that represents the string to search for in an Import. Computing it
every time through `GetProjectImportSearchPaths` was wasteful.

This required a number of changes:
 * Converted `ProjectImportPathMatch` to a class so it could be passed by
   reference, so it could be
 * Passed by reference to a translator so it could be
 * Made `INodePacketTranslatable` so it could be
 * Used in the toolset directly.

Since I removed the only use of `TranslateDictionaryList`, I deleted it
from both the interface and implementation of `NodePacketTranslator`.