### PR TITLE
Target netcoreapp1.0 for MSBuild executable

### DIFF
--- a/Before.Microsoft.Common.targets
+++ b/Before.Microsoft.Common.targets
@@ -5,7 +5,7 @@
     <!--
       This property is already defined in the root dir.props however importing Microsoft.Portable.CSharp.targets will
       override it.  If you change it here, update it in the root dir.props as well.  -->
-    <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+    <TargetFrameworkIdentifier Condition="'$(_TargetFrameworkIdentifierBackup)' != '' ">$(_TargetFrameworkIdentifierBackup)</TargetFrameworkIdentifier>
     <!-- This property needs to be cleared -->
     <TargetFrameworkMonikerDisplayName></TargetFrameworkMonikerDisplayName>
   </PropertyGroup>

--- a/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
@@ -67,7 +67,8 @@
     <!--
       contentFiles\any\netcoreapp1.0
     -->
-    <file src="$configuration$-NetCore\Output\MSBuild.exe" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\MSBuild.dll" target="contentFiles\any\netcoreapp1.0\" />
+    <file src="$configuration$-NetCore\Output\MSBuild.runtimeconfig.json" target="contentFiles\any\netcoreapp1.0\" />
     <file src="$configuration$-NetCore\Output\Microsoft.Common.CrossTargeting.targets" target="contentFiles\any\netcoreapp1.0\" />
     <file src="$configuration$-NetCore\Output\Microsoft.Common.CurrentVersion.targets" target="contentFiles\any\netcoreapp1.0\" />
     <file src="$configuration$-NetCore\Output\Microsoft.Common.overridetasks" target="contentFiles\any\netcoreapp1.0\" />

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -117,7 +117,7 @@ if /i "%TARGET%"=="CoreCLR" (
 )
 
 if /i "%TARGET%"=="CoreCLR" (
-    set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\MSBuild.exe"
+    set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\MSBuild.dll"
 ) else (
     set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\15.0\Bin\MSBuild.exe"
 )

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -86,7 +86,7 @@ MOVE_LOG_PATH="$THIS_SCRIPT_PATH"/"msbuild_move_bootstrap.log"
 PROJECT_FILE_ARG='"'"$THIS_SCRIPT_PATH/build.proj"'"'
 BOOTSTRAP_FILE_ARG='"'"$THIS_SCRIPT_PATH/BootStrapMSBuild.proj"'"'
 BOOTSTRAPPED_RUNTIME_HOST='"'"$THIS_SCRIPT_PATH/bin/Bootstrap/dotnet"'"'
-MSBUILD_BOOTSTRAPPED_EXE='"'"$THIS_SCRIPT_PATH/bin/Bootstrap/MSBuild.exe"'"'
+MSBUILD_BOOTSTRAPPED_EXE='"'"$THIS_SCRIPT_PATH/bin/Bootstrap/MSBuild.dll"'"'
 
 # Default msbuild arguments
 TARGET_ARG="Build"

--- a/dir.props
+++ b/dir.props
@@ -63,7 +63,7 @@
     <ToolPackagesDir>$(RepoRoot)packages$([System.IO.Path]::DirectorySeparatorChar)</ToolPackagesDir>
     <MicroBuildDir>$(ToolPackagesDir)\MicroBuild.Core\$(MicroBuildVersion)\build\</MicroBuildDir>
     <GitVersioningDir>$(PackagesDir)\Nerdbank.GitVersioning\$(GitVersioningVersion)\build\</GitVersioningDir>
-
+    
     <!-- Tell build tools to use the full framework dlls that contain build tasks (like the nuget assets task) -->
     <BuildToolsTaskDir>$(ToolsDir)net45/</BuildToolsTaskDir>
     <PackagingTaskDir>$(ToolsDir)net45/</PackagingTaskDir>
@@ -224,7 +224,11 @@
     <!--
       This property is re-created after importing Microsoft.Portable.CSharp.targets.  If you change the value here, also
       update it in Before.Microsoft.Common.targets -->
-    <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+    <TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">.NETStandard</TargetFrameworkIdentifier>
+    <!--
+      Backup $(TargetFrameworkIdentifier) because it will be statically set by Microsoft.CSharp.Portable.targets and reset in our Before.Microsoft.Common.targets
+    -->
+    <_TargetFrameworkIdentifierBackup Condition="'$(TargetFrameworkIdentifier)' != ''">$(TargetFrameworkIdentifier)</_TargetFrameworkIdentifierBackup>
     <NetCoreSurface>true</NetCoreSurface>
 
     <!-- Setting this to false stops the AppX targets, which aren't supported on .NET Core, from beeing imported -->
@@ -240,7 +244,7 @@
   <PropertyGroup>
     <PlatformTarget>$(RuntimeArchitecture)</PlatformTarget>
     <ImportGetNuGetPackageVersions Condition="'$(OS)' != 'Windows_NT'">false</ImportGetNuGetPackageVersions>
-    <NuGetTargetMoniker Condition="'$(NetCoreBuild)' == 'true'">.NETStandard,Version=$(TargetFrameworkVersion)</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(NetCoreBuild)' == 'true'">$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)</NuGetTargetMoniker>
     <NuGetTargetMoniker Condition="'$(NetCoreBuild)' != 'true'">.NETFramework,Version=$(TargetFrameworkVersion)</NuGetTargetMoniker>
   </PropertyGroup>
 

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Build.Shared
         private static readonly string[] s_msBuildProcess = {"MSBUILD"};
 
         /// <summary>
+        /// Name of MSBuild executable files.
+        /// </summary>
+        private static readonly string[] s_msBuildExeNames = {"MSBuild.exe", "MSBuild.dll"};
+
+        /// <summary>
         /// Gets the cached Build Environment instance.
         /// </summary>
         public static BuildEnvironment Instance => BuildEnvironmentHelperSingleton.s_instance;
@@ -123,11 +128,11 @@ namespace Microsoft.Build.Shared
         {
             if (string.IsNullOrEmpty(folder)) return null;
 
-            var msBuildPath = Path.Combine(folder, "MSBuild.exe");
-
-            return IsValidMSBuildPath(msBuildPath)
-                ? new BuildEnvironment(msBuildPath, runningTests, runningInVisualStudio, visualStudioPath)
-                : null;
+            return (
+                    s_msBuildExeNames.Select(msbuildFileName => Path.Combine(folder, msbuildFileName))
+                    .Where(IsValidMSBuildPath)
+                    .Select(msBuildPath => new BuildEnvironment(msBuildPath, runningTests, runningInVisualStudio, visualStudioPath))
+                   ).FirstOrDefault();
         }
 
         /// <summary>
@@ -143,7 +148,7 @@ namespace Microsoft.Build.Shared
         private static bool IsValidMSBuildPath(string path)
         {
             bool msbuildExeExists = !string.IsNullOrEmpty(path) &&
-                    Path.GetFileName(path).Equals("MSBuild.exe", StringComparison.OrdinalIgnoreCase) &&
+                s_msBuildExeNames.Any(i => i.Equals(Path.GetFileName(path), StringComparison.OrdinalIgnoreCase)) &&
                     File.Exists(path);
 #if FEATURE_SYSTEM_CONFIGURATION
             // If we can read toolsets out of msbuild.exe.config, we must

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Build.UnitTests
     {
         private readonly ITestOutputHelper _output;
 
+#if FEATURE_RUN_EXE_IN_TESTS
+        private const string MSBuildExeName = "MSBuild.exe";
+#else
+        private const string MSBuildExeName = "MSBuild.dll";
+#endif
+
         public ToolLocationHelper_Tests(ITestOutputHelper output)
         {
             _output = output;
@@ -591,10 +597,10 @@ namespace Microsoft.Build.UnitTests
                     ToolLocationHelper.GetPathToBuildToolsFile("MSBuild.exe", "4.0")
                 );
 
-            string tv12path = Path.Combine(ProjectCollection.GlobalProjectCollection.GetToolset(ObjectModelHelpers.MSBuildDefaultToolsVersion).ToolsPath, "MSBuild.exe");
+            string tv12path = Path.Combine(ProjectCollection.GlobalProjectCollection.GetToolset(ObjectModelHelpers.MSBuildDefaultToolsVersion).ToolsPath, MSBuildExeName);
 
-            Assert.Equal(tv12path, ToolLocationHelper.GetPathToBuildToolsFile("MSBuild.exe", ObjectModelHelpers.MSBuildDefaultToolsVersion));
-            Assert.Equal(tv12path, ToolLocationHelper.GetPathToBuildToolsFile("MSBuild.exe", ToolLocationHelper.CurrentToolsVersion));
+            Assert.Equal(tv12path, ToolLocationHelper.GetPathToBuildToolsFile(MSBuildExeName, ObjectModelHelpers.MSBuildDefaultToolsVersion));
+            Assert.Equal(tv12path, ToolLocationHelper.GetPathToBuildToolsFile(MSBuildExeName, ToolLocationHelper.CurrentToolsVersion));
         }
 
 #if RUNTIME_TYPE_NETCORE

--- a/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Build.Engine.UnitTests
 {
     public class BuildEnvironmentHelper_Tests
     {
+#if FEATURE_RUN_EXE_IN_TESTS
+        private const string MSBuildExeName = "MSBuild.exe";
+#else
+        private const string MSBuildExeName = "MSBuild.dll";
+#endif
         [Fact]
         public void GetExecutablePath()
         {
@@ -22,7 +27,7 @@ namespace Microsoft.Build.Engine.UnitTests
             var msbuildPath = Path.GetDirectoryName(AssemblyUtilities.GetAssemblyLocation(typeof(Project).GetTypeInfo().Assembly));
             Directory.SetCurrentDirectory(msbuildPath);
 
-            string path = Path.Combine(Directory.GetCurrentDirectory(), "msbuild.exe").ToLowerInvariant();
+            string path = Path.Combine(Directory.GetCurrentDirectory(), MSBuildExeName).ToLowerInvariant();
             string configPath = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile.ToLowerInvariant();
             string directoryName = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.ToLowerInvariant();
             string executablePath = BuildEnvironmentHelper.Instance.CurrentMSBuildExePath.ToLowerInvariant();

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -8,6 +8,7 @@
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
     <NoWarn>$(NoWarn);1701</NoWarn>
+    <TargetExt>.dll</TargetExt>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -216,7 +217,9 @@
     <Content Include="MSBuild.rsp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-
+    <Content Include="MSBuild.runtimeconfig.json" Condition="'$(NetCoreBuild)' == 'true'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="Microsoft.Build.CommonTypes.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -2,7 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PlatformSpecificBuild>true</PlatformSpecificBuild>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' and ('$(Configuration)' == 'Debug-NetCore' or '$(Configuration)' == 'Release-NetCore')">v1.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug-NetCore' or '$(Configuration)' == 'Release-NetCore'">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <NoStdLib>true</NoStdLib>
+    <NoWarn>$(NoWarn);1701</NoWarn>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -249,4 +254,16 @@
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="..\dir.targets" />
+  <PropertyGroup Condition="'$(NetCoreBuild)' == 'true'">
+    <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two
+            properties to any folder that exists to skip the GetReferenceAssemblyPaths task (not target) and
+            to prevent it from outputting a warning (MSB3644).
+        -->
+    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)</_TargetFrameworkDirectories>
+    <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)</_FullFrameworkReferenceAssemblyPaths>
+
+    <!-- MSBuild thinks all EXEs need binding redirects, not so for CoreCLR! -->
+    <AutoUnifyAssemblyReferences>true</AutoUnifyAssemblyReferences>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+  </PropertyGroup>
 </Project>

--- a/src/XMakeCommandLine/MSBuild.runtimeconfig.json
+++ b/src/XMakeCommandLine/MSBuild.runtimeconfig.json
@@ -1,0 +1,8 @@
+{
+  "runtimeOptions": {
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "1.0.1"
+    }
+  }
+}

--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -24,6 +24,12 @@ namespace Microsoft.Build.UnitTests
 {
     public class XMakeAppTests
     {
+#if FEATURE_RUN_EXE_IN_TESTS
+        private const string MSBuildExeName = "MSBuild.exe";
+#else
+        private const string MSBuildExeName = "MSBuild.dll";
+#endif
+
         [Fact]
         public void GatherCommandLineSwitchesTwoProperties()
         {
@@ -1028,7 +1034,7 @@ namespace Microsoft.Build.UnitTests
                 string rspPath = Path.Combine(directory, "msbuild.rsp");
 
                 exeDirectory = CopyMSBuild();
-                string exePath = Path.Combine(exeDirectory, "msbuild.exe");
+                string exePath = Path.Combine(exeDirectory, MSBuildExeName);
                 string mainRspPath = Path.Combine(exeDirectory, "msbuild.rsp");
 
                 Directory.CreateDirectory(exeDirectory);
@@ -1070,7 +1076,7 @@ namespace Microsoft.Build.UnitTests
                 directory = CopyMSBuild();
                 string projectPath = Path.Combine(directory, "my.proj");
                 string rspPath = Path.Combine(directory, "msbuild.rsp");
-                string exePath = Path.Combine(directory, "msbuild.exe");
+                string exePath = Path.Combine(directory, MSBuildExeName);
 
                 string content = ObjectModelHelpers.CleanupFileContents("<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Warning Text='[A=$(A)]'/></Target></Project>");
                 File.WriteAllText(projectPath, content);
@@ -1195,7 +1201,7 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        #region IgnoreProjectExtensionTests
+#region IgnoreProjectExtensionTests
 
         /// <summary>
         /// Test the case where the extension is a valid extension but is not a project
@@ -1554,9 +1560,9 @@ namespace Microsoft.Build.UnitTests
                 return fileNamesToReturn.ToArray();
             }
         }
-        #endregion
+#endregion
 
-        #region ProcessFileLoggerSwitches
+#region ProcessFileLoggerSwitches
         /// <summary>
         /// Test the case where no file logger switches are given, should be no file loggers attached
         /// </summary>
@@ -1800,9 +1806,9 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(0, distributedLoggerRecords.Count); // "Expected no distributed loggers to be attached"
             Assert.Equal(0, loggers.Count); // "Expected no central loggers to be attached"
         }
-        #endregion
+#endregion
 
-        #region ProcessConsoleLoggerSwitches
+#region ProcessConsoleLoggerSwitches
         [Fact]
         public void ProcessConsoleLoggerSwitches()
         {
@@ -1850,7 +1856,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(0, string.Compare(distributedLogger.CentralLogger.Parameters, "SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;parameter;Parameter", StringComparison.OrdinalIgnoreCase)); // "Expected parameter in logger to match parameters passed in"
             Assert.Equal(0, string.Compare(distributedLogger.ForwardingLoggerDescription.LoggerSwitchParameters, "SHOWPROJECTFILE=TRUE;Parameter1;Parameter;;;Parameter;Parameter", StringComparison.OrdinalIgnoreCase)); // "Expected parameter in logger to match parameter passed in"
         }
-        #endregion
+#endregion
 
         private string CopyMSBuild()
         {

--- a/src/XMakeCommandLine/project.json
+++ b/src/XMakeCommandLine/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "frameworks": {
     "net46": {},
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0",
+        "Microsoft.NETCore.App": "1.0.1",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Diagnostics.FileVersionInfo": "4.0.0",
         "System.Diagnostics.Process": "4.1.0",

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -61,11 +61,12 @@
 
   <!-- Debugging support -->
   <PropertyGroup Condition="'$(NetCoreBuild)' == 'true'">
+    <StartAction>Program</StartAction>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
     <TestHost Condition="'$(OsEnvironment)' == 'Windows_NT'">dotnet.exe</TestHost>
     <TestHost Condition="'$(OsEnvironment)' != 'Windows_NT'">dotnet</TestHost>
     <StartProgram Condition="'$(StartProgram)'==''">$(DeploymentDir)\$(TestHost)</StartProgram>
-    <StartArguments>msbuild.exe</StartArguments>
+    <StartArguments>$(TargetPath)</StartArguments>
   </PropertyGroup>
 
 
@@ -92,7 +93,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetCoreBuild)' == 'true'">
-    <NuGetTargetMoniker>.NETStandard,Version=$(TargetFrameworkVersion)</NuGetTargetMoniker>
+    <NuGetTargetMoniker>$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)</NuGetTargetMoniker>
   </PropertyGroup>
   
   <Import Project="$(RepoRoot)\targets\GenApi.targets" Condition="'$(OS)' == 'Windows_NT'" />

--- a/src/nuget/MSBuild.nuspec
+++ b/src/nuget/MSBuild.nuspec
@@ -65,6 +65,6 @@
   </metadata>
   <files>
     <file src="_._" target="lib\netstandard1.3" />
-    <file src="MSBuild.exe" target="runtimes\any\native" />
+    <file src="MSBuild.dll" target="runtimes\any\native\MSBuild.exe" />
   </files>
 </package>


### PR DESCRIPTION
Instead of targeting NETStandard1.5, our executable should target netcoreapp1.0.  This also renames MSBuild.exe to MSBuild.dll

Related to #1136 Rename MSBuild.exe to MSBuild.dll for .NET Core

Closes #1136 and #1098 