### PR TITLE
Add app.config redirects for deprecated assemblies

### DIFF
--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -35,6 +35,16 @@
           <codeBase version="15.1.0.0" href="..\Microsoft.Build.Utilities.Core.dll"/>
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Engine" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Engine.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Conversion.Core.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
         </dependentAssembly>

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -31,6 +31,14 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Engine" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
         </dependentAssembly>


### PR DESCRIPTION
After c3f85b added these to our VSIX and we stopped using the ones built
from the VS repo (as version 15.0), various things in VS broke because
Microsoft.Build.Engine 15.0 couldn't be loaded. Adding redirects for it
and Conversion.Core which was changed similarly.

Fixes the MSBuild.exe side of
https://devdiv.visualstudio.com/DevDiv/_workitems?id=273046.