### PR TITLE
Fix-up xplat desktop build.

### DIFF
--- a/setup/Microsoft.Build.swixproj
+++ b/setup/Microsoft.Build.swixproj
@@ -20,8 +20,8 @@
   <PropertyGroup>
     <OutDir>$(BaseOutputPath)setup\</OutDir>
     <OutputPath>$(BaseOutputPath)setup\</OutputPath>
-    <X86BinPath>$(BaseOutputPath)X86\$(OS)\$(Configuration)\</X86BinPath>
-    <X64BinPath>$(BaseOutputPath)X64\$(OS)\$(Configuration)\</X64BinPath>
+    <X86BinPath>$(BaseOutputPath)X86\$(OS)\$(Configuration)\Output\</X86BinPath>
+    <X64BinPath>$(BaseOutputPath)X64\$(OS)\$(Configuration)\Output\</X64BinPath>
   </PropertyGroup>
 
   <!-- Needed for the MicroBuild signing plugin -->

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -25,9 +25,7 @@ namespace Microsoft.Build.Shared
         /// The most current Visual Studio Version known to this version of MSBuild. 
         /// </summary>
 #if STANDALONEBUILD
-#if STATIC_VERSION_NUMBER
         internal const string CurrentVisualStudioVersion = "15.0";
-#endif
 #else
         internal const string CurrentVisualStudioVersion = Microsoft.VisualStudio.Internal.BrandNames.VSGeneralVersion;
 #endif

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -733,8 +733,9 @@
     <!-- Assemblies Files we depend on -->
     <!-- Be conservative when adding references... adding System.Xml.Linq can add .47 sec cold start time to our launch time, or 80 ms to warm start time -->
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable" />
-    <Reference Include="System.Threading.Tasks.Dataflow" />
+    <Reference Include="System.Threading.Tasks.Dataflow">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -1,10 +1,12 @@
 ﻿{
+  "dependencies": {
+    "System.Collections.Immutable": "1.2.0"
+  },
   "frameworks": {
     "net46": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
-        "System.Collections.Immutable": "1.2.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Diagnostics.Contracts": "4.0.1",
         "System.Diagnostics.FileVersionInfo": "4.0.0",

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -952,7 +952,6 @@
       <HintPath>$(CompilerToolsDir)\Microsoft.Build.Tasks.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable" />
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/XMakeTasks/project.json
+++ b/src/XMakeTasks/project.json
@@ -1,4 +1,7 @@
 ﻿{
+  "dependencies": {
+    "System.Collections.Immutable": "1.2.0"
+  },
   "frameworks": {
     "net46": {},
     "netstandard1.3": {


### PR DESCRIPTION
 - Change setup binpath to end in 'Output'
 - Remove #if around STATIC_VERSION_NUMBER. Visual Studio version was not
   defined in that way.
 - Move System.Collections.Immutable to NuGet reference of the correct
   version.