### PR TITLE
Fix build warnings in MSBuildTaskHost

### DIFF
--- a/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -9,6 +9,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <NuGetTargetMoniker>.NETFramework,Version=$(TargetFrameworkVersion)</NuGetTargetMoniker>
     <OutputType>Exe</OutputType>
     <AssemblyName>MSBuildTaskHost</AssemblyName>
     <DefineConstants>$(DefineConstants);CLR2COMPATIBILITY</DefineConstants>


### PR DESCRIPTION
This was caused by the introduction of project.json to the project.  We are setting NuGetTargetMoniker in dir.props before this project has changed the TargetFrameworkVersion.

So you get these warnings:

```
"D:\MSBuild\src\XMakeCommandLine\MSBuildTaskHost\MSBuildTaskHost.csproj" (default target) (1) ->
(ResolveNuGetPackages target) ->
 warning : Your project is not referencing the ".NETFramework,Version=v4.6" framework. Add a reference to ".NETFramework,Version=v4.6" in the "frameworks" section of your project.json, and then re-run NuGet restore.
```