### PR TITLE
Fix unit tests that use CreateInMemoryProject

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -208,7 +208,7 @@ case $host in
         ;;
 esac
 
-BUILD_MSBUILD_ARGS="$PROJECT_FILE_ARG /t:$TARGET_ARG /p:OS=$OS_ARG /p:Configuration=$CONFIGURATION /p:OverrideToolHost=$RUNTIME_HOST /verbosity:minimal $EXTRA_ARGS"
+BUILD_MSBUILD_ARGS="$PROJECT_FILE_ARG /p:OS=$OS_ARG /p:Configuration=$CONFIGURATION /p:OverrideToolHost=$RUNTIME_HOST /verbosity:minimal $EXTRA_ARGS"
 
 setHome
 
@@ -216,7 +216,7 @@ restoreBuildTools
 
 echo
 echo "** Rebuilding MSBuild with downloaded binaries"
-runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_EXE" "$BUILD_MSBUILD_ARGS" "$BOOTSTRAP_BUILD_LOG_PATH"
+runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_EXE" "/t:Rebuild $BUILD_MSBUILD_ARGS" "$BOOTSTRAP_BUILD_LOG_PATH"
 
 if [[ $BOOTSTRAP_ONLY = true ]]; then
     exit $?
@@ -229,4 +229,4 @@ runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_EXE" "$MOVE_MSBUIL
 
 echo
 echo "** Rebuilding MSBuild with locally built binaries"
-runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_BOOTSTRAPPED_EXE" "$BUILD_MSBUILD_ARGS" "$LOCAL_BUILD_LOG_PATH"
+runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_BOOTSTRAPPED_EXE" "/t:$TARGET_ARG $BUILD_MSBUILD_ARGS" "$LOCAL_BUILD_LOG_PATH"

--- a/dir.targets
+++ b/dir.targets
@@ -44,6 +44,12 @@
     <XunitOptions Condition="'$(OS)'=='Windows_NT' and '$(MonoBuild)' == 'true'">$(XunitOptions) -notrait category=mono-windows-failing</XunitOptions>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(JENKINS_URL)' != ''">
+    <!-- Properties for when the tests are running in Jenkins -->
+    <XunitOptions Condition="'$(NetCoreBuild)' == 'true'">$(XunitOptions) -showprogress</XunitOptions>
+    <XunitOptions Condition="'$(NetCoreBuild)' != 'true'">$(XunitOptions) -verbose</XunitOptions>
+  </PropertyGroup>
+
   <Target Name="CopyBuildOutputToDeploymentDirectories"
           Condition="'$(CopyBuildOutputToDeploymentDirectories)' != 'false'">
     <ItemGroup>

--- a/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             }
             finally
             {
-                EscapingInProjectsHelper.CleanupWeirdoFiles();
+                ObjectModelHelpers.DeleteTempProjectDirectory();
             }
         }
 
@@ -361,7 +361,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             }
             finally
             {
-                EscapingInProjectsHelper.CleanupWeirdoFiles();
+                ObjectModelHelpers.DeleteTempProjectDirectory();
             }
         }
 
@@ -423,7 +423,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             }
             finally
             {
-                EscapingInProjectsHelper.CleanupWeirdoFiles();
+                ObjectModelHelpers.DeleteTempProjectDirectory();
             }
         }
 
@@ -697,7 +697,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             }
             finally
             {
-                EscapingInProjectsHelper.CleanupWeirdoFiles();
+                ObjectModelHelpers.DeleteTempProjectDirectory();
             }
         }
 
@@ -735,7 +735,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             }
             finally
             {
-                EscapingInProjectsHelper.CleanupWeirdoFiles();
+                ObjectModelHelpers.DeleteTempProjectDirectory();
             }
         }
 #endif
@@ -1777,27 +1777,12 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// </summary>
         internal static void CreateThreeWeirdoFiles()
         {
-            CleanupWeirdoFiles();
-
-            string tempPath = Path.GetTempPath();
+            ObjectModelHelpers.DeleteTempProjectDirectory();
 
             // Create 3 files in the temp path -- a.weirdo, b.weirdo, and c.weirdo.
-            File.WriteAllText(Path.Combine(tempPath, "a.weirdo"), String.Empty);
-            File.WriteAllText(Path.Combine(tempPath, "b.weirdo"), String.Empty);
-            File.WriteAllText(Path.Combine(tempPath, "c.weirdo"), String.Empty);
-        }
-
-        /// <summary>
-        /// Delete all *.weirdo files from the temp directory.
-        /// </summary>
-        internal static void CleanupWeirdoFiles()
-        {
-            // Delete all *.weirdo files from the temp path.
-            string[] filesEndingWithWeirdo = Directory.GetFiles(Path.GetTempPath(), "*.weirdo");
-            foreach (string fileEndingWithWeirdo in filesEndingWithWeirdo)
-            {
-                File.Delete(fileEndingWithWeirdo);
-            }
+            File.WriteAllText(Path.Combine(ObjectModelHelpers.TempProjectDir, "a.weirdo"), String.Empty);
+            File.WriteAllText(Path.Combine(ObjectModelHelpers.TempProjectDir, "b.weirdo"), String.Empty);
+            File.WriteAllText(Path.Combine(ObjectModelHelpers.TempProjectDir, "c.weirdo"), String.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
Some tests use ObjectModelHelpers.CreateInMemoryProject() in order to create a temporary project.  The current implementation points to the TEMP folder which on many machines can contain well over 10,000 files.  The glob tests are timing out on Mac machines in CI probably because their TEMP folders contain even more files.

I also had to fix some tests using "wierdo" files since they are trying to create an in-memory project but expect certain things on disk.