### PR TITLE
adding support for versioned SDK content in ToolLocationHelper

### DIFF
--- a/src/Utilities/ApiContract.cs
+++ b/src/Utilities/ApiContract.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Build.Utilities
             return String.Equals(elementName, Elements.ContainedApiContracts, StringComparison.Ordinal);
         }
 
+        internal static bool IsVersionedContentElement(string elementName)
+        {
+            return string.Equals(elementName, Elements.VersionedContent, StringComparison.Ordinal);
+        }
+
         /// <summary>
         /// Given an XML element containing API contracts, read out all contracts within that element. 
         /// </summary>
@@ -85,6 +90,11 @@ namespace Microsoft.Build.Utilities
             /// Element representing an individual API contract
             /// </summary>
             public const string ApiContract = "ApiContract";
+
+            /// <summary>
+            /// Element representing a flag to indicate if the SDK content is versioned
+            /// </summary>
+            public const string VersionedContent = "VersionedContent";
         }
 
         /// <summary>

--- a/src/Utilities/PlatformManifest.cs
+++ b/src/Utilities/PlatformManifest.cs
@@ -83,6 +83,12 @@ namespace Microsoft.Build.Utilities
             private set;
         }
 
+        public bool VersionedContent
+        {
+            get;
+            private set;
+        }
+
         /// <summary>
         /// Flag set to true if an exception occurred while reading the manifest
         /// </summary>
@@ -165,6 +171,12 @@ namespace Microsoft.Build.Utilities
                             if (ApiContract.IsContainedApiContractsElement(childElement.Name))
                             {
                                 ApiContract.ReadContractsElement(childElement, ApiContracts);
+                            }
+                            else if(ApiContract.IsVersionedContentElement(childElement.Name))
+                            {
+                                bool versionedContent = false;
+                                bool.TryParse(childElement.InnerText, out versionedContent);
+                                this.VersionedContent = versionedContent;
                             }
                             else if (String.Equals(childElement.Name, Elements.DependentPlatform, StringComparison.Ordinal))
                             {

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1068,7 +1068,14 @@ namespace Microsoft.Build.Utilities
 
                     if (!manifest.ReadError)
                     {
-                        contractWinMDs = GetApiContractReferences(manifest.ApiContracts, matchingSdk.Path);
+                        if (manifest.VersionedContent)
+                        {
+                            contractWinMDs = GetApiContractReferences(manifest.ApiContracts, matchingSdk.Path, manifest.PlatformVersion);
+                        }
+                        else
+                        {
+                            contractWinMDs = GetApiContractReferences(manifest.ApiContracts, matchingSdk.Path);
+                        }
                     }
                 }
             }
@@ -1088,6 +1095,18 @@ namespace Microsoft.Build.Utilities
         /// <returns>List of matching WinMDs</returns>
         internal static string[] GetApiContractReferences(IEnumerable<ApiContract> apiContracts, string targetPlatformSdkRoot)
         {
+            return GetApiContractReferences(apiContracts, targetPlatformSdkRoot, String.Empty);
+        }
+
+        /// <summary>
+        /// Return the WinMD paths referenced by the given api contracts and target sdk root
+        /// </summary>
+        /// <param name="apiContracts">The API contract definitions</param>
+        /// <param name="targetPlatformSdkRoot">The root of the target platform SDK</param>
+        /// <param name="targetPlatformSdkVersion">The version of the target platform SDK</param>
+        /// <returns>List of matching WinMDs</returns>
+        internal static string[] GetApiContractReferences(IEnumerable<ApiContract> apiContracts, string targetPlatformSdkRoot, string targetPlatformSdkVersion)
+        {
             if (apiContracts == null)
             {
                 return new string[] { };
@@ -1095,7 +1114,7 @@ namespace Microsoft.Build.Utilities
 
             List<string> contractWinMDs = new List<string>();
 
-            string referencesRoot = Path.Combine(targetPlatformSdkRoot, referencesFolderName);
+            string referencesRoot = Path.Combine(targetPlatformSdkRoot, referencesFolderName, targetPlatformSdkVersion);
 
             foreach (ApiContract contract in apiContracts)
             {

--- a/src/Utilities/UnitTests/Microsoft.Build.Utilities.UnitTests.csproj
+++ b/src/Utilities/UnitTests/Microsoft.Build.Utilities.UnitTests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="..\..\XMakeBuildEngine\BackEnd\Node\NativeMethods.cs">
       <Link>NativeMethods.cs</Link>
     </Compile>
+    <Compile Include="PlatformManifest_Tests.cs" />
     <Compile Include="TrackedDependencies\FileTrackerTests.cs" />
     <Compile Include="TrackedDependencies\TrackedDependenciesTests.cs" />
     <Compile Include="TrackedDependencies\MockEngine.cs" />

--- a/src/Utilities/UnitTests/PlatformManifest_Tests.cs
+++ b/src/Utilities/UnitTests/PlatformManifest_Tests.cs
@@ -6,33 +6,32 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
+using Xunit;
 
 namespace Microsoft.Build.UnitTests
 {
     /// <summary>
     /// Basic tests of Platform.xml parsing
     /// </summary>
-    [TestClass]
     sealed public class PlatformManifest_Tests
     {
         /// <summary>
         /// Should get a read error when the manifest location is invalid
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void InvalidManifestLocation()
         {
             PlatformManifest manifest = new PlatformManifest("|||||||");
 
-            Assert.IsTrue(manifest.ReadError);
+            Assert.True(manifest.ReadError);
         }
 
         /// <summary>
         /// Should get a read error when the manifest location is valid but empty
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void EmptyManifestLocation()
         {
             string manifestDirectory = null;
@@ -42,7 +41,7 @@ namespace Microsoft.Build.UnitTests
                 manifestDirectory = FileUtilities.GetTemporaryDirectory();
                 PlatformManifest manifest = new PlatformManifest(manifestDirectory);
 
-                Assert.IsTrue(manifest.ReadError);
+                Assert.True(manifest.ReadError);
             }
             finally
             {
@@ -57,7 +56,7 @@ namespace Microsoft.Build.UnitTests
         /// Should get a read error when the manifest location is valid but doesn't have a 
         /// file named Platform.xml
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void ManifestLocationHasNoPlatformXml()
         {
             string manifestDirectory = null;
@@ -68,7 +67,7 @@ namespace Microsoft.Build.UnitTests
                 File.WriteAllText(Path.Combine(manifestDirectory, "SomeOtherFile.xml"), "hello");
                 PlatformManifest manifest = new PlatformManifest(manifestDirectory);
 
-                Assert.IsTrue(manifest.ReadError);
+                Assert.True(manifest.ReadError);
             }
             finally
             {
@@ -82,34 +81,34 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Should get a read error when trying to read an invalid manifest file. 
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void InvalidManifest()
         {
             string contents = @"|||||";
 
             using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
             {
-                Assert.IsTrue(manifest.Manifest.ReadError);
+                Assert.True(manifest.Manifest.ReadError);
             }
         }
 
         /// <summary>
         /// Verify that a simple PlatformManifest can be successfully constructed. 
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void SimpleValidManifest()
         {
             string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0` />";
 
             using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
             {
-                Assert.IsFalse(manifest.Manifest.ReadError);
-                Assert.AreEqual("UAP", manifest.Manifest.Name);
-                Assert.AreEqual("Universal Application Platform", manifest.Manifest.FriendlyName);
-                Assert.AreEqual("1.0.0.0", manifest.Manifest.PlatformVersion);
+                Assert.False(manifest.Manifest.ReadError);
+                Assert.Equal("UAP", manifest.Manifest.Name);
+                Assert.Equal("Universal Application Platform", manifest.Manifest.FriendlyName);
+                Assert.Equal("1.0.0.0", manifest.Manifest.PlatformVersion);
 
-                Assert.AreEqual(0, manifest.Manifest.DependentPlatforms.Count);
-                Assert.AreEqual(0, manifest.Manifest.ApiContracts.Count);
+                Assert.Equal(0, manifest.Manifest.DependentPlatforms.Count);
+                Assert.Equal(0, manifest.Manifest.ApiContracts.Count);
             }
         }
 
@@ -117,20 +116,20 @@ namespace Microsoft.Build.UnitTests
         /// Verify that a simple PlatformManifest can be successfully constructed, even if it's missing 
         /// some fields. 
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void SimpleValidManifestWithMissingFriendlyName()
         {
             string contents = @"<ApplicationPlatform name=`UAP` version=`1.0.0.0` />";
 
             using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
             {
-                Assert.IsFalse(manifest.Manifest.ReadError);
-                Assert.AreEqual("UAP", manifest.Manifest.Name);
-                Assert.AreEqual(String.Empty, manifest.Manifest.FriendlyName);
-                Assert.AreEqual("1.0.0.0", manifest.Manifest.PlatformVersion);
+                Assert.False(manifest.Manifest.ReadError);
+                Assert.Equal("UAP", manifest.Manifest.Name);
+                Assert.Equal(String.Empty, manifest.Manifest.FriendlyName);
+                Assert.Equal("1.0.0.0", manifest.Manifest.PlatformVersion);
 
-                Assert.AreEqual(0, manifest.Manifest.DependentPlatforms.Count);
-                Assert.AreEqual(0, manifest.Manifest.ApiContracts.Count);
+                Assert.Equal(0, manifest.Manifest.DependentPlatforms.Count);
+                Assert.Equal(0, manifest.Manifest.ApiContracts.Count);
             }
         }
 
@@ -138,7 +137,7 @@ namespace Microsoft.Build.UnitTests
         /// Platform manifest with a dependent platform missing some information. 
         /// NOTE: probably ought to be an error. 
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void DependentPlatformMissingName()
         {
             string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0`>
@@ -147,21 +146,21 @@ namespace Microsoft.Build.UnitTests
 
             using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
             {
-                Assert.IsFalse(manifest.Manifest.ReadError);
+                Assert.False(manifest.Manifest.ReadError);
 
-                Assert.AreEqual(0, manifest.Manifest.ApiContracts.Count);
-                Assert.AreEqual(1, manifest.Manifest.DependentPlatforms.Count);
+                Assert.Equal(0, manifest.Manifest.ApiContracts.Count);
+                Assert.Equal(1, manifest.Manifest.DependentPlatforms.Count);
 
                 List<PlatformManifest.DependentPlatform> platforms = new List<PlatformManifest.DependentPlatform>(manifest.Manifest.DependentPlatforms);
-                Assert.AreEqual(String.Empty, platforms[0].Name);
-                Assert.AreEqual("1.0.0.0", platforms[0].Version);
+                Assert.Equal(String.Empty, platforms[0].Name);
+                Assert.Equal("1.0.0.0", platforms[0].Version);
             }
         }
 
         /// <summary>
         /// Verify a PlatformManifest with multiple dependent platforms.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void MultipleDependentPlatforms()
         {
             string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0`>
@@ -172,18 +171,18 @@ namespace Microsoft.Build.UnitTests
 
             using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
             {
-                Assert.IsFalse(manifest.Manifest.ReadError);
+                Assert.False(manifest.Manifest.ReadError);
 
-                Assert.AreEqual(0, manifest.Manifest.ApiContracts.Count);
-                Assert.AreEqual(3, manifest.Manifest.DependentPlatforms.Count);
+                Assert.Equal(0, manifest.Manifest.ApiContracts.Count);
+                Assert.Equal(3, manifest.Manifest.DependentPlatforms.Count);
 
                 List<PlatformManifest.DependentPlatform> platforms = new List<PlatformManifest.DependentPlatform>(manifest.Manifest.DependentPlatforms);
-                Assert.AreEqual("UAP", platforms[0].Name);
-                Assert.AreEqual("1.0.0.0", platforms[0].Version);
-                Assert.AreEqual("UAP", platforms[1].Name);
-                Assert.AreEqual("1.0.2.3", platforms[1].Version);
-                Assert.AreEqual("MyPlatform", platforms[2].Name);
-                Assert.AreEqual("8.8.8.8", platforms[2].Version);
+                Assert.Equal("UAP", platforms[0].Name);
+                Assert.Equal("1.0.0.0", platforms[0].Version);
+                Assert.Equal("UAP", platforms[1].Name);
+                Assert.Equal("1.0.2.3", platforms[1].Version);
+                Assert.Equal("MyPlatform", platforms[2].Name);
+                Assert.Equal("8.8.8.8", platforms[2].Version);
             }
         }
 
@@ -191,7 +190,7 @@ namespace Microsoft.Build.UnitTests
         /// Platform manifest with a contract missing some information. 
         /// NOTE: technically probably ought to be an error. 
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void ContractMissingVersion()
         {
             string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0`>
@@ -203,24 +202,24 @@ namespace Microsoft.Build.UnitTests
 
             using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
             {
-                Assert.IsFalse(manifest.Manifest.ReadError);
+                Assert.False(manifest.Manifest.ReadError);
 
-                Assert.AreEqual(1, manifest.Manifest.DependentPlatforms.Count);
+                Assert.Equal(1, manifest.Manifest.DependentPlatforms.Count);
                 PlatformManifest.DependentPlatform platform = manifest.Manifest.DependentPlatforms.First();
-                Assert.AreEqual("UAP", platform.Name);
-                Assert.AreEqual("1.0.2.3", platform.Version);
+                Assert.Equal("UAP", platform.Name);
+                Assert.Equal("1.0.2.3", platform.Version);
 
-                Assert.AreEqual(1, manifest.Manifest.ApiContracts.Count);
+                Assert.Equal(1, manifest.Manifest.ApiContracts.Count);
                 ApiContract contract = manifest.Manifest.ApiContracts.First();
-                Assert.AreEqual("System", contract.Name);
-                Assert.AreEqual(String.Empty, contract.Version);
+                Assert.Equal("System", contract.Name);
+                Assert.Equal(String.Empty, contract.Version);
             }
         }
 
         /// <summary>
         /// Verify a platform manifest with API contracts. 
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void MultipleContracts()
         {
             string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0`>
@@ -233,19 +232,70 @@ namespace Microsoft.Build.UnitTests
 
             using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
             {
-                Assert.IsFalse(manifest.Manifest.ReadError);
+                Assert.False(manifest.Manifest.ReadError);
 
-                Assert.AreEqual(0, manifest.Manifest.DependentPlatforms.Count);
-                Assert.AreEqual(3, manifest.Manifest.ApiContracts.Count);
+                Assert.Equal(0, manifest.Manifest.DependentPlatforms.Count);
+                Assert.Equal(3, manifest.Manifest.ApiContracts.Count);
 
                 List<ApiContract> contracts = new List<ApiContract>(manifest.Manifest.ApiContracts);
 
-                Assert.AreEqual("System", contracts[0].Name);
-                Assert.AreEqual("1.2.0.4", contracts[0].Version);
-                Assert.AreEqual("Windows.Foundation", contracts[1].Name);
-                Assert.AreEqual("1.0.0.0", contracts[1].Version);
-                Assert.AreEqual("Windows.Foundation.OtherStuff", contracts[2].Name);
-                Assert.AreEqual("1.5.0.0", contracts[2].Version);
+                Assert.Equal("System", contracts[0].Name);
+                Assert.Equal("1.2.0.4", contracts[0].Version);
+                Assert.Equal("Windows.Foundation", contracts[1].Name);
+                Assert.Equal("1.0.0.0", contracts[1].Version);
+                Assert.Equal("Windows.Foundation.OtherStuff", contracts[2].Name);
+                Assert.Equal("1.5.0.0", contracts[2].Version);
+            }
+        }
+
+        [Fact]
+        public void VersionedContentFlagMissingReturnsFalse()
+        {
+            string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0`>
+                                </ApplicationPlatform>";
+
+            using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
+            {
+                Assert.False(manifest.Manifest.VersionedContent);
+            }
+        }
+
+        [Fact]
+        public void VersionedContentInvalidFlagReturnsFalse()
+        {
+            string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0`>
+                                    <VersionedContent>Invalid</VersionedContent>
+                                </ApplicationPlatform>";
+
+            using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
+            {
+                Assert.False(manifest.Manifest.VersionedContent);
+            }
+        }
+
+        [Fact]
+        public void VersionedContentFalseFlagReturnsFalse()
+        {
+            string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0`>
+                                    <VersionedContent>False</VersionedContent>
+                                </ApplicationPlatform>";
+
+            using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
+            {
+                Assert.False(manifest.Manifest.VersionedContent);
+            }
+        }
+
+        [Fact]
+        public void VersionedContentTrueFlagReturnsTrue()
+        {
+            string contents = @"<ApplicationPlatform name=`UAP` friendlyName=`Universal Application Platform` version=`1.0.0.0`>
+                                    <VersionedContent>True</VersionedContent>
+                                </ApplicationPlatform>";
+
+            using (TemporaryPlatformManifest manifest = new TemporaryPlatformManifest(contents))
+            {
+                Assert.True(manifest.Manifest.VersionedContent);
             }
         }
 

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -76,6 +76,29 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void GetApiContractReferencesFindsVersionedWinMDs()
+        {
+            string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            string tempVersion = "10.0.12345.0";
+            string referenceDirectory = Path.Combine(tempDirectory, @"References", tempVersion, @"Foo\Bar");
+
+            try
+            {
+                Directory.CreateDirectory(referenceDirectory);
+                File.WriteAllText(Path.Combine(referenceDirectory, "One.winmd"), "First");
+                string[] returnValue = ToolLocationHelper.GetApiContractReferences(new ApiContract[] { new ApiContract { Name = "Foo", Version = "Bar" } }, tempDirectory, tempVersion);
+                Assert.Equal(1, returnValue.Length);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDirectory))
+                {
+                    Directory.Delete(tempDirectory, true);
+                }
+            }
+        }
+
+        [Fact]
         public void GatherExtensionSDKsInvalidVersionDirectory()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());


### PR DESCRIPTION
Add support for the new Platform.xml value "VersionedContent" (boolean).
If present and true, this flag instructs ToolLocationHelper to retrieve References from a versioned folder. SDK team will make the appropriate changes to Platform.xml, UAP.props, and UAP.arm.props to ensure other content paths are updated appropriately.