### PR TITLE
Fix package creation

### DIFF
--- a/build/NuGetPackages/CreateNuGetPackages.proj
+++ b/build/NuGetPackages/CreateNuGetPackages.proj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\.., dir.props))\dir.props" />
 
   <Import Project="$(SourceDir)BuildValues.props" />
   


### PR DESCRIPTION
For some reason this broke but it shouldn't be importing the parent dir.props because it overrides $(BaseOutputPath)