### PR TITLE
Make static regex compiled

### DIFF
--- a/src/Shared/CanonicalError.cs
+++ b/src/Shared/CanonicalError.cs
@@ -53,98 +53,105 @@ namespace Microsoft.Build.Shared
     internal static class CanonicalError
     {
         // Defines the main pattern for matching messages.
-        static private Regex s_originCategoryCodeTextExpression = new Regex
-             (
+        private static readonly Lazy<Regex> s_originCategoryCodeTextExpression = new Lazy<Regex>(
+            () => new Regex
+                (
                 // Beginning of line and any amount of whitespace.
                 @"^\s*"
-                // Match a [optional project number prefix 'ddd>'], single letter + colon + remaining filename, or
-                // string with no colon followed by a colon.
+                    // Match a [optional project number prefix 'ddd>'], single letter + colon + remaining filename, or
+                    // string with no colon followed by a colon.
                 + @"(((?<ORIGIN>(((\d+>)?[a-zA-Z]?:[^:]*)|([^:]*))):)"
-                // Origin may also be empty. In this case there's no trailing colon.
+                    // Origin may also be empty. In this case there's no trailing colon.
                 + "|())"
-                // Match the empty string or a string without a colon that ends with a space
+                    // Match the empty string or a string without a colon that ends with a space
                 + "(?<SUBCATEGORY>(()|([^:]*? )))"
-                // Match 'error' or 'warning'.
+                    // Match 'error' or 'warning'.
                 + @"(?<CATEGORY>(error|warning))"
-                // Match anything starting with a space that's not a colon/space, followed by a colon. 
-                // Error code is optional in which case "error"/"warning" can be followed immediately by a colon.
+                    // Match anything starting with a space that's not a colon/space, followed by a colon. 
+                    // Error code is optional in which case "error"/"warning" can be followed immediately by a colon.
                 + @"( \s*(?<CODE>[^: ]*))?\s*:"
-                // Whatever's left on this line, including colons.
+                    // Whatever's left on this line, including colons.
                 + "(?<TEXT>.*)$",
-                RegexOptions.IgnoreCase
-             );
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                ));
 
         // Matches and extracts filename and location from an 'origin' element.
-        static private Regex s_filenameLocationFromOrigin = new Regex
-             (
-                 "^"                                             // Beginning of line
-                 + @"(\d+>)?"                                     // Optional ddd> project number prefix
-                 + "(?<FILENAME>.*)"                              // Match anything.
-                 + @"\("                                          // Find a parenthesis.
-                 + @"(?<LOCATION>[\,,0-9,-]*)"                    // Match any combination of numbers and ',' and '-'
-                 + @"\)\s*"                                       // Find the closing paren then any amount of spaces.
-                 + "$",                                           // End-of-line
-                 RegexOptions.IgnoreCase
-             );
+        private static readonly Lazy<Regex> s_filenameLocationFromOrigin = new Lazy<Regex>(
+            () => new Regex
+                (
+                "^" // Beginning of line
+                + @"(\d+>)?" // Optional ddd> project number prefix
+                + "(?<FILENAME>.*)" // Match anything.
+                + @"\(" // Find a parenthesis.
+                + @"(?<LOCATION>[\,,0-9,-]*)" // Match any combination of numbers and ',' and '-'
+                + @"\)\s*" // Find the closing paren then any amount of spaces.
+                + "$", // End-of-line
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                ));
 
         // Matches location that is a simple number.
-        static private Regex s_lineFromLocation = new Regex        // Example: line
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        private static readonly Lazy<Regex> s_lineFromLocation = new Lazy<Regex>(
+            () => new Regex // Example: line
+                (
+                "^" // Beginning of line
+                + "(?<LINE>[0-9]*)" // Match any number.
+                + "$", // End-of-line
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                ));
 
         // Matches location that is a range of lines.
-        static private Regex s_lineLineFromLocation = new Regex    // Example: line-line
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + "-"                                             // Dash
-                + "(?<ENDLINE>[0-9]*)"                            // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        private static readonly Lazy<Regex> s_lineLineFromLocation = new Lazy<Regex>(
+            () => new Regex // Example: line-line
+                (
+                "^" // Beginning of line
+                + "(?<LINE>[0-9]*)" // Match any number.
+                + "-" // Dash
+                + "(?<ENDLINE>[0-9]*)" // Match any number.
+                + "$", // End-of-line
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                ));
 
         // Matches location that is a line and column
-        static private Regex s_lineColFromLocation = new Regex     // Example: line,col
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + ","                                             // Comma
-                + "(?<COLUMN>[0-9]*)"                             // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        private static readonly Lazy<Regex> s_lineColFromLocation = new Lazy<Regex>(
+            () => new Regex // Example: line,col
+                (
+                "^" // Beginning of line
+                + "(?<LINE>[0-9]*)" // Match any number.
+                + "," // Comma
+                + "(?<COLUMN>[0-9]*)" // Match any number.
+                + "$", // End-of-line
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                ));
 
         // Matches location that is a line and column-range
-        static private Regex s_lineColColFromLocation = new Regex  // Example: line,col-col
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + ","                                             // Comma
-                + "(?<COLUMN>[0-9]*)"                             // Match any number.
-                + "-"                                             // Dash
-                + "(?<ENDCOLUMN>[0-9]*)"                          // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        private static readonly Lazy<Regex> s_lineColColFromLocation = new Lazy<Regex>(
+            () => new Regex // Example: line,col-col
+                (
+                "^" // Beginning of line
+                + "(?<LINE>[0-9]*)" // Match any number.
+                + "," // Comma
+                + "(?<COLUMN>[0-9]*)" // Match any number.
+                + "-" // Dash
+                + "(?<ENDCOLUMN>[0-9]*)" // Match any number.
+                + "$", // End-of-line
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                ));
 
         // Matches location that is line,col,line,col
-        static private Regex s_lineColLineColFromLocation = new Regex      // Example: line,col,line,col
-            (
-                "^"                                              // Beginning of line
-                + "(?<LINE>[0-9]*)"                               // Match any number.
-                + ","                                             // Comma
-                + "(?<COLUMN>[0-9]*)"                             // Match any number.
-                + ","                                             // Dash
-                + "(?<ENDLINE>[0-9]*)"                            // Match any number.
-                + ","                                             // Dash
-                + "(?<ENDCOLUMN>[0-9]*)"                          // Match any number.
-                + "$",                                            // End-of-line
-                RegexOptions.IgnoreCase
-            );
+        private static readonly Lazy<Regex> s_lineColLineColFromLocation = new Lazy<Regex>(
+            () => new Regex // Example: line,col,line,col
+                (
+                "^" // Beginning of line
+                + "(?<LINE>[0-9]*)" // Match any number.
+                + "," // Comma
+                + "(?<COLUMN>[0-9]*)" // Match any number.
+                + "," // Dash
+                + "(?<ENDLINE>[0-9]*)" // Match any number.
+                + "," // Dash
+                + "(?<ENDCOLUMN>[0-9]*)" // Match any number.
+                + "$", // End-of-line
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                ));
 
         /// <summary>
         /// Represents the parts of a decomposed canonical message.
@@ -306,7 +313,7 @@ namespace Microsoft.Build.Shared
             //  Here's an example from the Japanese version of LINK.EXE:
             //   AssemblyInfo.cpp : fatal error LNK1106: ???????????? ??????????????: 0x6580 ??????????
             //
-            Match match = s_originCategoryCodeTextExpression.Match(message);
+            Match match = s_originCategoryCodeTextExpression.Value.Match(message);
 
             if (!match.Success)
             {
@@ -337,7 +344,7 @@ namespace Microsoft.Build.Shared
 
             // Origin is not a simple file, but it still could be of the form,
             //  foo.cpp(location)
-            match = s_filenameLocationFromOrigin.Match(origin);
+            match = s_filenameLocationFromOrigin.Value.Match(origin);
 
             if (match.Success)
             {
@@ -357,14 +364,14 @@ namespace Microsoft.Build.Shared
                 //      (line,col,line,col)
                 if (location.Length > 0)
                 {
-                    match = s_lineFromLocation.Match(location);
+                    match = s_lineFromLocation.Value.Match(location);
                     if (match.Success)
                     {
                         parsedMessage.line = ConvertToIntWithDefault(match.Groups["LINE"].Value.Trim());
                     }
                     else
                     {
-                        match = s_lineLineFromLocation.Match(location);
+                        match = s_lineLineFromLocation.Value.Match(location);
                         if (match.Success)
                         {
                             parsedMessage.line = ConvertToIntWithDefault(match.Groups["LINE"].Value.Trim());
@@ -372,7 +379,7 @@ namespace Microsoft.Build.Shared
                         }
                         else
                         {
-                            match = s_lineColFromLocation.Match(location);
+                            match = s_lineColFromLocation.Value.Match(location);
                             if (match.Success)
                             {
                                 parsedMessage.line = ConvertToIntWithDefault(match.Groups["LINE"].Value.Trim());
@@ -380,7 +387,7 @@ namespace Microsoft.Build.Shared
                             }
                             else
                             {
-                                match = s_lineColColFromLocation.Match(location);
+                                match = s_lineColColFromLocation.Value.Match(location);
                                 if (match.Success)
                                 {
                                     parsedMessage.line = ConvertToIntWithDefault(match.Groups["LINE"].Value.Trim());
@@ -389,7 +396,7 @@ namespace Microsoft.Build.Shared
                                 }
                                 else
                                 {
-                                    match = s_lineColLineColFromLocation.Match(location);
+                                    match = s_lineColLineColFromLocation.Value.Match(location);
                                     if (match.Success)
                                     {
                                         parsedMessage.line = ConvertToIntWithDefault(match.Groups["LINE"].Value.Trim());

--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -20,10 +20,12 @@ namespace Microsoft.Build.Shared
     internal static class FileUtilitiesRegex
     {
         // regular expression used to match file-specs beginning with "<drive letter>:" 
-        internal static readonly Regex DrivePattern = new Regex(@"^[A-Za-z]:");
+        internal static readonly Regex DrivePattern = new Regex(@"^[A-Za-z]:", RegexOptions.Compiled);
 
         // regular expression used to match UNC paths beginning with "\\<server>\<share>"
-        internal static readonly Regex UNCPattern = new Regex(String.Format(CultureInfo.InvariantCulture,
-            @"^[\{0}\{1}][\{0}\{1}][^\{0}\{1}]+[\{0}\{1}][^\{0}\{1}]+", Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        internal static readonly Regex UNCPattern =
+            new Regex(
+                string.Format(CultureInfo.InvariantCulture, @"^[\{0}\{1}][\{0}\{1}][^\{0}\{1}]+[\{0}\{1}][^\{0}\{1}]+",
+                    Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), RegexOptions.Compiled);
     }
 }

--- a/src/Shared/ProjectWriter.cs
+++ b/src/Shared/ProjectWriter.cs
@@ -40,7 +40,10 @@ namespace Microsoft.Build.Shared
 
         // regular expression used to match item vector transforms
         // internal for unit testing only
-        internal static readonly Regex itemVectorTransformPattern = new Regex(itemVectorTransformSpecification, RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture);
+        internal static readonly Lazy<Regex> itemVectorTransformPattern = new Lazy<Regex>(
+            () =>
+                new Regex(itemVectorTransformSpecification,
+                    RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptions.Compiled));
 
         // description of an item vector transform, including the optional separator specification, but with no (named) capturing
         // groups -- see the WriteString() method for details
@@ -53,7 +56,10 @@ namespace Microsoft.Build.Shared
 
         // regular expression used to match item vector transforms, with no (named) capturing groups
         // internal for unit testing only
-        internal static readonly Regex itemVectorTransformRawPattern = new Regex(itemVectorTransformRawSpecification, RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture);
+        internal static readonly Lazy<Regex> itemVectorTransformRawPattern = new Lazy<Regex>(
+            () =>
+                new Regex(itemVectorTransformRawSpecification,
+                    RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptions.Compiled));
 
         /**************************************************************************************************************************
          * WARNING: The regular expressions above MUST be kept in sync with the expressions in the ItemExpander class.
@@ -122,14 +128,14 @@ namespace Microsoft.Build.Shared
         /// <param name="text"></param>
         public override void WriteString(string text)
         {
-            MatchCollection itemVectorTransforms = itemVectorTransformRawPattern.Matches(text);
+            MatchCollection itemVectorTransforms = itemVectorTransformRawPattern.Value.Matches(text);
 
             // if the string contains any item vector transforms
             if (itemVectorTransforms.Count > 0)
             {
                 // separate out the text that surrounds the transforms
                 // NOTE: use the Regex with no (named) capturing groups, otherwise Regex.Split() will split on them
-                string[] surroundingTextPieces = itemVectorTransformRawPattern.Split(text);
+                string[] surroundingTextPieces = itemVectorTransformRawPattern.Value.Split(text);
 
                 ErrorUtilities.VerifyThrow(itemVectorTransforms.Count == (surroundingTextPieces.Length - 1),
                     "We must have two pieces of surrounding text for every item vector transform found.");
@@ -141,7 +147,7 @@ namespace Microsoft.Build.Shared
                     base.WriteString(surroundingTextPieces[i]);
 
                     // break up the transform into its constituent pieces
-                    Match itemVectorTransform = itemVectorTransformPattern.Match(itemVectorTransforms[i].Value);
+                    Match itemVectorTransform = itemVectorTransformPattern.Value.Match(itemVectorTransforms[i].Value);
 
                     ErrorUtilities.VerifyThrow(itemVectorTransform.Success,
                         "Item vector transform must be matched by both the raw and decorated regular expressions.");

--- a/src/XMakeBuildEngine/Construction/Solution/SolutionFile.cs
+++ b/src/XMakeBuildEngine/Construction/Solution/SolutionFile.cs
@@ -31,32 +31,38 @@ namespace Microsoft.Build.Construction
 
         // An example of a project line looks like this:
         //  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1\ClassLibrary1.csproj", "{05A5AD00-71B5-4612-AF2F-9EA9121C4111}"
-        private static readonly Regex s_crackProjectLine = new Regex
-        (
-            "^"                                             // Beginning of line
-            + "Project\\(\"(?<PROJECTTYPEGUID>.*)\"\\)"
-            + "\\s*=\\s*"                                    // Any amount of whitespace plus "=" plus any amount of whitespace
-            + "\"(?<PROJECTNAME>.*)\""
-            + "\\s*,\\s*"                                   // Any amount of whitespace plus "," plus any amount of whitespace
-            + "\"(?<RELATIVEPATH>.*)\""
-            + "\\s*,\\s*"                                   // Any amount of whitespace plus "," plus any amount of whitespace
-            + "\"(?<PROJECTGUID>.*)\""
-            + "$"                                           // End-of-line
-        );
+        private static readonly Lazy<Regex> s_crackProjectLine = new Lazy<Regex>(
+            () => new Regex
+                (
+                "^" // Beginning of line
+                + "Project\\(\"(?<PROJECTTYPEGUID>.*)\"\\)"
+                + "\\s*=\\s*" // Any amount of whitespace plus "=" plus any amount of whitespace
+                + "\"(?<PROJECTNAME>.*)\""
+                + "\\s*,\\s*" // Any amount of whitespace plus "," plus any amount of whitespace
+                + "\"(?<RELATIVEPATH>.*)\""
+                + "\\s*,\\s*" // Any amount of whitespace plus "," plus any amount of whitespace
+                + "\"(?<PROJECTGUID>.*)\""
+                + "$", // End-of-line
+                RegexOptions.Compiled
+                )
+            );
 
         // An example of a property line looks like this:
         //      AspNetCompiler.VirtualPath = "/webprecompile"
         // Because website projects now include the target framework moniker as
         // one of their properties, <PROPERTYVALUE> may now have '=' in it. 
 
-        private static readonly Regex s_crackPropertyLine = new Regex
-        (
-            "^"                                             // Beginning of line
-            + "(?<PROPERTYNAME>[^=]*)"
-            + "\\s*=\\s*"                                    // Any amount of whitespace plus "=" plus any amount of whitespace
-            + "(?<PROPERTYVALUE>.*)"
-            + "$"                                           // End-of-line
-        );
+        private static readonly Lazy<Regex> s_crackPropertyLine = new Lazy<Regex>(
+            () => new Regex
+                (
+                "^" // Beginning of line
+                + "(?<PROPERTYNAME>[^=]*)"
+                + "\\s*=\\s*" // Any amount of whitespace plus "=" plus any amount of whitespace
+                + "(?<PROPERTYVALUE>.*)"
+                + "$", // End-of-line
+                RegexOptions.Compiled
+                )
+            );
 
         internal const int slnFileMinUpgradableVersion = 7; // Minimum version for MSBuild to give a nice message
         internal const int slnFileMinVersion = 9; // Minimum version for MSBuild to actually do anything useful
@@ -779,7 +785,7 @@ namespace Microsoft.Build.Construction
                     {
                         // This should be a dependency.  The GUID identifying the parent project should
                         // be both the property name and the property value.
-                        Match match = s_crackPropertyLine.Match(line);
+                        Match match = s_crackPropertyLine.Value.Match(line);
                         ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
                             new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseProjectDepGuidError", proj.ProjectName);
 
@@ -797,7 +803,7 @@ namespace Microsoft.Build.Construction
                     line = ReadLine();
                     while ((line != null) && (!line.StartsWith("EndProjectSection", StringComparison.Ordinal)))
                     {
-                        Match match = s_crackPropertyLine.Match(line);
+                        Match match = s_crackPropertyLine.Value.Match(line);
                         ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
                             new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseWebProjectPropertiesError", proj.ProjectName);
 
@@ -1233,7 +1239,7 @@ namespace Microsoft.Build.Construction
             ProjectInSolution proj
         )
         {
-            Match match = s_crackProjectLine.Match(firstLine);
+            Match match = s_crackProjectLine.Value.Match(firstLine);
             ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
                 new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseProjectError");
 
@@ -1320,7 +1326,7 @@ namespace Microsoft.Build.Construction
                     continue;
                 }
 
-                Match match = s_crackPropertyLine.Match(str);
+                Match match = s_crackPropertyLine.Value.Match(str);
                 ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
                     new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseNestedProjectError");
 

--- a/src/XMakeBuildEngine/Evaluation/ConditionEvaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/ConditionEvaluator.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Build.Evaluation
 
     internal static class ConditionEvaluator
     {
-        private readonly static Regex s_singlePropertyRegex = new Regex(@"^\$\(([^\$\(\)]*)\)$");
+        private static readonly Lazy<Regex> s_singlePropertyRegex = new Lazy<Regex>(
+            () => new Regex(@"^\$\(([^\$\(\)]*)\)$", RegexOptions.Compiled));
 
         /// <summary>
         /// Update our table which keeps track of all the properties that are referenced
@@ -64,7 +65,7 @@ namespace Microsoft.Build.Evaluation
                     bool lastPiece = pieceSeparator < 0;
                     int pieceEnd = lastPiece ? leftValue.Length : pieceSeparator;
 
-                    Match singlePropertyMatch = s_singlePropertyRegex.Match(leftValue, pieceStart, pieceEnd - pieceStart);
+                    Match singlePropertyMatch = s_singlePropertyRegex.Value.Match(leftValue, pieceStart, pieceEnd - pieceStart);
 
                     if (singlePropertyMatch.Success)
                     {

--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -714,7 +714,7 @@ namespace Microsoft.Build.Evaluation
                     // if there are no item vectors in the string
                     // run a simpler Regex to find item metadata references
                     MetadataMatchEvaluator matchEvaluator = new MetadataMatchEvaluator(metadata, options);
-                    result = RegularExpressions.ItemMetadataPattern.Replace(expression, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));
+                    result = RegularExpressions.ItemMetadataPattern.Value.Replace(expression, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));
                 }
                 else
                 {
@@ -746,7 +746,7 @@ namespace Microsoft.Build.Evaluation
                                 // Extract the part of the expression that appears before the item vector expression
                                 // e.g. the ABC in ABC@(foo->'%(FullPath)')
                                 string subExpressionToReplaceIn = expression.Substring(start, itemVectorExpressions[n].Index - start);
-                                string replacementResult = RegularExpressions.NonTransformItemMetadataPattern.Replace(subExpressionToReplaceIn, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));
+                                string replacementResult = RegularExpressions.NonTransformItemMetadataPattern.Value.Replace(subExpressionToReplaceIn, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));
 
                                 // Append the metadata replacement
                                 finalResultBuilder.Append(replacementResult);
@@ -754,7 +754,7 @@ namespace Microsoft.Build.Evaluation
                                 // Expand any metadata that appears in the item vector expression's separator
                                 if (itemVectorExpressions[n].Separator != null)
                                 {
-                                    vectorExpression = RegularExpressions.NonTransformItemMetadataPattern.Replace(itemVectorExpressions[n].Value, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata), -1, itemVectorExpressions[n].SeparatorStart);
+                                    vectorExpression = RegularExpressions.NonTransformItemMetadataPattern.Value.Replace(itemVectorExpressions[n].Value, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata), -1, itemVectorExpressions[n].SeparatorStart);
                                 }
 
                                 // Append the item vector expression as is
@@ -771,7 +771,7 @@ namespace Microsoft.Build.Evaluation
                         if (start < expression.Length)
                         {
                             string subExpressionToReplaceIn = expression.Substring(start);
-                            string replacementResult = RegularExpressions.NonTransformItemMetadataPattern.Replace(subExpressionToReplaceIn, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));
+                            string replacementResult = RegularExpressions.NonTransformItemMetadataPattern.Value.Replace(subExpressionToReplaceIn, new MatchEvaluator(matchEvaluator.ExpandSingleMetadata));
 
                             finalResultBuilder.Append(replacementResult);
                         }
@@ -2253,7 +2253,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             matchEvaluator = new MetadataMatchEvaluator(item.Item1, item.Item2, elementLocation);
 
-                            include = RegularExpressions.ItemMetadataPattern.Replace(arguments[0], matchEvaluator.GetMetadataValueFromMatch);
+                            include = RegularExpressions.ItemMetadataPattern.Value.Replace(arguments[0], matchEvaluator.GetMetadataValueFromMatch);
                         }
 
                         // Include may be empty. Historically we have created items with empty include
@@ -2591,7 +2591,9 @@ namespace Microsoft.Build.Evaluation
             /// Regular expression used to match item metadata references embedded in strings.
             /// For example, %(Compile.DependsOn) or %(DependsOn).
             /// </summary> 
-            internal static readonly Regex ItemMetadataPattern = new Regex(ItemMetadataSpecification, RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture);
+            internal static readonly Lazy<Regex> ItemMetadataPattern = new Lazy<Regex>(
+                () => new Regex(ItemMetadataSpecification,
+                    RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptions.Compiled));
 
             /// <summary>
             /// Name of the group matching the "name" of a metadatum.
@@ -2612,12 +2614,16 @@ namespace Microsoft.Build.Evaluation
             /// regular expression used to match item metadata references outside of item vector transforms
             /// </summary>
             /// <remarks>PERF WARNING: this Regex is complex and tends to run slowly</remarks>
-            internal static readonly Regex NonTransformItemMetadataPattern =
-                new Regex
+            internal static readonly Lazy<Regex> NonTransformItemMetadataPattern = new Lazy<Regex>(
+                () => new Regex
                     (
-                    @"((?<=" + ItemVectorWithTransformLHS + @")" + ItemMetadataSpecification + @"(?!" + ItemVectorWithTransformRHS + @")) | ((?<!" + ItemVectorWithTransformLHS + @")" + ItemMetadataSpecification + @"(?=" + ItemVectorWithTransformRHS + @")) | ((?<!" + ItemVectorWithTransformLHS + @")" + ItemMetadataSpecification + @"(?!" + ItemVectorWithTransformRHS + @"))",
-                    RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture
-                    );
+                    @"((?<=" + ItemVectorWithTransformLHS + @")" + ItemMetadataSpecification + @"(?!" +
+                    ItemVectorWithTransformRHS + @")) | ((?<!" + ItemVectorWithTransformLHS + @")" +
+                    ItemMetadataSpecification + @"(?=" + ItemVectorWithTransformRHS + @")) | ((?<!" +
+                    ItemVectorWithTransformLHS + @")" + ItemMetadataSpecification + @"(?!" +
+                    ItemVectorWithTransformRHS + @"))",
+                    RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture | RegexOptions.Compiled
+                    ));
 
             /// <summary>
             /// Complete description of an item metadata reference, including the optional qualifying item type.

--- a/src/XMakeTasks/AssemblyDependency/AssemblyFoldersExResolver.cs
+++ b/src/XMakeTasks/AssemblyDependency/AssemblyFoldersExResolver.cs
@@ -24,11 +24,14 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Regex for breaking up the searchpath pieces.
         /// </summary>
-        private static readonly Regex s_crackAssemblyFoldersExSentinel = new Regex
-        (
-            AssemblyResolutionConstants.assemblyFoldersExSentinel + "(?<REGISTRYKEYROOT>[^,]*),(?<TARGETRUNTIMEVERSION>[^,]*),(?<REGISTRYKEYSUFFIX>[^,]*)([,]*)(?<CONDITIONS>.*)}",
-            RegexOptions.IgnoreCase
-        );
+        private static readonly Lazy<Regex> s_crackAssemblyFoldersExSentinel = new Lazy<Regex>(
+            () => new Regex
+                (
+                AssemblyResolutionConstants.assemblyFoldersExSentinel +
+                "(?<REGISTRYKEYROOT>[^,]*),(?<TARGETRUNTIMEVERSION>[^,]*),(?<REGISTRYKEYSUFFIX>[^,]*)([,]*)(?<CONDITIONS>.*)}",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                )
+            );
 
         /// <summary>
         /// Delegate.
@@ -129,7 +132,7 @@ namespace Microsoft.Build.Tasks
             _isInitialized = true;
 
             // Crack the search path just one time.
-            Match match = s_crackAssemblyFoldersExSentinel.Match(this.searchPathElement);
+            Match match = s_crackAssemblyFoldersExSentinel.Value.Match(this.searchPathElement);
             _wasMatch = false;
 
             if (match.Success)

--- a/src/XMakeTasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
+++ b/src/XMakeTasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
@@ -21,13 +21,16 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
     internal class AssemblyFoldersFromConfigResolver : Resolver
     {
         /// <summary>
-        /// Regex for breaking up the search path pieces.
+        ///     Regex for breaking up the search path pieces.
         /// </summary>
-        private static readonly Regex s_crackAssemblyFoldersFromConfigSentinel = new Regex
-        (
-            AssemblyResolutionConstants.assemblyFoldersFromConfigSentinel + "(?<ASSEMBLYFOLDERCONFIGFILE>[^,]*),(?<TARGETRUNTIMEVERSION>[^,]*)}",
-            RegexOptions.IgnoreCase
-        );
+        private static readonly Lazy<Regex> s_crackAssemblyFoldersFromConfigSentinel = new Lazy<Regex>(
+            () => new Regex
+                (
+                AssemblyResolutionConstants.assemblyFoldersFromConfigSentinel +
+                "(?<ASSEMBLYFOLDERCONFIGFILE>[^,]*),(?<TARGETRUNTIMEVERSION>[^,]*)}",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled
+                )
+            );
 
         /// <summary>
         /// Whether or not the search path could be cracked.
@@ -95,7 +98,7 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
             _isInitialized = true;
 
             // Crack the search path just one time.
-            Match match = s_crackAssemblyFoldersFromConfigSentinel.Match(this.searchPathElement);
+            Match match = s_crackAssemblyFoldersFromConfigSentinel.Value.Match(this.searchPathElement);
             _wasMatch = false;
 
             if (match.Success)


### PR DESCRIPTION
To make them run faster (.net blog says 30% faster). The increased Regex creation time should be shadowed by how many regex calls are made during evaluation (e.g. for each metadata reference) and execution.

Some regexes I could not make lazy because they are referenced from the MSBuildTaskHost which compiles against .net 3.5