### PR TITLE
Locate optimization data in MSBuild subfolder

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -136,4 +136,8 @@
     <BuildBinDir>$(ProjectDir)build\bin\$(Platform)\$(OS)\$(Configuration)</BuildBinDir>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <IBCMergeSubPath>x86/MSBuild</IBCMergeSubPath>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Fixes #1128 by pointing to the subfolder where MSBuild's optimization data
lives in the (internal-only) datastore.

This fix requires the IBCMerge Microbuild plugin 0.3.1 or greater.