### PR TITLE
Ignore whitespace text nodes when parsing projects

### DIFF
--- a/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
@@ -103,11 +103,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Check it will use large element location when it should.
         /// Using file as BIZARRELY XmlTextReader+StringReader crops or trims.
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/270")]
-#else
         [Fact]
-#endif
         public void TestLargeElementLocationUsedLargeColumn()
         {
             string file = null;
@@ -135,11 +131,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// Check it will use large element location when it should.
         /// Using file as BIZARRELY XmlTextReader+StringReader crops or trims.
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/270")]
-#else
         [Fact]
-#endif
         public void TestLargeElementLocationUsedLargeLine()
         {
             string file = null;

--- a/src/XMakeBuildEngine/Xml/ProjectXmlUtilities.cs
+++ b/src/XMakeBuildEngine/Xml/ProjectXmlUtilities.cs
@@ -48,6 +48,13 @@ namespace Microsoft.Build.Internal
                         VerifyThrowProjectValidNamespace(childElement);
                         children.Add(childElement);
                         break;
+                    case XmlNodeType.Text:
+                        // Whitespace is read as a #text element so if the node is purely whitespace, just ignore it.
+                        if (!String.IsNullOrWhiteSpace(child.InnerText) && throwForInvalidNodeTypes)
+                        {
+                            ThrowProjectInvalidChildElement(child.Name, element.Name, element.Location);
+                        }
+                        break;
 
                     default:
                         if (throwForInvalidNodeTypes)

--- a/src/XMakeBuildEngine/Xml/ProjectXmlUtilities.cs
+++ b/src/XMakeBuildEngine/Xml/ProjectXmlUtilities.cs
@@ -48,15 +48,15 @@ namespace Microsoft.Build.Internal
                         VerifyThrowProjectValidNamespace(childElement);
                         children.Add(childElement);
                         break;
-                    case XmlNodeType.Text:
-                        // Whitespace is read as a #text element so if the node is purely whitespace, just ignore it.
-                        if (!String.IsNullOrWhiteSpace(child.InnerText) && throwForInvalidNodeTypes)
-                        {
-                            ThrowProjectInvalidChildElement(child.Name, element.Name, element.Location);
-                        }
-                        break;
 
                     default:
+                        if (child.NodeType == XmlNodeType.Text && String.IsNullOrWhiteSpace(child.InnerText))
+                        {
+                            // If the text is greather than 4k and only contains whitespace, the XML reader will assume it's a text node
+                            // instead of ignoring it.  Our call to String.IsNullOrWhiteSpace() can be a little slow if the text is
+                            // large but this should be extremely rare.
+                            break;
+                        }
                         if (throwForInvalidNodeTypes)
                         {
                             ThrowProjectInvalidChildElement(child.Name, element.Name, element.Location);


### PR DESCRIPTION
This just ignores purely whitespace text nodes.  The XML reader only looks at the first 4k of text to determine if it should be ignored.  Our tests are generating 70k of whitespace so the XML reader gives up after 4k and assumes its a text node.

Closes #270

Fixes test failures in #1004 when this change is ported to master.