### PR TITLE
﻿Avoid IO exceptions when possible

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string NormalizePathForComparisonNoThrow(string path, string currentDirectory)
         {
-            return GetFullPathNoThrow(path, currentDirectory).TrimEnd('/', '\\');
+            return GetFullPathNoThrow(path, currentDirectory).NormalizeForPathComparison();
         }
 
         /// <summary>
@@ -506,6 +506,12 @@ namespace Microsoft.Build.Shared
         {
             var fullPath = fileSpec;
 
+            // file is invalid, return early to avoid triggering an exception
+            if (IsInvalidPath(fullPath))
+            {
+                return fullPath;
+            }
+
             try
             {
                 fullPath = GetFullPath(fileSpec, currentDirectory);
@@ -515,6 +521,18 @@ namespace Microsoft.Build.Shared
             }
 
             return fullPath;
+        }
+
+        private static bool IsInvalidPath(string path)
+        {
+            if (path.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+            {
+                return true;
+            }
+
+            var filename = Path.GetFileName(path);
+
+            return filename.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -519,7 +519,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
            new[] { "aab", "aaxb", @"dir\abb", @"dir\abxb" },
            new[] { "aab", @"dir\abb" })]
         // items as files: include with non-escaped glob does not match exclude with escaped wildcard character.
-        // The exclude is treated as a literal and only matches against non-glob include fragments (i.e., against values and item references)
+        // The exclude is treated as a literal and only matches against non-glob include fragments (i.e., against values and item references). %2A is *
         [InlineData(ItemWithIncludeAndExclude,
             @"**\a*b;**\a%2Axb",
             @"**\a%2Axb",

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -2538,6 +2538,33 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Fact]
+        public void GetItemProvenanceGlobMatchesItselfAsGlob()
+        {
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`ab*cd`/>
+                    <B Include=`tx?yz`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
+            };
+
+            AssertProvenanceResult(expected, project, "ab*cd");
+
+            expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("B", Operation.Include, Provenance.Glob, 1),
+            };
+
+            AssertProvenanceResult(expected, project, "tx?yz");
+        }
+
+        [Fact]
         public void GetItemProvenanceResultsShouldBeInItemElementOrder()
         {
             var itemElements = Environment.ProcessorCount * 5;
@@ -2941,7 +2968,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             var project =
                 @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
                   <ItemGroup>
-                    <A Include=`|:/\?*`/>
+                    <A Include=`|:/\`/>
                   </ItemGroup>
                 </Project>
                 ";
@@ -2949,6 +2976,10 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             var expected = new ProvenanceResultTupleList();
 
             AssertProvenanceResult(expected, project, @"?:/*\|");
+
+            expected.Add(Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1));
+
+            AssertProvenanceResult(expected, project, @"|:/\");
         }
 
         [Fact]


### PR DESCRIPTION
Files with invalid characters will throw an exception, so do a check beforehand to avoid the exception.
CPS reported that projects with many non file items are hard to debug because all of the exceptions coming from this method.

Perf tests show that ~10ms are added to a GIP call on a project with 10000 item elements (from ~230ms to ~240) when GIP is called with no illegal items as paths (exceptions would not have been thrown). When all GIP calls have illegal strings as paths then, no perf hit happens. Probably the check cancels itself out with not having to call GetFullPath and swallowing the exception