### PR TITLE
Archive `init-tools.log` in CI builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -70,7 +70,7 @@ def project = GithubProject
             Utilities.standardJobSetup(newJob, project, isPR, branch)
             // Add archiving of logs (even if the build failed)
             Utilities.addArchival(newJob,
-                                  'msbuild*.log,**/Microsoft.*.UnitTests.dll_*', /* filesToArchive */
+                                  'init-tools.log,msbuild*.log,**/Microsoft.*.UnitTests.dll_*', /* filesToArchive */
                                   '', /* filesToExclude */
                                   false, /* doNotFailIfNothingArchived */
                                   false, /* archiveOnlyIfSuccessful */)


### PR DESCRIPTION
This will make it easier to diagnose CI build failures that happen during
init--currently there's a message printed to stderr that says to look at a
file that's already deleted.