### PR TITLE
Cache Item computation

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -847,6 +847,9 @@ namespace Microsoft.Build.Evaluation
                         _data.AddItemIgnoringCondition(itemData.Item);
                     }
                 }
+
+                // lazy evaluator can be collected now, the rest of evaluation does not need it anymore
+                lazyEvaluator = null;
             }
 
 #if (!STANDALONEBUILD)

--- a/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
+++ b/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
@@ -147,7 +147,17 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public IEnumerable<I> FilterItems(IEnumerable<I> items)
         {
-            return items.Where(i => Fragments.Any(f => f.ItemMatches(i.EvaluatedInclude) > 0));
+            return items.Where(MatchesItem);
+        }
+
+        /// <summary>
+        /// Return true if the given <param name="item"/> matches this itemspec
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public bool MatchesItem(I item)
+        {
+            return Fragments.Any(f => f.MatchCount(item.EvaluatedInclude) > 0);
         }
 
         /// <summary>
@@ -163,7 +173,7 @@ namespace Microsoft.Build.Evaluation
 
             foreach (var fragment in Fragments)
             {
-                var itemMatches = fragment.ItemMatches(itemToMatch);
+                var itemMatches = fragment.MatchCount(itemToMatch);
 
                 if (itemMatches > 0)
                 {
@@ -209,7 +219,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <returns>The number of times the <param name="itemToMatch"></param> appears in this fragment</returns>
-        public virtual int ItemMatches(string itemToMatch)
+        public virtual int MatchCount(string itemToMatch)
         {
             return FileMatcher.Value(itemToMatch) ? 1 : 0;
         }
@@ -250,7 +260,7 @@ namespace Microsoft.Build.Evaluation
             _expander = _containingItemSpec.Expander;
         }
 
-        public override int ItemMatches(string itemToMatch)
+        public override int MatchCount(string itemToMatch)
         {
             // cache referenced items as long as the expander does not change
             // reference equality works for now since the expander cannot mutate its item state (hopefully it stays that way)
@@ -264,7 +274,7 @@ namespace Microsoft.Build.Evaluation
                 _itemValueFragments = itemsFromCapture.Select(i => new ValueFragment(i.Item1, ProjectPath)).ToList();
             }
 
-            return _itemValueFragments.Count(v => v.ItemMatches(itemToMatch) > 0);
+            return _itemValueFragments.Count(v => v.MatchCount(itemToMatch) > 0);
         }
     }
 }

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IItemOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IItemOperation.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal partial class LazyItemEvaluator<P, I, M, D>
+    {
+        internal interface IItemOperation
+        {
+            void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore);
+        }
+    }
+}

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
+                ISet<string> excludePatternsForGlobs = null;
+
                 foreach (var fragment in _itemSpec.Fragments)
                 {
                     if (fragment is ItemExpressionFragment<P, I>)
@@ -91,11 +93,20 @@ namespace Microsoft.Build.Evaluation
                     else if (fragment is GlobFragment)
                     {
                         string glob = ((GlobFragment)fragment).ItemSpecFragment;
+
+                        if (excludePatternsForGlobs == null)
+                        {
+                            excludePatternsForGlobs = BuildExcludePatternsForGlobs(globsToIgnore, excludePatterns);
+                        }
+
                         string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
                             _rootDirectory,
                             glob,
-                            excludePatterns.Count > 0 ? (IEnumerable<string>) excludePatterns.Concat(globsToIgnore) : globsToIgnore
+                            excludePatternsForGlobs
                             );
+
+                        // itemsToAdd might grow 0 or more times during the following iteration. Proactively increase its capacity to ensure only one growth happens
+                        IncreaseListCapacityIfNecessary(itemsToAdd, includeSplitFilesEscaped.Length);
 
                         foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
                         {
@@ -111,6 +122,29 @@ namespace Microsoft.Build.Evaluation
                 return itemsToAdd;
             }
 
+            private static ISet<string> BuildExcludePatternsForGlobs(ImmutableHashSet<string> globsToIgnore, ImmutableList<string>.Builder excludePatterns)
+            {
+                var anyExcludes = excludePatterns.Count > 0;
+                var anyGlobstoIgnore = globsToIgnore.Count > 0;
+
+                if (anyGlobstoIgnore && anyExcludes)
+                {
+                    return excludePatterns.Concat(globsToIgnore).ToImmutableHashSet();
+                }
+
+                return anyExcludes ? excludePatterns.ToImmutableHashSet() : globsToIgnore;
+            }
+
+            private void IncreaseListCapacityIfNecessary(List<I> list, int itemsToAdd)
+            {
+                var newLength = list.Count + itemsToAdd;
+
+                if (list.Capacity < newLength)
+                {
+                    list.Capacity = newLength;
+                }
+            }
+
             protected override void MutateItems(ICollection<I> items)
             {
                 DecorateItemsWithMetadata(items, _metadata);
@@ -118,7 +152,10 @@ namespace Microsoft.Build.Evaluation
 
             protected override void SaveItems(ICollection<I> items, ImmutableList<ItemData>.Builder listBuilder)
             {
-                listBuilder.AddRange(items.Select(item => new ItemData(item, _elementOrder, _conditionResult)));
+                foreach (var item in items)
+                {
+                    listBuilder.Add(new ItemData(item, _elementOrder, _conditionResult));
+                }
             }
         }
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.Evaluation
             {
                 foreach (var item in items)
                 {
-                    listBuilder.Add(new ItemData(item, _elementOrder, _conditionResult));
+                    listBuilder.Add(new ItemData(item, _itemElement, _elementOrder, _conditionResult));
                 }
             }
         }

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Evaluation
 
             protected override ICollection<I> SelectItems(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
-                return SelectItemsMatchingItemSpec(listBuilder, _itemElement.RemoveLocation);
+                return SelectItemsMatchingItemSpec(listBuilder, _itemElement.RemoveLocation).ToList();
             }
 
             protected override void SaveItems(ICollection<I> items, ImmutableList<ItemData>.Builder listBuilder)

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Evaluation\ItemSpec.cs" />
     <Compile Include="Evaluation\ItemsAndMetadataPair.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.cs" />
+    <Compile Include="Evaluation\LazyItemEvaluator.IItemOperation.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.UpdateOperation.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.IncludeOperation.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.ItemFactoryWrapper.cs" />

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ItemEvaluation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ItemEvaluation_Tests.cs
@@ -7,6 +7,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using Microsoft.Build.Evaluation;
 using Xunit;
 using System.Text;
@@ -47,44 +49,75 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                             <i Include='@(i2)'/>
 
-                            <i2 Include='d;e;f'>
+                            <i2 Include='d;e;f;@(i2)'>
                                 <m1>m1_updated</m1>
                                 <m2>m2_updated</m2>
                             </i2>";
 
-            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content);
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, allItems: true);
 
-            var expectedMetadata = new Dictionary<string, string>
+            var mI2_1 = new Dictionary<string, string>
             {
                 {"m1", "m1_contents"},
                 {"m2", "m2_contents"},
             };
 
-            ObjectModelHelpers.AssertItems(new [] {"a", "b", "c"}, items, expectedMetadata);
+            var itemsForI = items.Where(i => i.ItemType == "i").ToList();
+            ObjectModelHelpers.AssertItems(new [] {"a", "b", "c"}, itemsForI, mI2_1);
+
+            var mI2_2 = new Dictionary<string, string>
+            {
+                {"m1", "m1_updated"},
+                {"m2", "m2_updated"},
+            };
+
+            var itemsForI2 = items.Where(i => i.ItemType == "i2").ToList();
+            ObjectModelHelpers.AssertItems(
+                new[] { "a", "b", "c", "d", "e", "f", "a", "b", "c" },
+                itemsForI2,
+                new [] { mI2_1, mI2_1 , mI2_1, mI2_2, mI2_2, mI2_2, mI2_2, mI2_2, mI2_2 });
         }
 
-        [Fact]
-        public void RemoveShouldPreserveIntermediaryReferences()
+        [Theory]
+        // remove the items by referencing each one
+        [InlineData(
+            @"
+            <i2 Include='a;b;c'>
+                <m1>m1_contents</m1>
+                <m2>m2_contents</m2>
+            </i2>
+
+            <i Include='@(i2)'/>
+
+            <i2 Remove='a;b;c'/>"
+            )]
+        // remove the items via a glob
+        [InlineData(
+            @"
+            <i2 Include='a;b;c'>
+                <m1>m1_contents</m1>
+                <m2>m2_contents</m2>
+            </i2>
+
+            <i Include='@(i2)'/>
+
+            <i2 Remove='*'/>"
+            )]
+        public void RemoveShouldPreserveIntermediaryReferences(string content)
         {
-            var content = @"
-                            <i2 Include='a;b;c'>
-                                <m1>m1_contents</m1>
-                                <m2>m2_contents</m2>
-                            </i2>
-
-                            <i Include='@(i2)'/>
-
-                            <i2 Remove='a;b;c'/>";
-
-            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content);
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, allItems: true);
 
             var expectedMetadata = new Dictionary<string, string>
             {
                 {"m1", "m1_contents"},
                 {"m2", "m2_contents"}
             };
+            
+            var itemsForI = items.Where(i => i.ItemType == "i").ToList();
+            ObjectModelHelpers.AssertItems(new[] { "a", "b", "c" }, itemsForI, expectedMetadata);
 
-            ObjectModelHelpers.AssertItems(new[] { "a", "b", "c" }, items, expectedMetadata);
+            var itemsForI2 = items.Where(i => i.ItemType == "i2").ToList();
+            ObjectModelHelpers.AssertItems(new string[0], itemsForI2);
         }
 
         [Fact]
@@ -108,7 +141,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                                 <m4>m4_updated</m4>
                             </i2>";
 
-            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content);
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, allItems: true);
+
 
             var a = new Dictionary<string, string>
             {
@@ -134,7 +168,84 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 {"m4", "m4_contents"},
             };
 
-            ObjectModelHelpers.AssertItems(new[] { "a", "b", "c" }, items, new [] {a, b, c});
+            var itemsForI = items.Where(i => i.ItemType == "i").ToList();
+            ObjectModelHelpers.AssertItems(new[] { "a", "b", "c" }, itemsForI, new [] {a, b, c});
+
+            var metadataForI2 = new Dictionary<string, string>()
+            {
+                {"m1", "m1_updated"},
+                {"m2", "m2_updated"},
+                {"m3", "m3_updated"},
+                {"m4", "m4_updated"}
+            };
+
+            var itemsForI2 = items.Where(i => i.ItemType == "i2").ToList();
+            ObjectModelHelpers.AssertItems(new[] { "a", "b", "c" }, itemsForI2, metadataForI2);
+        }
+
+        [Fact]
+        public void MultipleInterItemDependenciesOnSameItemOperation()
+        {
+            var content = @"
+                            <i1 Include='i1_1;i1_2;i1_3;i1_4;i1_5'/>
+                            <i1 Update='*'>
+                                <m>i1</m>
+                            </i1>
+                            <i1 Remove='*i1_5'/>
+
+                            <i_cond Condition='@(i1->Count()) == 4' Include='i1 has 4 items'/>
+
+                            <i2 Include='@(i1);i2_4'/>
+                            <i2 Remove='i?_4'/>
+                            <i2 Update='i?_1'>
+                               <m>i2</m>
+                            </i2>
+
+                            <i3 Include='@(i1);i3_3'/>
+                            <i3 Remove='*i?_3'/>
+
+                            <i1 Remove='*i1_2'/>
+                            <i1 Include='i1_6'/>";
+
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, allItems: true);
+
+            var i1BaseMetadata = new Dictionary<string, string>()
+            {
+                {"m", "i1"}
+            };
+
+            //i1 items: i1_1; i1_3; i1_4; i1_6
+            var i1Metadata = new Dictionary<string, string>[]
+            {
+                i1BaseMetadata,
+                i1BaseMetadata,
+                i1BaseMetadata,
+                new Dictionary<string, string>()
+            };
+
+            var i1Items = items.Where(i => i.ItemType == "i1").ToList();
+            ObjectModelHelpers.AssertItems(new[] { "i1_1", "i1_3", "i1_4", "i1_6" }, i1Items, i1Metadata);
+
+            //i2 items: i1_1; i1_2; i1_3
+            var i2Metadata = new Dictionary<string, string>[]
+            {
+                new Dictionary<string, string>()
+                {
+                    {"m", "i2"}
+                }, 
+                i1BaseMetadata,
+                i1BaseMetadata
+            };
+
+            var i2Items = items.Where(i => i.ItemType == "i2").ToList();
+            ObjectModelHelpers.AssertItems(new[] { "i1_1", "i1_2", "i1_3" }, i2Items, i2Metadata);
+
+            //i3 items: i1_1; i1_2; i1_4
+            var i3Items = items.Where(i => i.ItemType == "i3").ToList();
+            ObjectModelHelpers.AssertItems(new[] { "i1_1", "i1_2", "i1_4" }, i3Items, i1BaseMetadata);
+
+            var i_condItems = items.Where(i => i.ItemType == "i_cond").ToList();
+            ObjectModelHelpers.AssertItems(new[] { "i1 has 4 items" }, i_condItems);
         }
 
         [Fact]

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -2710,6 +2710,26 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         {
             get
             {
+                // Provenance for an item in the first element with multiple matching updates
+                yield return new object[]
+                {
+                    @"
+                    <A Include=`a;b;a`/>
+                    <A Update=`a;b;c`/>
+                    <A Update=`a*`/>
+                    <A Update=`*a*;a`/>
+                    ",
+                    "a",
+                    0, // first item 'a' from the include
+                    new ProvenanceResultTupleList()
+                    {
+                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 2),
+                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral, 1),
+                        Tuple.Create("A", Operation.Update, Provenance.Glob, 1),
+                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2)
+                    }
+                };
+
                 // Provenance for an item in the last element. Nothing matches
                 yield return new object[]
                 {


### PR DESCRIPTION
On the test repo (solution with 72 VCX projects) this reduces evaluation by ~120ms. The improvement should get significantly better the more cross item references there are.

Items can cross-reference each other during evaluation via:
- item references (`Include="@(a)"`)
- conditions on item groups, items, and metadata (`Condition="@(a->Count()) != 0"`)
- metadata item references (`<m>@(a)</m>`)

In terms of memory, the cache pressure isn't that large because many other allocations are prevented by not doing the repeated computations, so the more cross item references there are, the more the cache pays for itself