### PR TITLE
Improve GetItemProvenance performance

### DIFF
--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -1105,7 +1106,11 @@ namespace Microsoft.Build.Evaluation
 
         private List<GlobResult> GetAllGlobs(List<ProjectItemElement> projectItemElements)
         {
-            return projectItemElements.SelectMany(GetAllGlobs).ToList();
+            return projectItemElements
+                .AsParallel()
+                .AsOrdered()
+                .SelectMany(GetAllGlobs)
+                .ToList();
         }
 
         private IEnumerable<GlobResult> GetAllGlobs(ProjectItemElement itemElement)
@@ -1257,9 +1262,12 @@ namespace Microsoft.Build.Evaluation
             }
 
             return
-                projectItemElements.Select(i => ComputeProvenanceResult(itemToMatch, i))
-                    .Where(r => r != null)
-                    .ToList();
+                projectItemElements
+                .AsParallel()
+                .AsOrdered()
+                .Select(i => ComputeProvenanceResult(itemToMatch, i))
+                .Where(r => r != null)
+                .ToList();
         }
 
         private ProvenanceResult ComputeProvenanceResult(string itemToMatch, ProjectItemElement itemElement)

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Build.Construction;
@@ -2537,6 +2538,32 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Fact]
+        public void GetItemProvenanceResultsShouldBeInItemElementOrder()
+        {
+            var itemElements = Environment.ProcessorCount * 5;
+            var expected = new ProvenanceResultTupleList();
+
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    {0}
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < itemElements; i++)
+            {
+                sb.AppendLine($"<i_{i} Include=\"a\"/>");
+                expected.Add(Tuple.Create($"i_{i}", Operation.Include, Provenance.StringLiteral, 1));
+            }
+
+            project = string.Format(project, sb);
+
+            AssertProvenanceResult(expected, project, "a");
+        }
+
+        [Fact]
         public void GetItemProvenanceShouldReturnTheSameResultsIfProjectIsReevaluated()
         {
             var projectContents =
@@ -3052,6 +3079,32 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             AssertGlobResult(expected, project, "");
             AssertGlobResult(expected, project, null);
+        }
+
+        [Fact]
+        public void GetAllGlobsResultsShouldBeInItemElementOrder()
+        {
+            var itemElements = Environment.ProcessorCount * 5;
+            var expected = new GlobResultList();
+
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    {0}
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < itemElements; i++)
+            {
+                sb.AppendLine($"<i_{i} Include=\"*\"/>");
+                expected.Add(Tuple.Create($"i_{i}", "*", ImmutableHashSet<string>.Empty));
+            }
+
+            project = string.Format(project, sb);
+
+            AssertGlobResult(expected, project);
         }
 
         [Fact]


### PR DESCRIPTION
I tested this on an artificial project with 10000 elements. Without these changes calling GIP took 1600ms. With these changes, it takes 200ms (on 12 logical cores). CPS was fine with the slight change in behaviour.