### PR TITLE
Separate Xlf file syncing from localized builds

### DIFF
--- a/build/LocalizationTasks/EmitLocalizedResources.cs
+++ b/build/LocalizationTasks/EmitLocalizedResources.cs
@@ -114,8 +114,7 @@ namespace Microsoft.Build.LocalizationTasks
 
         private static string GetCultureCodeFromPath(string localizedResourcePath)
         {
-            return Path.GetExtension(Path.GetFileNameWithoutExtension(localizedResourcePath)).Substring(1);
-                // remove the . at the beginning
+            return Path.GetExtension(Path.GetFileNameWithoutExtension(localizedResourcePath)).Substring(1); // remove the . at the beginning
         }
     }
 }

--- a/build/dirs.proj
+++ b/build/dirs.proj
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <Project Include="LocalizationTasks\Microsoft.Build.LocalizationTasks.csproj"
-             Condition="'$(FullFrameworkBuild)' == 'true' and '$(LocalizedBuild)' == 'true'" />
+             Condition="'$(FullFrameworkBuild)' == 'true' and '$(LocalizationBuildAssetsRequired)' == 'true'" />
   </ItemGroup>
 
   <Import Project="..\dir.traversal.targets" />

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -8,6 +8,7 @@ if /i "%1"=="--target" set TARGET=%2&& shift && shift && goto parseArguments
 if /i "%1"=="--host" set HOST=%2&& shift && shift && goto parseArguments
 if /i "%1"=="--bootstrap-only" set BOOTSTRAP_ONLY=true&& shift && goto parseArguments
 if /i "%1"=="--localized-build" set LOCALIZED_BUILD=true&& shift && goto parseArguments
+if /i "%1"=="--sync-xlf" set SYNC_XLF=true&& shift && goto parseArguments
 
 :: Unknown parameters
 goto :usage
@@ -64,6 +65,11 @@ if "%LOCALIZED_BUILD%"=="true" (
     set LOCALIZED_BUILD_ARGUMENT="/p:LocalizedBuild=true"
 )
 
+set SYNC_XLF_ARGUMENT=
+if "%SYNC_XLF%"=="true" (
+    set SYNC_XLF_ARGUMENT="/p:SyncXlf=true"
+)
+
 :: Restore build tools
 call %~dp0init-tools.cmd
 
@@ -71,7 +77,7 @@ echo.
 echo ** Rebuilding MSBuild with downloaded binaries
 
 set MSBUILDLOGPATH=%~dp0msbuild_bootstrap_build.log
-call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%BUILD_CONFIGURATION% /p:"SkipBuildPackages=true" %LOCALIZED_BUILD_ARGUMENT%
+call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%BUILD_CONFIGURATION% /p:"SkipBuildPackages=true" %LOCALIZED_BUILD_ARGUMENT% %SYNC_XLF_ARGUMENT%
 
 if %ERRORLEVEL% NEQ 0 (
     echo.
@@ -142,6 +148,7 @@ echo   --target ^<target^>              CoreCLR or Desktop ^(default: Desktop^)
 echo   --host ^<host^>                  CoreCLR or Desktop ^(default: Desktop^)
 echo   --bootstrap-only                 Do not rebuild msbuild with local binaries
 echo   --localized-build                Do a localized build
+echo   --sync-xlf                       Synchronize xlf files from resx files
 exit /b 1
 
 :error

--- a/dir.props
+++ b/dir.props
@@ -22,6 +22,11 @@
     <IncludeNuGetImports Condition="'$(IncludeNuGetImports)' == ''">false</IncludeNuGetImports>
   </PropertyGroup>
 
+  <!-- Localization switches -->
+  <PropertyGroup>
+    <LocalizationBuildAssetsRequired Condition="'$(LocalizedBuild)' == 'true' or '$(SyncXlf)' == 'true'">true</LocalizationBuildAssetsRequired>
+  </PropertyGroup>
+
   <PropertyGroup>
     <SerializeProjects>false</SerializeProjects>
   </PropertyGroup>

--- a/src/UpdateLocalizedResources.targets
+++ b/src/UpdateLocalizedResources.targets
@@ -1,73 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="UpdateXlf" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
-  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" Condition="$(LocalizedBuild) == 'true'" TaskName="SaveXlfToResx"/>
-  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" Condition="$(LocalizedBuild) == 'true'" TaskName="UpdateXlfFromResx"/>
-  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" Condition="$(LocalizedBuild) == 'true'" TaskName="EmitLocalizedResources"/>
+  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" TaskName="SaveXlfToResx"/>
+  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" TaskName="UpdateXlfFromResx"/>
+  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" TaskName="EmitLocalizedResources"/>
 
-  <!-- Emit the localized EmbeddedResource items before the common targets start using them -->
-  <Target Name="EmitLocalizedResources"
-          BeforeTargets="$(PrepareResourceNamesDependsOn);PrepareResourceNames">
+  <Target Name="AddLocalizedResxFilesToEmbeddedResource"
+          BeforeTargets="$(PrepareResourcesDependsOn);PrepareResources"
+          DependsOnTargets="SyncXlf;GenerateLocalizedResxResourcesFromXlf;AddEnglishResxFilesToEmbeddedResource"
+          Condition="'$(LocalizedBuild)' == 'true'">
+
     <ItemGroup>
-      <NeutralResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resx'"/> 
+      <!-- The depending targets generate and materialize localized resx files in @(LocalizedResxResources) -->
+      <EmbeddedResource Include="@(LocalizedResxResources)"/>
     </ItemGroup>
-
-    <EmitLocalizedResources 
-      NeutralResources="@(NeutralResources)"
-      AssemblyName="$(AssemblyName)"
-      LocalizedResxRoot="$(IntermediateOutputPath)"
-      RelativePathToXlfRoot=".\xlf\">
-
-      <Output TaskParameter="ResolvedXlfResources" ItemName="XlfFiles" />
-      <Output TaskParameter="ResolvedLocalizedResxResources" ItemName="EmbeddedResource" />
-
-    </EmitLocalizedResources>
   </Target>
 
-  <!-- The default english resources do not have corresponding xlf files. Simply copy them and add en in the name 
-       Can't have english xlf (for uniformity) because the xlf sync code only updates the <source> tags, not the <target> targ.
-       That would cause the english xlf files to become out of date
-
-       This target needs to run after EmitLocalizedResource, otherwise the copied intermediary files would leak into NeutralResource
-  -->
-  <Target Name="UpdateLocalizedResxForEnglishResx"
-          BeforeTargets="$(PrepareResourceNamesDependsOn);PrepareResourceNames"
-          AfterTargets="EmitLocalizedResources">
-
-      <ItemGroup>
-        <EnglishResources Include="@(NeutralResources -> '$(IntermediateOutputPath)%(Filename).en%(Extension)')"/>
-      </ItemGroup>
-
-      <Copy
-        SourceFiles="@(NeutralResources)"
-        DestinationFiles="@(EnglishResources)"
-      />
-
-      <ItemGroup>
-        <EmbeddedResource Include="@(EnglishResources)">
-          <LogicalName>$(AssemblyName).%(FileName).resources</LogicalName>
-        </EmbeddedResource>
-      </ItemGroup>      
-
-  </Target>
-
-  <Target Name="UpdateXlf"
-          BeforeTargets="CoreResGen"
-          AfterTargets="SplitResourcesByCulture"
-          DependsOnTargets="EmitLocalizedResources;UpdateLocalizedResxForEnglishResx" 
-          Condition="$(LocalizedBuild) == 'true' and $(IsTestProject) != 'true'">
-    
-    <UpdateXlfFromResx
-      Condition="%(Identity) != ''"
-      ResxPath="%(NeutralResx)"
-      XlfPath="@(XlfFiles)"
-    />
-
-  </Target>
-
-  <Target Name="ConvertXlfToLocalizedResx"
-          AfterTargets="UpdateXlf"
-          BeforeTargets="CoreResGen">
+  <!-- Materialize the contents of the localized resx files from their corresponding xlf files -->
+  <Target Name="GenerateLocalizedResxResourcesFromXlf"
+          DependsOnTargets="EmitLocalizedResources" >
 
     <SaveXlfToResx
       Condition="%(Identity) != ''"
@@ -79,7 +30,74 @@
 
   </Target>
 
-    <!-- Copy paste and modify OpenSourceSign from sign.targets because it only signs the main assembly 
+  <!-- The default english resources do not have corresponding xlf files. Simply copy them and add en in the name 
+       Can't have english xlf (for uniformity) because the xlf sync code only updates the <source> tags, not the <target> targ.
+       That would cause the english xlf files to become out of date
+
+       This target needs to run after EmitLocalizedResource, otherwise the copied intermediary files would leak into NeutralResource
+  -->
+  <Target Name="AddEnglishResxFilesToEmbeddedResource"
+          DependsOnTargets="EmitLocalizedResources">
+
+      <ItemGroup>
+        <EnglishResources Include="@(NeutralResources -> '$(IntermediateOutputPath)%(Filename).en%(Extension)')"/>
+      </ItemGroup>
+
+      <Copy
+        SourceFiles="@(NeutralResources)"
+        DestinationFiles="@(EnglishResources)"
+      />
+
+      <ItemGroup>
+        <LocalizedResxResources Include="@(EnglishResources)">
+          <LogicalName>$(AssemblyName).%(FileName).resources</LogicalName>
+        </LocalizedResxResources>
+      </ItemGroup>      
+
+  </Target>
+
+  <!-- 
+    [IN]
+    @(EmbeddedResource)
+
+    [OUT]
+    @(NeutralResources) - base resources that contain the English strings
+    @(XlfFiles) - Location of xlf files relative to their companion neutral resource
+    @(LocalizedResxResources) - Location of generated resx files. Each xlf file will generate one or more localized resx file
+  -->
+  <Target Name="EmitLocalizedResources"
+          BeforeTargets="$(PrepareResourcesDependsOn);PrepareResources">
+
+    <ItemGroup>
+      <NeutralResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resx'"/> 
+    </ItemGroup>
+
+    <EmitLocalizedResources 
+      NeutralResources="@(NeutralResources)"
+      AssemblyName="$(AssemblyName)"
+      LocalizedResxRoot="$(IntermediateOutputPath)"
+      RelativePathToXlfRoot=".\xlf\">
+
+      <Output TaskParameter="ResolvedXlfResources" ItemName="XlfFiles" />
+      <Output TaskParameter="ResolvedLocalizedResxResources" ItemName="LocalizedResxResources" />
+
+    </EmitLocalizedResources>
+  </Target>
+
+  <Target Name="SyncXlf"
+          BeforeTargets="Build"
+          DependsOnTargets="EmitLocalizedResources" 
+          Condition="$(SyncXlf) == 'true' and $(IsTestProject) != 'true'">
+    
+    <UpdateXlfFromResx
+      Condition="%(Identity) != ''"
+      ResxPath="%(NeutralResx)"
+      XlfPath="@(XlfFiles)"
+    />
+
+  </Target>
+
+  <!-- Copy paste and modify OpenSourceSign from sign.targets because it only signs the main assembly 
   and provides no extension mechanism to add more assemblies to it
   
   If satellite assemblies do not get their delay sign bit switched off, the main assemblies won't load them

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -82,7 +82,7 @@
   </PropertyGroup>
 
   <!-- Update localized resources from the default English ones-->
-  <Import Project="UpdateLocalizedResources.targets" Condition="'$(LocalizedBuild)' == 'true' and '$(IsTestProject)' != 'true' and '$(DoNotLocalizeProject)' != 'true'"/>
+  <Import Project="UpdateLocalizedResources.targets" Condition="'$(LocalizationBuildAssetsRequired)' == 'true' and '$(IsTestProject)' != 'true' and '$(DoNotLocalizeProject)' != 'true'"/>
 
   <!-- Restore packages -->
   <PropertyGroup>


### PR DESCRIPTION
This improves development experience: ideally, we'd want devs to always produce satellites. If satellite production also updates xlf files, then this produces lots of unwanted diffs (if the dev does not want to commit xlf changes).
