### PR TITLE
Fix xlf syncing race

### DIFF
--- a/build/LocalizationTasks/EmitLocalizedResources.cs
+++ b/build/LocalizationTasks/EmitLocalizedResources.cs
@@ -114,8 +114,7 @@ namespace Microsoft.Build.LocalizationTasks
 
         private static string GetCultureCodeFromPath(string localizedResourcePath)
         {
-            return Path.GetExtension(Path.GetFileNameWithoutExtension(localizedResourcePath)).Substring(1);
-                // remove the . at the beginning
+            return Path.GetExtension(Path.GetFileNameWithoutExtension(localizedResourcePath)).Substring(1); // remove the . at the beginning
         }
     }
 }

--- a/build/dirs.proj
+++ b/build/dirs.proj
@@ -2,7 +2,8 @@
   <Import Project="dir.props" />
 
   <ItemGroup>
-    <Project Include="LocalizationTasks\Microsoft.Build.LocalizationTasks.csproj" />
+    <Project Include="LocalizationTasks\Microsoft.Build.LocalizationTasks.csproj"
+             Condition="'$(LocalizationBuildAssetsRequired)' == 'true'" />
   </ItemGroup>
 
   <Import Project="..\dir.traversal.targets" />

--- a/dir.props
+++ b/dir.props
@@ -21,6 +21,11 @@
      <DebugSymbols Condition="'$(UseRoslynCompilers)' == 'true'">false</DebugSymbols>
   </PropertyGroup>
 
+  <!-- Localization switches -->
+  <PropertyGroup>
+    <LocalizationBuildAssetsRequired Condition="'$(LocalizedBuild)' == 'true' or '$(SyncXlf)' == 'true'">true</LocalizationBuildAssetsRequired>
+  </PropertyGroup>
+
    <!-- Common repo directories -->
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>

--- a/src/UpdateLocalizedResources.targets
+++ b/src/UpdateLocalizedResources.targets
@@ -69,7 +69,9 @@
           BeforeTargets="$(PrepareResourcesDependsOn);PrepareResources">
 
     <ItemGroup>
-      <NeutralResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resx'"/> 
+      <NeutralResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resx'">
+        <IsShared>$([System.String]::Copy('%(Filename)').StartsWith('Strings.shared.'))</IsShared>
+      </NeutralResources> 
     </ItemGroup>
 
     <EmitLocalizedResources 
@@ -82,6 +84,13 @@
       <Output TaskParameter="ResolvedLocalizedResxResources" ItemName="LocalizedResxResources" />
 
     </EmitLocalizedResources>
+
+    <ItemGroup>
+      <XlfFiles>
+        <IsShared>$([System.String]::Copy('%(Filename)').StartsWith('Strings.shared.'))</IsShared>
+      </XlfFiles>
+    </ItemGroup>
+
   </Target>
 
   <Target Name="SyncXlf"
@@ -89,10 +98,19 @@
           DependsOnTargets="EmitLocalizedResources" 
           Condition="$(SyncXlf) == 'true' and $(IsTestProject) != 'true'">
     
+    <!-- only one project should update the shared resources. Otherwise races happen -->
+    <ItemGroup>
+      <XlfFilesToSync Include="@(XlfFiles)"/>
+      <XlfFilesToSync
+        Remove="@(XlfFilesToSync)"
+        Condition="'$(AssemblyName)' != 'MSBuild' and '%(XlfFilesToSync.IsShared)' == 'True'"
+        />
+    </ItemGroup>
+
     <UpdateXlfFromResx
       Condition="%(Identity) != ''"
       ResxPath="%(NeutralResx)"
-      XlfPath="@(XlfFiles)"
+      XlfPath="@(XlfFilesToSync)"
     />
 
   </Target>

--- a/src/UpdateLocalizedResources.targets
+++ b/src/UpdateLocalizedResources.targets
@@ -1,73 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="UpdateXlf" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
-  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" Condition="$(LocalizedBuild) == 'true'" TaskName="SaveXlfToResx"/>
-  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" Condition="$(LocalizedBuild) == 'true'" TaskName="UpdateXlfFromResx"/>
-  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" Condition="$(LocalizedBuild) == 'true'" TaskName="EmitLocalizedResources"/>
+  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" TaskName="SaveXlfToResx"/>
+  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" TaskName="UpdateXlfFromResx"/>
+  <UsingTask AssemblyFile="$(BuildBinDir)\Microsoft.Build.LocalizationTasks.dll" TaskName="EmitLocalizedResources"/>
 
-  <!-- Emit the localized EmbeddedResource items before the common targets start using them -->
-  <Target Name="EmitLocalizedResources"
-          BeforeTargets="$(PrepareResourceNamesDependsOn);PrepareResourceNames">
+  <Target Name="AddLocalizedResxFilesToEmbeddedResource"
+          BeforeTargets="$(PrepareResourcesDependsOn);PrepareResources"
+          DependsOnTargets="SyncXlf;GenerateLocalizedResxResourcesFromXlf;AddEnglishResxFilesToEmbeddedResource"
+          Condition="'$(LocalizedBuild)' == 'true'">
+
     <ItemGroup>
-      <NeutralResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resx'"/> 
+      <!-- The depending targets generate and materialize localized resx files in @(LocalizedResxResources) -->
+      <EmbeddedResource Include="@(LocalizedResxResources)"/>
     </ItemGroup>
-
-    <EmitLocalizedResources 
-      NeutralResources="@(NeutralResources)"
-      AssemblyName="$(AssemblyName)"
-      LocalizedResxRoot="$(IntermediateOutputPath)"
-      RelativePathToXlfRoot=".\xlf\">
-
-      <Output TaskParameter="ResolvedXlfResources" ItemName="XlfFiles" />
-      <Output TaskParameter="ResolvedLocalizedResxResources" ItemName="EmbeddedResource" />
-
-    </EmitLocalizedResources>
   </Target>
 
-  <!-- The default english resources do not have corresponding xlf files. Simply copy them and add en in the name 
-       Can't have english xlf (for uniformity) because the xlf sync code only updates the <source> tags, not the <target> targ.
-       That would cause the english xlf files to become out of date
-
-       This target needs to run after EmitLocalizedResource, otherwise the copied intermediary files would leak into NeutralResource
-  -->
-  <Target Name="UpdateLocalizedResxForEnglishResx"
-          BeforeTargets="$(PrepareResourceNamesDependsOn);PrepareResourceNames"
-          AfterTargets="EmitLocalizedResources">
-
-      <ItemGroup>
-        <EnglishResources Include="@(NeutralResources -> '$(IntermediateOutputPath)%(Filename).en%(Extension)')"/>
-      </ItemGroup>
-
-      <Copy
-        SourceFiles="@(NeutralResources)"
-        DestinationFiles="@(EnglishResources)"
-      />
-
-      <ItemGroup>
-        <EmbeddedResource Include="@(EnglishResources)">
-          <LogicalName>$(AssemblyName).%(FileName).resources</LogicalName>
-        </EmbeddedResource>
-      </ItemGroup>      
-
-  </Target>
-
-  <Target Name="UpdateXlf"
-          BeforeTargets="CoreResGen"
-          AfterTargets="SplitResourcesByCulture"
-          DependsOnTargets="EmitLocalizedResources;UpdateLocalizedResxForEnglishResx" 
-          Condition="$(LocalizedBuild) == 'true' and $(IsTestProject) != 'true'">
-    
-    <UpdateXlfFromResx
-      Condition="%(Identity) != ''"
-      ResxPath="%(NeutralResx)"
-      XlfPath="@(XlfFiles)"
-    />
-
-  </Target>
-
-  <Target Name="ConvertXlfToLocalizedResx"
-          AfterTargets="UpdateXlf"
-          BeforeTargets="CoreResGen">
+  <!-- Materialize the contents of the localized resx files from their corresponding xlf files -->
+  <Target Name="GenerateLocalizedResxResourcesFromXlf"
+          DependsOnTargets="EmitLocalizedResources" >
 
     <SaveXlfToResx
       Condition="%(Identity) != ''"
@@ -79,7 +30,74 @@
 
   </Target>
 
-    <!-- Copy paste and modify OpenSourceSign from sign.targets because it only signs the main assembly 
+  <!-- The default english resources do not have corresponding xlf files. Simply copy them and add en in the name 
+       Can't have english xlf (for uniformity) because the xlf sync code only updates the <source> tags, not the <target> targ.
+       That would cause the english xlf files to become out of date
+
+       This target needs to run after EmitLocalizedResource, otherwise the copied intermediary files would leak into NeutralResource
+  -->
+  <Target Name="AddEnglishResxFilesToEmbeddedResource"
+          DependsOnTargets="EmitLocalizedResources">
+
+      <ItemGroup>
+        <EnglishResources Include="@(NeutralResources -> '$(IntermediateOutputPath)%(Filename).en%(Extension)')"/>
+      </ItemGroup>
+
+      <Copy
+        SourceFiles="@(NeutralResources)"
+        DestinationFiles="@(EnglishResources)"
+      />
+
+      <ItemGroup>
+        <LocalizedResxResources Include="@(EnglishResources)">
+          <LogicalName>$(AssemblyName).%(FileName).resources</LogicalName>
+        </LocalizedResxResources>
+      </ItemGroup>      
+
+  </Target>
+
+  <!-- 
+    [IN]
+    @(EmbeddedResource)
+
+    [OUT]
+    @(NeutralResources) - base resources that contain the English strings
+    @(XlfFiles) - Location of xlf files relative to their companion neutral resource
+    @(LocalizedResxResources) - Location of generated resx files. Each xlf file will generate one or more localized resx file
+  -->
+  <Target Name="EmitLocalizedResources"
+          BeforeTargets="$(PrepareResourcesDependsOn);PrepareResources">
+
+    <ItemGroup>
+      <NeutralResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resx'"/> 
+    </ItemGroup>
+
+    <EmitLocalizedResources 
+      NeutralResources="@(NeutralResources)"
+      AssemblyName="$(AssemblyName)"
+      LocalizedResxRoot="$(IntermediateOutputPath)"
+      RelativePathToXlfRoot=".\xlf\">
+
+      <Output TaskParameter="ResolvedXlfResources" ItemName="XlfFiles" />
+      <Output TaskParameter="ResolvedLocalizedResxResources" ItemName="LocalizedResxResources" />
+
+    </EmitLocalizedResources>
+  </Target>
+
+  <Target Name="SyncXlf"
+          BeforeTargets="Build"
+          DependsOnTargets="EmitLocalizedResources" 
+          Condition="$(SyncXlf) == 'true' and $(IsTestProject) != 'true'">
+    
+    <UpdateXlfFromResx
+      Condition="%(Identity) != ''"
+      ResxPath="%(NeutralResx)"
+      XlfPath="@(XlfFiles)"
+    />
+
+  </Target>
+
+  <!-- Copy paste and modify OpenSourceSign from sign.targets because it only signs the main assembly 
   and provides no extension mechanism to add more assemblies to it
   
   If satellite assemblies do not get their delay sign bit switched off, the main assemblies won't load them

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -9,7 +9,7 @@
   <Import Project="$(GitVersioningDir)dotnet\Nerdbank.GitVersioning.targets" />
 
   <!-- Update localized resources from the default English ones-->
-  <Import Project="UpdateLocalizedResources.targets" Condition="'$(LocalizedBuild)' == 'true' and '$(IsTestProject)' != 'true' and '$(DoNotLocalizeProject)' != 'true'"/>
+  <Import Project="UpdateLocalizedResources.targets" Condition="'$(LocalizationBuildAssetsRequired)' == 'true' and '$(IsTestProject)' != 'true' and '$(DoNotLocalizeProject)' != 'true'"/>
 
   <!-- Restore packages -->
   <PropertyGroup>


### PR DESCRIPTION
This solves a race in the SyncXlf task. Because localization is per project, and because MSBuild uses a Shared directory with shared resources (which is not a project but gets linked in by all the other projects),
each project will try to sync the shared xlf files and crash with concurrent writes.

Short term fix is to disable parallel builds when xlfs are synced. Long term fix would be turning the stuff under Shared into a csproj project.

#1138 depends on this.