### PR TITLE
Update vsix setup

### DIFF
--- a/setup/files.swr
+++ b/setup/files.swr
@@ -10,7 +10,9 @@ folder InstallDir:\MSBuild\15.0
   file source=$(X86BinPath)Microsoft.VisualStudioVersion.v15.Common.props
 
 folder InstallDir:\MSBuild\15.0\Bin
+  file source=$(X86BinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngen=yes
+  file source=$(X86BinPath)Microsoft.Build.Engine.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngen=yes
@@ -139,7 +141,9 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X64BinPath)MSBuild.exe.config
   file source=$(X64BinPath)MSBuildTaskHost.exe.config
 
+  file source=$(X86BinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngen=yes
+  file source=$(X86BinPath)Microsoft.Build.Engine.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngen=yes
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngen=yes

--- a/setup/files.swr
+++ b/setup/files.swr
@@ -44,6 +44,10 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)Microsoft.WinFx.targets
   file source=$(X86BinPath)Microsoft.WorkflowBuildExtensions.targets
 
+folder InstallDir:\MSBuild\15.0\MSBuild
+  file source=$(X86BinPath)Microsoft.Build.Core.xsd
+  file source=$(X86BinPath)Microsoft.Build.CommonTypes.xsd
+
 folder InstallDir:\MSBuild\15.0\Bin\cs
   file source=$(X86BinPath)cs\Microsoft.Build.resources.dll vs.file.ngen=yes
   file source=$(X86BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
@@ -165,6 +169,10 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)Microsoft.WinFx.targets
   file source=$(X86BinPath)Microsoft.WorkflowBuildExtensions.targets
 
+folder InstallDir:\MSBuild\15.0\Bin\amd64\MSBuild
+  file source=$(X86BinPath)Microsoft.Build.Core.xsd
+  file source=$(X86BinPath)Microsoft.Build.CommonTypes.xsd
+
 folder InstallDir:\MSBuild\15.0\Bin\amd64\cs
   file source=$(X64BinPath)cs\Microsoft.Build.resources.dll vs.file.ngen=yes
   file source=$(X64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngen=yes
@@ -255,3 +263,5 @@ folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)XMakeBuildEngine\Microsoft.Build.pkgdef
   file source=$(SourceDir)XmakeTasks\Microsoft.Build.Tasks.Core.pkgdef
   file source=$(SourceDir)Utilities\Microsoft.Build.Utilities.Core.pkgdef
+  file source=$(SourceDir)XMakeConversion\Microsoft.Build.Conversion.Core.pkgdef
+  file source=$(SourceDir)OrcasEngine\Microsoft.Build.Engine.pkgdef

--- a/src/OrcasEngine/Microsoft.Build.Engine.pkgdef
+++ b/src/OrcasEngine/Microsoft.Build.Engine.pkgdef
@@ -1,0 +1,7 @@
+[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{7214565F-670F-4FEA-B50E-144CDC590E7B}]
+"name"="Microsoft.Build.Engine"
+"codeBase"="$BaseInstallDir$\MSBuild\15.0\Bin\Microsoft.Build.Engine.dll"
+"publicKeyToken"="b03f5f7f11d50a3a"
+"culture"="neutral"
+"oldVersion"="0.0.0.0-99.9.9.9"
+"newVersion"="15.1.0.0"

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -181,6 +181,14 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 
+    <None Include="Microsoft.Build.CommonTypes.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Microsoft.Build.Core.xsd">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <!-- File for Assemblies we depend on -->

--- a/src/XMakeConversion/Microsoft.Build.Conversion.Core.pkgdef
+++ b/src/XMakeConversion/Microsoft.Build.Conversion.Core.pkgdef
@@ -1,0 +1,7 @@
+[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{69CFFD1A-343F-46C5-81B3-8437CD1272CD}]
+"name"="Microsoft.Build.Conversion.Core"
+"codeBase"="$BaseInstallDir$\MSBuild\15.0\Bin\Microsoft.Build.Conversion.Core.dll"
+"publicKeyToken"="b03f5f7f11d50a3a"
+"culture"="neutral"
+"oldVersion"="0.0.0.0-99.9.9.9"
+"newVersion"="15.1.0.0"


### PR DESCRIPTION
Include `Microsoft.Build.Conversion.Core.dll`, `Microsoft.Build.Engine.dll`, and the schema files to match existing install structure.