### PR TITLE
Build the correct legacy packages for the correct framework

### DIFF
--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -61,9 +61,20 @@
 
   <!-- Workaround to remove items from PackagesNuSpecFiles (defined in packages.targets). This ItemGroup
        is defined with a wildcard Include and no way to override. -->
-  <Target Name="RemovePackages" BeforeTargets="BuildPackages" Condition="$(FullFrameworkBuild) != 'true'" >
-    <ItemGroup>
-        <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.Engine.nuspec;$(SourceDir)nuget\Microsoft.Build.Conversion.Core.nuspec" />
+  <Target Name="RemovePackages" BeforeTargets="BuildPackages">
+    <ItemGroup Condition="$(NetCoreBuild) == 'true'">
+        <!-- Remove packages that don't support netstandard1.3 (NetCore) -->
+        <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.Conversion.Core.nuspec" />
+        <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.Engine.nuspec" />
+    </ItemGroup>
+    <ItemGroup Condition="$(FullFrameworkBuild) == 'true'">
+      <!-- Remove packages that don't support net45 (FullFramework) -->
+      <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.Framework.nuspec" />
+      <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.nuspec" />
+      <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.Targets.nuspec" />
+      <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.Tasks.Core.nuspec" />
+      <PackagesNuSpecFiles Remove="$(SourceDir)nuget\Microsoft.Build.Utilities.Core.nuspec" />
+      <PackagesNuSpecFiles Remove="$(SourceDir)nuget\MSBuild.nuspec" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This is for the legacy packages only.

@tmeschter had already excluded Microsoft.Build.Engine and Microsoft.Build.Conversion.Core from building packages for NetCore.  This excludes the other packages from building on net46 because they only package files into netstandard1.3 directories anyway.

This will make it possible for me to update the build definition to be publishing the legacy and new packages during the same build.