### PR TITLE
Update CI badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ For more information on MSBuild, see the [MSDN documentation](https://msdn.micro
 
 ### Build Status
 Full framework build from `master` (stable, inserted into Visual Studio builds):
-[![Build Status](http://dotnet-ci.cloudapp.net/job/Microsoft_msbuild/job/innerloop_master_Windows_NT_Desktop/badge/icon)](http://dotnet-ci.cloudapp.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_master_Windows_NT_Desktop)
+[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_master_Windows_NT_Desktop)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_master_Windows_NT_Desktop)
 
 The `xplat` branch is soon to be merged back upstream. Follow the [The Great Merge](https://github.com/Microsoft/msbuild/milestone/6) milestone for progress.
 
 | Runtime\OS | Windows | Ubuntu |Mac OS X|
 |:------|:------:|:------:|:------:|
-| **Full Framework** |[![Build Status](http://dotnet-ci.cloudapp.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Windows_NT_Desktop)](http://dotnet-ci.cloudapp.net/job/Microsoft_msbuild/job/innerloop_xplat_Windows_NT_Desktop/)| N/A | N/A |
-|**.NET Core**|[![Build Status](http://dotnet-ci.cloudapp.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Windows_NT_CoreCLR)](http://dotnet-ci.cloudapp.net/job/Microsoft_msbuild/job/innerloop_xplat_Windows_NT_CoreCLR/)|[![Build Status](http://dotnet-ci.cloudapp.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Ubuntu14.04_CoreCLR)](http://dotnet-ci.cloudapp.net/job/Microsoft_msbuild/job/innerloop_xplat_Ubuntu14.04_CoreCLR/)|[![Build Status](http://dotnet-ci.cloudapp.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_OSX_CoreCLR)](http://dotnet-ci.cloudapp.net/job/Microsoft_msbuild/job/innerloop_xplat_OSX_CoreCLR/)|
+| **Full Framework** |[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Windows_NT_Desktop)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_Windows_NT_Desktop)| N/A | N/A |
+|**.NET Core**|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Windows_NT_CoreCLR)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_Windows_NT_CoreCLR)|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/master/_Ubuntu14.04_CoreCLR_prtest)](https://ci.dot.net/job/Microsoft_msbuild/master/_Ubuntu14.04_CoreCLR_prtest)|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_OSX_CoreCLR)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_OSX_CoreCLR)|
 
 [![Join the chat at https://gitter.im/Microsoft/msbuild](https://badges.gitter.im/Microsoft/msbuild.svg)](https://gitter.im/Microsoft/msbuild?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Check out what we're working on using our Waffle board!](https://badge.waffle.io/Microsoft/msbuild.svg?label=In+Progress&title=waffle+board)](http://waffle.io/Microsoft/msbuild)

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Full framework build from `master` (stable, inserted into Visual Studio builds):
 
 The `xplat` branch is soon to be merged back upstream. Follow the [The Great Merge](https://github.com/Microsoft/msbuild/milestone/6) milestone for progress.
 
-| Runtime\OS | Windows | Ubuntu |Mac OS X|
-|:------|:------:|:------:|:------:|
-| **Full Framework** |[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Windows_NT_Desktop)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_Windows_NT_Desktop)| N/A | N/A |
-|**.NET Core**|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Windows_NT_CoreCLR)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_Windows_NT_CoreCLR)|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/master/_Ubuntu14.04_CoreCLR_prtest)](https://ci.dot.net/job/Microsoft_msbuild/master/_Ubuntu14.04_CoreCLR_prtest)|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_OSX_CoreCLR)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_OSX_CoreCLR)|
+| Runtime\OS | Windows | Ubuntu 14.04 | Ubuntu 16.04 |Mac OS X|
+|:------|:------:|:------:|:------:|:------:|
+| **Full Framework** |[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Windows_NT_Desktop)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_Windows_NT_Desktop)| N/A | N/A | N/A |
+|**.NET Core**|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_Windows_NT_CoreCLR)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_Windows_NT_CoreCLR)|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/master/_Ubuntu14.04_CoreCLR_prtest)](https://ci.dot.net/job/Microsoft_msbuild/master/_Ubuntu14.04_CoreCLR_prtest)|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/master/innerloop_xplat_Ubuntu16.04_CoreCLR)](https://ci.dot.net/job/Microsoft_msbuild/master/innerloop_xplat_Ubuntu16.04_CoreCLR)|[![Build Status](https://ci.dot.net/buildStatus/icon?job=Microsoft_msbuild/innerloop_xplat_OSX_CoreCLR)](https://ci.dot.net/job/Microsoft_msbuild/innerloop_xplat_OSX_CoreCLR)|
 
 [![Join the chat at https://gitter.im/Microsoft/msbuild](https://badges.gitter.im/Microsoft/msbuild.svg)](https://gitter.im/Microsoft/msbuild?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Check out what we're working on using our Waffle board!](https://badge.waffle.io/Microsoft/msbuild.svg?label=In+Progress&title=waffle+board)](http://waffle.io/Microsoft/msbuild)


### PR DESCRIPTION
A couple were pointed to bogus locations, and all were pointed to the old domain rather than the new `ci.dot.net`. New markdown was copy/pasted from Jenkins' "Markdown (without view)" from each job's "Embeddable Build Status" link.