### PR TITLE
Disable parallel build on xlf sync

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -24,6 +24,9 @@
   <!-- Localization switches -->
   <PropertyGroup>
     <LocalizationBuildAssetsRequired Condition="'$(LocalizedBuild)' == 'true' or '$(SyncXlf)' == 'true'">true</LocalizationBuildAssetsRequired>
+
+    <!-- Syncing xlf files in parallel leads to races because of the shared resources under /Shared/Resources/xlf -->
+    <BuildInParallel Condition="'$(SyncXlf)' == 'true'">false</BuildInParallel>
   </PropertyGroup>
 
    <!-- Common repo directories -->

--- a/src/UpdateLocalizedResources.targets
+++ b/src/UpdateLocalizedResources.targets
@@ -69,9 +69,7 @@
           BeforeTargets="$(PrepareResourcesDependsOn);PrepareResources">
 
     <ItemGroup>
-      <NeutralResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resx'">
-        <IsShared>$([System.String]::Copy('%(Filename)').StartsWith('Strings.shared.'))</IsShared>
-      </NeutralResources> 
+      <NeutralResources Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resx'"/> 
     </ItemGroup>
 
     <EmitLocalizedResources 
@@ -84,13 +82,6 @@
       <Output TaskParameter="ResolvedLocalizedResxResources" ItemName="LocalizedResxResources" />
 
     </EmitLocalizedResources>
-
-    <ItemGroup>
-      <XlfFiles>
-        <IsShared>$([System.String]::Copy('%(Filename)').StartsWith('Strings.shared.'))</IsShared>
-      </XlfFiles>
-    </ItemGroup>
-
   </Target>
 
   <Target Name="SyncXlf"
@@ -98,19 +89,10 @@
           DependsOnTargets="EmitLocalizedResources" 
           Condition="$(SyncXlf) == 'true' and $(IsTestProject) != 'true'">
     
-    <!-- only one project should update the shared resources. Otherwise races happen -->
-    <ItemGroup>
-      <XlfFilesToSync Include="@(XlfFiles)"/>
-      <XlfFilesToSync
-        Remove="@(XlfFilesToSync)"
-        Condition="'$(AssemblyName)' != 'MSBuild' and '%(XlfFilesToSync.IsShared)' == 'True'"
-        />
-    </ItemGroup>
-
     <UpdateXlfFromResx
       Condition="%(Identity) != ''"
       ResxPath="%(NeutralResx)"
-      XlfPath="@(XlfFilesToSync)"
+      XlfPath="@(XlfFiles)"
     />
 
   </Target>


### PR DESCRIPTION
Fixing the race in #1145 created two other races:
- if only one project updates the shared xlf, if that project is not the first one, all the others see stale shared xlf files. This means the other projects' generated resx files will be stale. Can crash msbuild with resource not found exception
- if a project is generating resx from shared xlf just as the anointed project is updating them, the xlf won't be able to be opened.

Fast fix is to just disable parallel builds when SyncXlf is set to true. CI should not sync xlf files. We should only do this manually when we want to commit the changed xlf files (requesting localization or adding new resources (to avoid crashing localized msbuilds with resource not found)).

Other, better, but more time consuming solutions:
- synx xlf during an extra traversal project that happens before `src/dirs.proj`. Since localization is project specific, it will still have to call `src/dirs.proj` but with the `SyncXlf` target instead of the `Build` target
- even better, transform the /Shared folder into an actual project, and make the rest of the projects depend on it, rather than share its sources and resources