### PR TITLE
Allow MSBuild to query VS setup for toolset

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -11,6 +11,14 @@ namespace Microsoft.Build.Shared
 {
     internal class BuildEnvironmentHelper
     {
+        // Since this class is added as 'link' to shared source in multiple projects,
+        // MSBuildConstants.CurrentVisualStudioVersion is not available in all of them.
+        private const string CurrentVisualStudioVersion = "15.0";
+
+        // MSBuildConstants.CurrentToolsVersion
+        private const string CurrentToolsVersion = "15.0";
+
+        // Duplicated in InternalErrorException.cs. Update both when changing.
         private static readonly string[] s_testRunners =
         {
             "XUNIT", "NUNIT", "MSTEST", "VSTEST", "TASKRUNNER",
@@ -87,7 +95,7 @@ namespace Microsoft.Build.Shared
         {
             if (string.IsNullOrEmpty(visualStudioPath)) return null;
 
-            var msbuildFromVisualStudioRoot = FileUtilities.CombinePaths(visualStudioPath, "MSBuild", "15.0", "Bin");
+            var msbuildFromVisualStudioRoot = FileUtilities.CombinePaths(visualStudioPath, "MSBuild", CurrentToolsVersion, "Bin");
             return TryFromFolder(msbuildFromVisualStudioRoot, runningTests, runningInVisualStudio, visualStudioPath);
         }
 
@@ -166,7 +174,7 @@ namespace Microsoft.Build.Shared
                 () => TryGetVsFromMSBuildLocation(processNameCurrentProcess)
             };
 
-            return possibleLocations.Select(location => location()).FirstOrDefault(path => path != null);
+            return possibleLocations.Select(location => location()).FirstOrDefault(path => !string.IsNullOrEmpty(path));
         }
 
         private static string TryGetVsFromProcess(string process)
@@ -186,7 +194,7 @@ namespace Microsoft.Build.Shared
 
             if (!string.IsNullOrEmpty(vsInstallDir) &&
                 !string.IsNullOrEmpty(vsVersion) &&
-                vsVersion == "15.0" &&
+                vsVersion == CurrentVisualStudioVersion &&
                 Directory.Exists(vsInstallDir))
             {
                 return vsInstallDir;
@@ -198,7 +206,7 @@ namespace Microsoft.Build.Shared
         private static string TryGetVsFromInstalled()
         {
             var instances = s_getVisualStudioInstances();
-            Version v = new Version("15.0");
+            Version v = new Version(CurrentVisualStudioVersion);
 
             // Get the first instance of Visual Studio that matches our Major/Minor compatible version
             return instances.FirstOrDefault(

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -38,8 +38,28 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Gets the cached Build Environment instance.
         /// </summary>
-        public static BuildEnvironment Instance => BuildEnvironmentHelperSingleton.s_instance;
-        
+        public static BuildEnvironment Instance
+        {
+            get
+            {
+                try
+                {
+                    return BuildEnvironmentHelperSingleton.s_instance;
+                }
+                catch (TypeInitializationException e)
+                {
+                    if (e.InnerException != null)
+                    {
+                        // Throw the error that caused the TypeInitializationException.
+                        // (likely InvalidOperationException)
+                        throw e.InnerException;
+                    }
+
+                    throw;
+                }
+            }
+        }
+
         /// <summary>
         /// Find the location of MSBuild.exe based on the current environment.
         /// </summary>
@@ -299,6 +319,11 @@ namespace Microsoft.Build.Shared
 
         private static class BuildEnvironmentHelperSingleton
         {
+            // Explicit static constructor to tell C# compiler
+            // not to mark type as beforefieldinit
+            static BuildEnvironmentHelperSingleton()
+            { }
+
             public static BuildEnvironment s_instance = Initialize();
         }
     }

--- a/src/Shared/InternalErrorException.cs
+++ b/src/Shared/InternalErrorException.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Build.Shared
         private static bool RunningTests()
         {
             // Copied logic from BuildEnvironmentHelper. Removed reference for single use due
-            // to additional dependencies.
+            // to additional dependencies. Update both if needed.
             string[] testRunners =
             {
                 "XUNIT", "NUNIT", "MSTEST", "VSTEST", "TASKRUNNER", "VSTESTHOST", "QTAGENT32",

--- a/src/Shared/InternalErrorException.cs
+++ b/src/Shared/InternalErrorException.cs
@@ -8,6 +8,8 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Security.Permissions; // for SecurityPermissionAttribute
 using System.Runtime.Serialization;
 
@@ -114,9 +116,7 @@ namespace Microsoft.Build.Shared
 #if DEBUG   
             if (Environment.GetEnvironmentVariable("MSBUILDDONOTLAUNCHDEBUGGER") == null)
             {
-                string processName = Process.GetCurrentProcess().ProcessName.ToUpperInvariant();
-
-                if (!BuildEnvironmentHelper.Instance.RunningTests)
+                if (!RunningTests())
                 {
                     if (Environment.GetEnvironmentVariable("_NTROOT") == null)
                     {
@@ -129,5 +129,25 @@ namespace Microsoft.Build.Shared
 #endif
         }
         #endregion
+
+        private static bool RunningTests()
+        {
+            // Copied logic from BuildEnvironmentHelper. Removed reference for single use due
+            // to additional dependencies.
+            string[] testRunners =
+            {
+                "XUNIT", "NUNIT", "MSTEST", "VSTEST", "TASKRUNNER", "VSTESTHOST", "QTAGENT32",
+                "CONCURRENT", "RESHARPER", "MDHOST", "TE.PROCESSHOST"
+            };
+
+            // Check if our current process name is in the list of own test runners
+            return IsProcessInList(Environment.GetCommandLineArgs()[0], testRunners) ||
+                   IsProcessInList(Process.GetCurrentProcess().MainModule.FileName, testRunners);
+        }
+
+        private static bool IsProcessInList(string processName, string[] processList)
+        {
+            return processList.Any(s => Path.GetFileNameWithoutExtension(processName)?.IndexOf(s, StringComparison.InvariantCultureIgnoreCase) >= 0);
+        }
     }
 }

--- a/src/Shared/VisualStudioLocationHelper.cs
+++ b/src/Shared/VisualStudioLocationHelper.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Setup.Configuration;
+
+namespace Microsoft.Build.Shared
+{
+    internal class VisualStudioInstance
+    {
+        /// <summary>
+        /// Version of the Visual Studio Instance
+        /// </summary>
+        internal Version Version { get; }
+
+        /// <summary>
+        /// Path to the Visual Studio installation
+        /// </summary>
+        internal string Path { get; }
+
+        /// <summary>
+        /// Full name of the Visual Studio instance with SKU name
+        /// </summary>
+        internal string Name { get; }
+
+        internal VisualStudioInstance(string name, string path, Version version)
+        {
+            Name = name;
+            Path = path;
+            Version = version;
+        }
+    }
+
+    internal class VisualStudioLocationHelper
+    {
+        private const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
+
+        /// <summary>
+        /// Query the Visual Studio setup API to get instances of Visual Studio installed
+        /// on the machine. Will not include anything before Visual Studio "15".
+        /// </summary>
+        /// <returns>Enumerable list of Visual Studio instances</returns>
+        internal static IEnumerable<VisualStudioInstance> GetInstances()
+        {
+            var validInstances = new List<VisualStudioInstance>();
+
+            try
+            {
+                var query = (ISetupConfiguration2)GetQuery();
+                var helper = (ISetupHelper)query;
+
+                var e = query.EnumAllInstances();
+
+                int fetched;
+                var instances = new ISetupInstance[1];
+                do
+                {
+                    e.Next(1, instances, out fetched);
+                    if (fetched > 0)
+                    {
+                        var instance = PrintInstance(instances[0], helper);
+                        if (instance != null)
+                        {
+                            validInstances.Add(instance);
+                        }
+                    }
+                }
+                while (fetched > 0);
+
+                return validInstances;
+            }
+            catch (Exception)
+            {
+                return validInstances;
+            }
+        }
+
+        private static ISetupConfiguration GetQuery()
+        {
+            try
+            {
+                // Try to CoCreate the class object.
+                return new SetupConfiguration();
+            }
+
+            catch (COMException ex) when (ex.ErrorCode == REGDB_E_CLASSNOTREG)
+            {
+                // Try to get the class object using app-local call.
+                ISetupConfiguration query;
+                var result = GetSetupConfiguration(out query, IntPtr.Zero);
+
+                if (result < 0)
+                {
+                    throw new COMException("Failed to get query", result);
+                }
+
+                return query;
+            }
+        }
+
+        private static VisualStudioInstance PrintInstance(ISetupInstance instance, ISetupHelper helper)
+        {
+            var instance2 = (ISetupInstance2)instance;
+            
+            var state = instance2.GetState();
+            if (state != InstanceState.Complete)
+            {
+                return null;
+            }
+
+            return new VisualStudioInstance(
+                instance.GetDisplayName(),
+                instance.GetInstallationPath(),
+                new Version(instance.GetInstallationVersion()));
+        }
+
+        [DllImport("Microsoft.VisualStudio.Setup.Configuration.Native.dll", ExactSpelling = true, PreserveSig = true)]
+        private static extern int GetSetupConfiguration(
+            [MarshalAs(UnmanagedType.Interface), Out] out ISetupConfiguration configuration,
+            IntPtr reserved);
+    }
+}

--- a/src/Shared/VisualStudioLocationHelper.cs
+++ b/src/Shared/VisualStudioLocationHelper.cs
@@ -7,73 +7,69 @@ using Microsoft.VisualStudio.Setup.Configuration;
 
 namespace Microsoft.Build.Shared
 {
-    internal class VisualStudioInstance
-    {
-        /// <summary>
-        /// Version of the Visual Studio Instance
-        /// </summary>
-        internal Version Version { get; }
-
-        /// <summary>
-        /// Path to the Visual Studio installation
-        /// </summary>
-        internal string Path { get; }
-
-        /// <summary>
-        /// Full name of the Visual Studio instance with SKU name
-        /// </summary>
-        internal string Name { get; }
-
-        internal VisualStudioInstance(string name, string path, Version version)
-        {
-            Name = name;
-            Path = path;
-            Version = version;
-        }
-    }
-
+    /// <summary>
+    /// Helper class to wrap the Microsoft.VisualStudio.Setup.Configuration.Interop API to query
+    /// Visual Studio setup for instances installed on the machine.
+    /// Code derived from sample: https://code.msdn.microsoft.com/Visual-Studio-Setup-0cedd331
+    /// </summary>
     internal class VisualStudioLocationHelper
     {
-        private const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
+        private const int REGDB_E_CLASSNOTREG = unchecked((int) 0x80040154);
 
         /// <summary>
         /// Query the Visual Studio setup API to get instances of Visual Studio installed
         /// on the machine. Will not include anything before Visual Studio "15".
         /// </summary>
         /// <returns>Enumerable list of Visual Studio instances</returns>
-        internal static IEnumerable<VisualStudioInstance> GetInstances()
+        internal static IList<VisualStudioInstance> GetInstances()
         {
             var validInstances = new List<VisualStudioInstance>();
 
             try
             {
-                var query = (ISetupConfiguration2)GetQuery();
-                var helper = (ISetupHelper)query;
-
+                // This code is not obvious. See the sample (link above) for reference.
+                var query = (ISetupConfiguration2) GetQuery();
                 var e = query.EnumAllInstances();
 
                 int fetched;
                 var instances = new ISetupInstance[1];
                 do
                 {
+                    // Call e.Next to query for the next instance (single item or nothing returned).
                     e.Next(1, instances, out fetched);
-                    if (fetched > 0)
-                    {
-                        var instance = PrintInstance(instances[0], helper);
-                        if (instance != null)
-                        {
-                            validInstances.Add(instance);
-                        }
-                    }
-                }
-                while (fetched > 0);
+                    if (fetched <= 0) continue;
 
-                return validInstances;
+                    var instance = instances[0];
+                    var state = ((ISetupInstance2) instance).GetState();
+                    Version version;
+
+                    try
+                    {
+                        version = new Version(instance.GetInstallationVersion());
+                    }
+                    catch (FormatException)
+                    {
+                        continue;
+                    }
+
+                    // If the install was complete and a valid version, consider it.
+                    if (state == InstanceState.Complete)
+                    {
+                        validInstances.Add(new VisualStudioInstance(
+                            instance.GetDisplayName(),
+                            instance.GetInstallationPath(),
+                            version));
+                    }
+                } while (fetched > 0);
             }
-            catch (Exception)
-            {
-                return validInstances;
+            catch (COMException)
+            { }
+            catch (DllNotFoundException)
+            { 
+                // This is OK, VS "15" or greater likely not installed.
             }
+
+            return validInstances;
         }
 
         private static ISetupConfiguration GetQuery()
@@ -99,25 +95,37 @@ namespace Microsoft.Build.Shared
             }
         }
 
-        private static VisualStudioInstance PrintInstance(ISetupInstance instance, ISetupHelper helper)
-        {
-            var instance2 = (ISetupInstance2)instance;
-            
-            var state = instance2.GetState();
-            if (state != InstanceState.Complete)
-            {
-                return null;
-            }
-
-            return new VisualStudioInstance(
-                instance.GetDisplayName(),
-                instance.GetInstallationPath(),
-                new Version(instance.GetInstallationVersion()));
-        }
-
         [DllImport("Microsoft.VisualStudio.Setup.Configuration.Native.dll", ExactSpelling = true, PreserveSig = true)]
         private static extern int GetSetupConfiguration(
             [MarshalAs(UnmanagedType.Interface), Out] out ISetupConfiguration configuration,
             IntPtr reserved);
+    }
+
+    /// <summary>
+    /// Wrapper class to represent an installed instance of Visual Studio.
+    /// </summary>
+    internal class VisualStudioInstance
+    {
+        /// <summary>
+        /// Version of the Visual Studio Instance
+        /// </summary>
+        internal Version Version { get; }
+
+        /// <summary>
+        /// Path to the Visual Studio installation
+        /// </summary>
+        internal string Path { get; }
+
+        /// <summary>
+        /// Full name of the Visual Studio instance with SKU name
+        /// </summary>
+        internal string Name { get; }
+
+        internal VisualStudioInstance(string name, string path, Version version)
+        {
+            Name = name;
+            Path = path;
+            Version = version;
+        }
     }
 }

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -152,6 +152,9 @@
       <Link>ToolsetElement.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\VisualStudioLocationHelper.cs">
+      <Link>VisualStudioLocationHelper.cs</Link>
+    </Compile>
     <Compile Include="ApiContract.cs" />
     <Compile Include="AppDomainIsolatedTask.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
@@ -244,6 +247,9 @@
       <Authenticode>Microsoft</Authenticode>
       <StrongName>StrongName</StrongName>
     </FilesToSign>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -1,7 +1,5 @@
 {
   "dependencies": {
-    "Microsoft.Tpl.Dataflow": "4.5.24",
-    "System.Collections.Immutable": "1.2.0",
     "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
   },
   "frameworks": {

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -112,6 +112,9 @@
     </Compile>
     <Compile Include="..\Shared\ReuseableStringBuilder.cs" />
     <Compile Include="..\Shared\ThreadPoolExtensions.cs" />
+    <Compile Include="..\Shared\VisualStudioLocationHelper.cs">
+      <Link>SharedUtilities\VisualStudioLocationHelper.cs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="BackEnd\BuildManager\BuildManager.cs" />
     <Compile Include="BackEnd\BuildManager\BuildParameters.cs" />

--- a/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -135,6 +135,43 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        public void BuildEnvironmentDetectsVisualStudioFromSetupInstance()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                // This test has no context to find MSBuild other than Visual Studio root.
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull,
+                    () =>
+                        new List<VisualStudioInstance>
+                        {
+                            new VisualStudioInstance("Invalid path", @"c:\_doesnotexist", new Version("15.0")),
+                            new VisualStudioInstance("VS", env.TempFolderRoot, new Version("15.0")),
+                        });
+
+                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
+            }
+        }
+
+        [Fact]
+        public void BuildEnvironmentVisualStudioNotFoundWhenVersionMismatch()
+        {
+            using (var env = new EmptyBuildEnviroment())
+            {
+                // This test has no context to find MSBuild other than Visual Studio root.
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull,
+                        () =>
+                            new List<VisualStudioInstance>
+                            {
+                                new VisualStudioInstance("Invalid path", @"c:\_doesnotexist", new Version("15.0")),
+                                new VisualStudioInstance("VS", env.TempFolderRoot, new Version("14.0")),
+                            });
+                });
+            }
+        }
+
+        [Fact]
         public void BuildEnvironmentDetectsRunningTests()
         {
             Assert.True(BuildEnvironmentHelper.Instance.RunningTests);

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -24,9 +24,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'" />
   <ItemGroup>
     <!-- Source Files -->
-    <Compile Include="..\..\Shared\BuildEnvironmentHelper.cs">
-      <Link>BuildEnvironmentHelper.cs</Link>
-    </Compile>
     <Compile Include="..\..\Shared\Constants.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -84,6 +84,9 @@
     <Compile Include="..\Shared\TempFileUtilities.cs">
       <Link>TempFileUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\VisualStudioLocationHelper.cs">
+      <Link>VisualStudioLocationHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\XMakeAttributes.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -158,29 +161,25 @@
     <Compile Include="XMake.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <None Include="project.json" />
     <!-- This is to enable CodeMarkers in MSBuild.exe -->
     <!-- Win32 RC Files -->
     <RCResourceFile Include="native.rc" />
-
     <!-- Resource Files -->
-
     <EmbeddedResource Include="Resources\Strings.resx">
       <LogicalName>$(AssemblyName).Strings.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-
     <EmbeddedResource Include="..\Shared\Resources\Strings.shared.resx">
       <Link>Resources\Strings.shared.resx</Link>
       <LogicalName>$(AssemblyName).Strings.shared.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-
     <!-- Content Files -->
     <Content Include="MSBuild.ico" />
     <Content Include="MSBuild.rsp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-
     <None Include="Microsoft.Build.CommonTypes.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -148,6 +148,9 @@
     <Compile Include="..\..\Shared\TaskParameterTypeVerifier.cs">
       <Link>TaskParameterTypeVerifier.cs</Link>
     </Compile>
+    <Compile Include="..\..\Shared\VisualStudioLocationHelper.cs">
+      <Link>VisualStudioLocationHelper.cs</Link>
+    </Compile>
     <Compile Include="..\..\Shared\XMakeAttributes.cs">
       <Link>XMakeAttributes.cs</Link>
     </Compile>
@@ -185,6 +188,7 @@
   <ItemGroup />
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\..\Shared\Resources\Strings.shared.resx">

--- a/src/XMakeCommandLine/MSBuildTaskHost/project.json
+++ b/src/XMakeCommandLine/MSBuildTaskHost/project.json
@@ -1,11 +1,9 @@
 {
   "dependencies": {
-    "Microsoft.Tpl.Dataflow": "4.5.24",
-    "System.Collections.Immutable": "1.2.0",
     "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
   },
   "frameworks": {
-    "net46": { }
+    "net35": { }
   },
   "runtimes": {
     "win": {},

--- a/src/XMakeCommandLine/project.json
+++ b/src/XMakeCommandLine/project.json
@@ -1,7 +1,5 @@
 {
   "dependencies": {
-    "Microsoft.Tpl.Dataflow": "4.5.24",
-    "System.Collections.Immutable": "1.2.0",
     "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
   },
   "frameworks": {

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -154,6 +154,9 @@
     <Compile Include="..\Shared\VisualStudioConstants.cs">
       <Link>VisualStudioConstants.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\VisualStudioLocationHelper.cs">
+      <Link>VisualStudioLocationHelper.cs</Link>
+    </Compile>
     <Compile Include="Al.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/XMakeTasks/project.json
+++ b/src/XMakeTasks/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "System.Collections.Immutable": "1.2.0"
+    "System.Collections.Immutable": "1.2.0",
+    "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
   },
   "frameworks": {
     "net46": { }

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -27,4 +27,13 @@
     <Touch Files="$(RestorePackagesSemaphore)" AlwaysCreate="true" />
   </Target>
 
+  <!-- Taken from Microsoft.VisualStudio.SDK.EmbedInteropTypes NuGet package which tries to fix this issue
+       (but doesn't include this assembly in their list).  -->
+  <Target Name="LinkVSEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Microsoft.VisualStudio.Setup.Configuration.Interop'">
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
This change allows for MSBuild to query the Visual Studio setup COM API (via managed interop) for instances of Visual Studio. When running on a machine with Visual Studio "15" this allows for a user to invoke the Build API without additional context (i.e. generic command window).

Also changed the behavior of the static initialization to not throw a TypeInitializationException on failure to find MSBuild.

Fixes #1161 