### PR TITLE
Fix hang in OS X test

### DIFF
--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
@@ -606,6 +606,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             ProjectRootElement project = ProjectRootElement.Create();
             string directory = null;
 
+            string savedCurrentDirectory = Directory.GetCurrentDirectory();
             try
             {
                 Directory.SetCurrentDirectory(Path.GetTempPath()); // should be used for project.DirectoryPath; it must exist
@@ -625,6 +626,8 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             finally
             {
                 FileUtilities.DeleteWithoutTrailingBackslash(directory, true);
+
+                Directory.SetCurrentDirectory(savedCurrentDirectory);
             }
         }
 


### PR DESCRIPTION
Globbing tests are enumerating every file in the current directory and this test is changing the current directory to the machine wide temp location.  On CI machines, there are 350,000 files there.