### PR TITLE
Bring back older packages

### DIFF
--- a/build/NuGetPackages/CreateNuGetPackages.proj
+++ b/build/NuGetPackages/CreateNuGetPackages.proj
@@ -24,15 +24,7 @@
   <Import Project="$(GitVersioningDir)dotnet\Nerdbank.GitVersioning.targets" />
   
   <ItemGroup>
-    <Project Include="$(RepoRoot)\ref\net46\**\*.csproj">
-      <Properties>Configuration=$(Configuration)</Properties>
-    </Project>
-    <Project Include="$(RepoRoot)\ref\netstandard1.3\**\*.csproj">
-      <Properties>Configuration=$(Configuration)-NetCore</Properties>
-    </Project>
-
     <NuSpecs Include="*.nuspec" />
-
   </ItemGroup>
 
   <PropertyGroup Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'">

--- a/build/NuGetPackages/CreateNuGetPackages.proj
+++ b/build/NuGetPackages/CreateNuGetPackages.proj
@@ -24,7 +24,15 @@
   <Import Project="$(GitVersioningDir)dotnet\Nerdbank.GitVersioning.targets" />
   
   <ItemGroup>
+    <Project Include="$(RepoRoot)\ref\net46\**\*.csproj">
+      <Properties>Configuration=$(Configuration)</Properties>
+    </Project>
+    <Project Include="$(RepoRoot)\ref\netstandard1.3\**\*.csproj">
+      <Properties>Configuration=$(Configuration)-NetCore</Properties>
+    </Project>
+
     <NuSpecs Include="*.nuspec" />
+
   </ItemGroup>
 
   <PropertyGroup Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'">

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -71,7 +71,7 @@ echo.
 echo ** Rebuilding MSBuild with downloaded binaries
 
 set MSBUILDLOGPATH=%~dp0msbuild_bootstrap_build.log
-call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%BUILD_CONFIGURATION% %LOCALIZED_BUILD_ARGUMENT%
+call "%~dp0build.cmd" /t:Rebuild /p:Configuration=%BUILD_CONFIGURATION% /p:"SkipBuildPackages=true" %LOCALIZED_BUILD_ARGUMENT%
 
 if %ERRORLEVEL% NEQ 0 (
     echo.

--- a/dir.props
+++ b/dir.props
@@ -103,6 +103,15 @@
     <NuGetToolPath Condition="'$(NuGetToolPath)'==''">$([System.IO.Path]::Combine($(NuGetDir), "NuGet.exe"))</NuGetToolPath>
   </PropertyGroup>
 
+  <!-- Copy the "_._" file to the output directory, which is used by the NuSpecs to indicate an empty folder -->
+  <ItemGroup>
+    <None Include="$(SourceDir)\nuget\_._">
+      <Link>_._</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+  </ItemGroup>
+
   <!-- Set default Configuration and Platform -->
   <PropertyGroup Condition="'$(Configuration)' ==''">
     <Configuration Condition="'$(OS)' == 'Windows_NT'">Debug</Configuration>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -31,4 +31,40 @@
   <Import Project="$(ToolsDir)BuildVersion.targets" Condition="Exists('$(ToolsDir)BuildVersion.targets')" />
   <Import Project="$(ToolsDir)versioning.targets" Condition="Exists('$(ToolsDir)versioning.targets')" />
 
+  <PropertyGroup>
+    <SkipVersionGeneration>true</SkipVersionGeneration>
+    <BaseVersion>0.1.0-preview</BaseVersion>
+    <BuildNumberMajor>$(RevisionNumber)</BuildNumberMajor>
+    <BuildNumberMinor>$([System.DateTime]::Now.ToString(`yMMdd`))</BuildNumberMinor>
+
+    <!-- The version for msbuild nuget packages. Used by packages.targets:AddNuGetPackageVersionMetadataToNuspecs -->
+    <PackageVersion>$(BaseVersion)-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
+
+    <!-- Turn off the automated package generation in packages.targets:AddNuGetPackageVersionMetadataToNuspecs and use the above PackageVersion-->
+    <DoNotGeneratePackageVersion>true</DoNotGeneratePackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Used by packages.targets:BuildPackages to inject properties into the nuspec-->
+    <NuspecProperties Include="version=$(PackageVersion)"/>
+    <NuspecProperties Include="targetmsbuildtoolsversion=$(TargetMSBuildToolsVersion)"/>
+  </ItemGroup>
+
+  <Import Project="$(ToolsDir)packages.targets" Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'" />
+
+  <PropertyGroup Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'">
+    <TraversalBuildDependsOn>
+      $(TraversalBuildDependsOn);
+      BuildPackages;
+    </TraversalBuildDependsOn>
+  </PropertyGroup>
+
+  <!-- Workaround to remove items from PackagesNuSpecFiles (defined in packages.targets). This ItemGroup
+       is defined with a wildcard Include and no way to override. -->
+  <Target Name="RemovePackages" BeforeTargets="BuildPackages" Condition="$(FullFrameworkBuild) != 'true'" >
+    <ItemGroup>
+        <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.Engine.nuspec;$(SourceDir)nuget\Microsoft.Build.Conversion.Core.nuspec" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/nuget/MSBuild.nuspec
+++ b/src/nuget/MSBuild.nuspec
@@ -13,7 +13,11 @@
     <summary>MSBuild APIs</summary>
     <description>
       This package includes APIs that support writing MSBuild tasks.
+      NOTE: This package is deprecated.  Please move to the Microsoft.Build.Runtime 15.1.X package available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
     </description>
+    <releaseNotes>
+      NOTE: This package is deprecated.  Please move to the Microsoft.Build.Runtime 15.1.X package available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
+    </releaseNotes>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/nuget/MSBuild.nuspec
+++ b/src/nuget/MSBuild.nuspec
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>MSBuild</id>
+    <version>0.1.0-preview</version>
+    <title>MSBuild APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>MSBuild APIs</summary>
+    <description>
+      This package includes APIs that support writing MSBuild tasks.
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.Build.Framework" />
+        <dependency id="Microsoft.Build" />
+        <dependency id="Microsoft.Build.Utilities.Core" />
+        <dependency id="Microsoft.Build.Tasks.Core" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.AppContext" version="4.1.0" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Collections.Concurrent" version="4.0.12" />
+        <dependency id="System.Collections.NonGeneric" version="4.0.1" />
+        <dependency id="System.Console" version="4.0.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.FileVersionInfo" version="4.0.0" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.IO.FileSystem" version="4.0.1" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />
+        <dependency id="System.IO.Pipes" version="4.0.0" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1" />
+        <dependency id="System.Reflection.Metadata" version="1.3.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Runtime.Handles" version="4.0.1" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Runtime.Loader" version="4.0.0" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.11" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Threading.ThreadPool" version="4.0.10" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="_._" target="lib\netstandard1.3" />
+    <file src="MSBuild.exe" target="runtimes\any\native" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.Build.Conversion.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Conversion.Core.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.Build.Conversion.Core</id>
+    <version>$version$</version>
+    <title>MSBuild APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>MSBuild APIs (DEPRECATED)</summary>
+    <description>
+      This package includes APIs that support writing MSBuild tasks.  NOTE: this package is deprecated.
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="net46">
+        <dependency id="Microsoft.Build" version="$version$" />
+        <dependency id="Microsoft.Build.Engine" version="$version$" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.Build.Conversion.Core.dll" target="lib\net46" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.Build.Engine.nuspec
+++ b/src/nuget/Microsoft.Build.Engine.nuspec
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.Build.Engine</id>
+    <version>$version$</version>
+    <title>MSBuild APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>MSBuild APIs (DEPRECATED)</summary>
+    <description>
+      This package includes APIs that support writing MSBuild tasks. NOTE: this package is deprecated.
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="net46">
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.Build.Engine.dll" target="lib\net46" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.Build.Framework.nuspec
+++ b/src/nuget/Microsoft.Build.Framework.nuspec
@@ -13,7 +13,11 @@
     <summary>MSBuild APIs</summary>
     <description>
       This package includes APIs that support writing MSBuild tasks.
+      NOTE: This package is deprecated.  Please move to the 15.1.X packages available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
     </description>
+    <releaseNotes>
+      This package is deprecated.  Please move to the 15.1.X packages available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
+    </releaseNotes>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/nuget/Microsoft.Build.Framework.nuspec
+++ b/src/nuget/Microsoft.Build.Framework.nuspec
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.Build.Framework</id>
+    <version>$version$</version>
+    <title>MSBuild APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>MSBuild APIs</summary>
+    <description>
+      This package includes APIs that support writing MSBuild tasks.
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.Build.Framework.dll" target="lib\netstandard1.3" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.Build.Targets.nuspec
+++ b/src/nuget/Microsoft.Build.Targets.nuspec
@@ -13,7 +13,11 @@
     <summary>MSBuild APIs</summary>
     <description>
       This package includes APIs that support writing MSBuild tasks.
+      NOTE: This package is deprecated.  Please move to the Microsoft.Build.Runtime 15.1.X package available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
     </description>
+    <releaseNotes>
+      NOTE: This package is deprecated.  Please move to the Microsoft.Build.Runtime 15.1.X package available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
+    </releaseNotes>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/nuget/Microsoft.Build.Targets.nuspec
+++ b/src/nuget/Microsoft.Build.Targets.nuspec
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.Build.Targets</id>
+    <version>$version$</version>
+    <title>MSBuild APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>MSBuild APIs</summary>
+    <description>
+      This package includes APIs that support writing MSBuild tasks.
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
+        <dependency id="Microsoft.Build" version="$version$" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="$version$" />
+        <dependency id="Microsoft.Build.Tasks.Core" version="$version$" />
+        <dependency id="MSBuild" />
+      </group>
+    </dependencies>
+    <contentFiles>
+      <files include="any/any/**/*.*" buildAction="None" copyToOutput="true" />
+    </contentFiles>
+  </metadata>
+  <files>
+    <file src="_._" target="lib\netstandard1.3" />
+    <file src="Microsoft.Common.CrossTargeting.targets" target="runtimes\any\native" />
+    <file src="Microsoft.CSharp.CrossTargeting.targets" target="runtimes\any\native" />
+    <file src="Microsoft.VisualBasic.CrossTargeting.targets" target="runtimes\any\native" />
+    <file src="Microsoft.Common.CurrentVersion.targets" target="runtimes\any\native" />
+    <file src="Microsoft.Common.targets" target="runtimes\any\native" />
+    <file src="Microsoft.CSharp.CurrentVersion.targets" target="runtimes\any\native" />
+    <file src="Microsoft.CSharp.targets" target="runtimes\any\native" />
+    <file src="Microsoft.NETFramework.CurrentVersion.targets" target="runtimes\any\native" />
+    <file src="Microsoft.NETFramework.targets" target="runtimes\any\native" />
+    <file src="Microsoft.VisualBasic.CurrentVersion.targets" target="runtimes\any\native" />
+    <file src="Microsoft.VisualBasic.targets" target="runtimes\any\native" />
+    <file src="Microsoft.Common.overridetasks" target="runtimes\any\native" />
+    <file src="Microsoft.Common.props" target="contentFiles\any\any\Extensions\$targetmsbuildtoolsversion$\" />
+    <file src="Microsoft.Common.tasks" target="runtimes\any\native" />
+    <file src="Microsoft.NETFramework.CurrentVersion.props" target="runtimes\any\native" />
+    <file src="Microsoft.NETFramework.props" target="runtimes\any\native" />
+    <file src="Microsoft.VisualStudioVersion.v11.Common.props" target="runtimes\any\native" />
+    <file src="Microsoft.VisualStudioVersion.v12.Common.props" target="runtimes\any\native" />
+    <file src="Microsoft.VisualStudioVersion.v14.Common.props" target="runtimes\any\native" />
+
+    <!-- Shim targets should only be included for full-framework deployments. -->
+    <!-- Until there is a distinction in the package, leaving them commented out here.
+    <file src="Microsoft.Data.Entity.targets" target="runtimes\any\native" />
+    <file src="Microsoft.ServiceModel.targets" target="runtimes\any\native" />
+    <file src="Microsoft.WinFx.targets" target="runtimes\any\native" />
+    <file src="Microsoft.WorkflowBuildExtensions.targets" target="runtimes\any\native" />
+    <file src="Microsoft.Xaml.targets" target="runtimes\any\native" />
+    <file src="Workflow.Targets" target="runtimes\any\native" />
+    <file src="Workflow.VisualBasic.Targets" target="runtimes\any\native" /> -->
+  </files>
+</package>

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -13,7 +13,11 @@
     <summary>MSBuild APIs</summary>
     <description>
       This package includes APIs that support writing MSBuild tasks.
+      NOTE: This package is deprecated.  Please move to the 15.1.X packages available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
     </description>
+    <releaseNotes>
+      This package is deprecated.  Please move to the 15.1.X packages available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
+    </releaseNotes>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.Build.Tasks.Core</id>
+    <version>$version$</version>
+    <title>MSBuild APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>MSBuild APIs</summary>
+    <description>
+      This package includes APIs that support writing MSBuild tasks.
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Collections.Concurrent" version="4.0.12" />
+        <dependency id="System.Collections.NonGeneric" version="4.0.1" />
+        <dependency id="System.Console" version="4.0.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.IO.FileSystem" version="4.0.1" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.ObjectModel" version="4.0.12" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Metadata" version="1.3.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Resources.Writer" version="4.0.0" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Runtime.Handles" version="4.0.1" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.1.0" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.11" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
+        <dependency id="System.Xml.XDocument" version="4.0.11" />
+        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.Build.Tasks.Core.dll" target="lib\netstandard1.3" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.Build.Utilities.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Utilities.Core.nuspec
@@ -13,7 +13,11 @@
     <summary>MSBuild APIs</summary>
     <description>
       This package includes APIs that support writing MSBuild tasks.
+      NOTE: This package is deprecated.  Please move to the 15.1.X packages available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
     </description>
+    <releaseNotes>
+      This package is deprecated.  Please move to the 15.1.X packages available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
+    </releaseNotes>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/nuget/Microsoft.Build.Utilities.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Utilities.Core.nuspec
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.Build.Utilities.Core</id>
+    <version>$version$</version>
+    <title>MSBuild APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>MSBuild APIs</summary>
+    <description>
+      This package includes APIs that support writing MSBuild tasks.
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Collections.Concurrent" version="4.0.12" />
+        <dependency id="System.Collections.NonGeneric" version="4.0.1" />
+        <dependency id="System.Console" version="4.0.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.IO.FileSystem" version="4.0.1" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.ObjectModel" version="4.0.12" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Runtime.Handles" version="4.0.1" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Threading.Timer" version="4.0.1" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
+        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.Build.Utilities.Core.dll" target="lib\netstandard1.3" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.Build</id>
+    <version>$version$</version>
+    <title>MSBuild APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>MSBuild APIs</summary>
+    <description>
+      This package includes APIs that support writing MSBuild tasks.
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.Build.Framework" version="$version$" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.AppContext" version="4.1.0" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Collections.Concurrent" version="4.0.12" />
+        <dependency id="System.Collections.NonGeneric" version="4.0.1" />
+        <dependency id="System.Console" version="4.0.0" />
+        <dependency id="System.Diagnostics.Contracts" version="4.0.1" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.FileVersionInfo" version="4.0.0" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.IO.Compression" version="4.1.0" />
+        <dependency id="System.IO.FileSystem" version="4.0.1" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />
+        <dependency id="System.IO.Pipes" version="4.0.0" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.ObjectModel" version="4.0.12" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1" />
+        <dependency id="System.Reflection.Metadata" version="1.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.0.1" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Runtime.Handles" version="4.0.1" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Runtime.Loader" version="4.0.0" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.11" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Tasks.Dataflow" version="4.6.0" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Threading.ThreadPool" version="4.0.10" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
+        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
+        <dependency id="System.Xml.XPath.XmlDocument" version="4.0.1" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.Build.dll" target="lib\netstandard1.3" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -13,7 +13,11 @@
     <summary>MSBuild APIs</summary>
     <description>
       This package includes APIs that support writing MSBuild tasks.
+      NOTE: This package is deprecated.  Please move to the 15.1.X packages available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
     </description>
+    <releaseNotes>
+      This package is deprecated.  Please move to the 15.1.X packages available on https://dotnet.myget.org/F/msbuild/api/v3/index.json.
+    </releaseNotes>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">


### PR DESCRIPTION
Back by popular demand.  This is a revert of a26376148ef0d0d83e450d25439190400516e2b9 with the packages marked as deprecated.

I'll modify the build def to publish continue publishing the old packages to the buildtools feed while the newer ones will get published to the msbuild feed.  The older ones will continue to follow the versioning scheme `0.1.0-X` and the new ones are versioned `15.1.X`.

When I rename `MSBuild.exe` to `MSBuild.dll` I'll have to update the old packages as well.  Hopefully soon we can stop building them.

FYI @nguerrera @eerhardt