### PR TITLE
Add PersistenceStyle property to DataSource

### DIFF
--- a/src/Framework/XamlTypes/DataSource.cs
+++ b/src/Framework/XamlTypes/DataSource.cs
@@ -59,13 +59,27 @@ namespace Microsoft.Build.Framework.XamlTypes
         /// The storage location for this data source. 
         /// </summary>
         /// <remarks>
-        /// This field is mandatory and is culture invariant. Current accepted values are <c>ProjectFile</c>
-        /// and <c>UserFile</c>. <c>ProjectFile</c> causes the property value to be written to and read from
-        /// the project manifest file or the property sheet (depending on which node in the solution explorer/property manager
-        /// window is used to spawn the property pages UI). <c>UserFile</c> causes the property value to be written to and
-        /// read from the .user file.
+        /// This field is mandatory unless <see cref="PersistenceStyle"/> is set. In that case, the parent 
+        /// <see cref="DataSource"/> will be used with the specified style. Example values are <c>ProjectFile</c> and 
+        /// <c>UserFile</c>. <c>ProjectFile</c> causes the property value to be written to and read from the project 
+        /// manifest file or the property sheet (depending on which node in the solution explorer/property manager window
+        /// is used to spawn the property pages UI). <c>UserFile</c> causes the property value to be written to and read
+        /// from the .user file.
         /// </remarks>
         public string Persistence
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The storage style for this data source.
+        /// </summary>
+        /// <remarks>
+        /// For example, with <see cref="Persistence"/> of <c>ProjectFile</c>, this field can be <c>Element</c> (default) to 
+        /// save as a child XML Element, or <c>Attribute</c> to save properties as an XML attribute.
+        /// </remarks>
+        public string PersistenceStyle
         {
             get;
             set;


### PR DESCRIPTION
Add a new property to DataSource to allow a CPS `IProjectProperties` to have customizable behavior.

For example, a rule file could contain the following:

```xml
 <Rule.DataSource>
    <DataSource Persistence="ProjectFile" PersistenceStyle="Attribute" HasConfigurationCondition="False" ItemType="MyType" />
 </Rule.DataSource>

 <StringProperty Name="MyProperty">
    <DataSource PersistenceStyle="Element" />
 <StringProperty> 
```

This will default to storing all properties from that rule as an attribute on the MSBuild Item, except for `MyProperty`, which will use the same data source, but be persisted as a child XML element.