### PR TITLE
Implement telemetry as another log message type 

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1068,6 +1068,14 @@ namespace Microsoft.Build.Tasks
         public System.Resources.ResourceManager TaskSharedResources { get { throw null; } set { } }
         public override string FormatResourceString(string resourceName, params object[] args) { throw null; }
     }
+    public sealed partial class Telemetry : Microsoft.Build.Tasks.TaskExtension
+    {
+        public Telemetry() { }
+        public string EventData { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string EventName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
     public abstract partial class ToolTaskExtension : Microsoft.Build.Utilities.ToolTask
     {
         internal ToolTaskExtension() { }

--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -405,6 +405,7 @@ namespace Microsoft.Build.Utilities
         public bool LogMessagesFromFile(string fileName) { throw null; }
         public bool LogMessagesFromFile(string fileName, Microsoft.Build.Framework.MessageImportance messageImportance) { throw null; }
         public bool LogMessagesFromStream(System.IO.TextReader stream, Microsoft.Build.Framework.MessageImportance messageImportance) { throw null; }
+        public void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties) { }
         public void LogWarning(string message, params object[] messageArgs) { }
         public void LogWarning(string subcategory, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogWarningFromException(System.Exception exception) { }

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -564,6 +564,14 @@ namespace Microsoft.Build.Tasks
         public System.Resources.ResourceManager TaskSharedResources { get { throw null; } set { } }
         public override string FormatResourceString(string resourceName, params object[] args) { throw null; }
     }
+    public sealed partial class Telemetry : Microsoft.Build.Tasks.TaskExtension
+    {
+        public Telemetry() { }
+        public string EventData { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string EventName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
     public abstract partial class ToolTaskExtension : Microsoft.Build.Utilities.ToolTask
     {
         internal ToolTaskExtension() { }

--- a/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -247,6 +247,7 @@ namespace Microsoft.Build.Utilities
         public bool LogMessagesFromFile(string fileName) { throw null; }
         public bool LogMessagesFromFile(string fileName, Microsoft.Build.Framework.MessageImportance messageImportance) { throw null; }
         public bool LogMessagesFromStream(System.IO.TextReader stream, Microsoft.Build.Framework.MessageImportance messageImportance) { throw null; }
+        public void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties) { }
         public void LogWarning(string message, params object[] messageArgs) { }
         public void LogWarning(string subcategory, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
         public void LogWarningFromException(System.Exception exception) { }

--- a/src/Framework/IBuildEngine5.cs
+++ b/src/Framework/IBuildEngine5.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Build.Framework
 {

--- a/src/Framework/IBuildEngine5.cs
+++ b/src/Framework/IBuildEngine5.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// This interface extends IBuildEngine to log telemetry.
+    /// </summary>
+    public interface IBuildEngine5 : IBuildEngine4
+    {
+        /// <summary>
+        /// Logs telemetry.
+        /// </summary>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="properties">The event properties.</param>
+        void LogTelemetry(string eventName, IDictionary<string, string> properties);
+    }
+}

--- a/src/Framework/IEventSource.cs
+++ b/src/Framework/IEventSource.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Framework
     public delegate void AnyEventHandler(object sender, BuildEventArgs e);
 
     /// <summary>
-    /// Type of handler for TelemetrySent events
+    /// Type of handler for TelemetryLogged events
     /// </summary>
     public delegate void TelemetryEventHandler(object sender, TelemetryEventArgs e);
 
@@ -153,13 +153,13 @@ namespace Microsoft.Build.Framework
         event BuildStatusEventHandler StatusEventRaised;
 
         /// <summary>
-        /// this event is raised to log any build event.  These events do not include telemetry.  To receive telemetry, you must attach to the <see cref="TelemetrySent"/> event.
+        /// this event is raised to log any build event.  These events do not include telemetry.  To receive telemetry, you must attach to the <see cref="TelemetryLogged"/> event.
         /// </summary>
         event AnyEventHandler AnyEventRaised;
 
         /// <summary>
-        /// this event is raised to when telemetry is sent.
+        /// this event is raised to when telemetry is logged.
         /// </summary>
-        event TelemetryEventHandler TelemetrySent;
+        event TelemetryEventHandler TelemetryLogged;
     }
 }

--- a/src/Framework/IEventSource.cs
+++ b/src/Framework/IEventSource.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Build.Framework
         event BuildStatusEventHandler StatusEventRaised;
 
         /// <summary>
-        /// this event is raised to log any build event
+        /// this event is raised to log any build event.  These events do not include telemetry.  To receive telemetry, you must attach to the <see cref="TelemetrySent"/> event.
         /// </summary>
         event AnyEventHandler AnyEventRaised;
 

--- a/src/Framework/IEventSource.cs
+++ b/src/Framework/IEventSource.cs
@@ -75,6 +75,11 @@ namespace Microsoft.Build.Framework
     /// </summary>
     public delegate void AnyEventHandler(object sender, BuildEventArgs e);
 
+    /// <summary>
+    /// Type of handler for TelemetrySent events
+    /// </summary>
+    public delegate void TelemetryEventHandler(object sender, TelemetryEventArgs e);
+
     /// <summary> 
     /// This interface defines the events raised by the build engine.
     /// Loggers use this interface to subscribe to the events they
@@ -151,5 +156,10 @@ namespace Microsoft.Build.Framework
         /// this event is raised to log any build event
         /// </summary>
         event AnyEventHandler AnyEventRaised;
+
+        /// <summary>
+        /// this event is raised to when telemetry is sent.
+        /// </summary>
+        event TelemetryEventHandler TelemetrySent;
     }
 }

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -17,7 +17,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'" />
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-MONO|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-MONO|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-MONO|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs">
@@ -60,6 +60,7 @@
     </Compile>
     <Compile Include="IBuildEngine3.cs" />
     <Compile Include="IBuildEngine4.cs" />
+    <Compile Include="IBuildEngine5.cs" />
     <Compile Include="IGeneratedTask.cs" />
     <Compile Include="LazyFormattedBuildEventArgs.cs" />
     <Compile Include="IBuildEngine.cs">
@@ -138,6 +139,7 @@
     <Compile Include="TaskStartedEventArgs.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="TelemetryEventArgs.cs" />
     <None Include="Event args classes.cd" />
     <None Include="project.json" />
     <!-- Win32 RC Files -->

--- a/src/Framework/TelemetryEventArgs.cs
+++ b/src/Framework/TelemetryEventArgs.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Arguments for telemetry events.
+    /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+    [Serializable]
+#endif
+    public sealed class TelemetryEventArgs : BuildEventArgs
+    {
+        /// <summary>
+        /// Gets or sets the name of the event.
+        /// </summary>
+        public string EventName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a list of properties associated with the event.
+        /// </summary>
+        public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/Framework/TelemetryEventArgs.cs
+++ b/src/Framework/TelemetryEventArgs.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Build.Framework

--- a/src/OrcasEngine/Engine/EventSource.cs
+++ b/src/OrcasEngine/Engine/EventSource.cs
@@ -644,5 +644,11 @@ namespace Microsoft.Build.BuildEngine
         /// </summary>
         /// <owner> t-jeffv, sumedhk </owner>
         public event AnyEventHandler AnyEventRaised;
+
+        /// <summary>
+        /// This event is not used in OrcasEngine
+        /// </summary>
+        [Obsolete("This event is not available for the older engine.")]
+        public event TelemetryEventHandler TelemetrySent;
     }
 }

--- a/src/OrcasEngine/Engine/EventSource.cs
+++ b/src/OrcasEngine/Engine/EventSource.cs
@@ -649,6 +649,6 @@ namespace Microsoft.Build.BuildEngine
         /// This event is not used in OrcasEngine
         /// </summary>
         [Obsolete("This event is not available for the older engine.")]
-        public event TelemetryEventHandler TelemetrySent;
+        public event TelemetryEventHandler TelemetryLogged;
     }
 }

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -1355,6 +1356,20 @@ namespace Microsoft.Build.Utilities
             }
 
             return isError;
+        }
+
+        #endregion
+
+        #region Telemetry logging methods
+
+        /// <summary>
+        /// Logs telemetry with the specified event name and properties.
+        /// </summary>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="properties">The list of properties associated with the event.</param>
+        public void LogTelemetry(string eventName, IDictionary<string, string> properties)
+        {
+            (BuildEngine as IBuildEngine5)?.LogTelemetry(eventName, properties);
         }
 
         #endregion

--- a/src/Shared/UnitTests/BuildEventArgsExtension.cs
+++ b/src/Shared/UnitTests/BuildEventArgsExtension.cs
@@ -444,22 +444,5 @@ namespace Microsoft.Build.UnitTests
 
             return ((BuildEventArgs)args).IsEquivalent(other);
         }
-
-        public static bool IsEquivalent(this TelemetryEventArgs args, TelemetryEventArgs other)
-        {
-            if (!String.Equals(args.EventName, other.EventName))
-            {
-                Console.WriteLine("event names are different");
-                return false;
-            }
-
-            if (!args.Properties.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).SequenceEqual(other.Properties.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)))
-            {
-                Console.WriteLine("Properties are different");
-                return false;
-            }
-
-            return ((BuildEventArgs)args).IsEquivalent(other);
-        }
     }
 }

--- a/src/Shared/UnitTests/BuildEventArgsExtension.cs
+++ b/src/Shared/UnitTests/BuildEventArgsExtension.cs
@@ -8,7 +8,6 @@
 using System;
 using Microsoft.Build.Framework;
 using System.Collections.Generic;
-using System.Linq;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 using Xunit;
 

--- a/src/Shared/UnitTests/MockEngine.cs
+++ b/src/Shared/UnitTests/MockEngine.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.UnitTests
      * is somewhat of a no-no for task assemblies.
      * 
      **************************************************************************/
-    sealed internal class MockEngine : IBuildEngine4
+    sealed internal class MockEngine : IBuildEngine5
     {
         private bool _isRunningMultipleNodes;
         private int _messages = 0;
@@ -128,6 +128,26 @@ namespace Microsoft.Build.UnitTests
             _log += eventArgs.Message;
             _log += "\n";
             ++_messages;
+        }
+
+        public void LogTelemetry(string eventName, IDictionary<string, string> properties)
+        {
+            if (_logToConsole)
+            {
+                Console.WriteLine($"Received telemetry event '{eventName}'");
+            }
+            _log += $"Received telemetry event '{eventName}'{Environment.NewLine}";
+            if (properties != null)
+            {
+                foreach (string key in properties.Keys)
+                {
+                    if (_logToConsole)
+                    {
+                        Console.WriteLine($"  Property '{key}' = '{properties[key]}'{Environment.NewLine}");
+                    }
+                    _log += $"  Property '{key}' = '{properties[key]}'{Environment.NewLine}";
+                }
+            }
         }
 
         public bool ContinueOnError

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -442,6 +442,12 @@ namespace Microsoft.Build.Utilities
             /// Handle warning events
             /// </summary>
             private BuildWarningEventHandler _buildWarningEventHandler = null;
+
+            /// <summary>
+            /// Handle telemetry events.
+            /// </summary>
+            private TelemetryEventHandler _telemetrySentEventHandler;
+
             #endregion
 
             /// <summary>
@@ -534,6 +540,11 @@ namespace Microsoft.Build.Utilities
             /// occurred.  It is raised on every event.
             /// </summary>
             public event AnyEventHandler AnyEventRaised;
+
+            /// <summary>
+            /// This event is raised when telemetry is sent.
+            /// </summary>
+            public event TelemetryEventHandler TelemetrySent;
 
             #endregion
 
@@ -1239,6 +1250,37 @@ namespace Microsoft.Build.Utilities
                     }
                 }
             }
+
+            /// <summary>
+            /// Raises a telemetry event to all registered loggers.
+            /// </summary>
+            internal void RaiseTelemetryEvent(object sender, TelemetryEventArgs buildEvent)
+            {
+                lock (_syncLock)
+                {
+                    if (TelemetrySent != null)
+                    {
+                        try
+                        {
+                            TelemetrySent(sender, buildEvent);
+                        }
+                        catch (LoggerException)
+                        {
+                            // if a logger has failed politely, abort immediately
+                            // first unregister all loggers, since other loggers may receive remaining events in unexpected orderings
+                            // if a fellow logger is throwing in an event handler.
+                            this.UnregisterAllEventHandlers();
+                            throw;
+                        }
+                        catch (Exception)
+                        {
+                            // first unregister all loggers, since other loggers may receive remaining events in unexpected orderings
+                            // if a fellow logger is throwing in an event handler.
+                            this.UnregisterAllEventHandlers();
+                        }
+                    }
+                }
+            }
             #endregion
 
             #region private methods
@@ -1261,6 +1303,7 @@ namespace Microsoft.Build.Utilities
                 _taskFinishedEventHandler = new TaskFinishedEventHandler(RaiseTaskFinishedEvent);
                 _taskStartedEventHandler = new TaskStartedEventHandler(RaiseTaskStartedEvent);
                 _buildWarningEventHandler = new BuildWarningEventHandler(RaiseWarningEvent);
+                _telemetrySentEventHandler = new TelemetryEventHandler(RaiseTelemetryEvent);
 
                 _eventSourceForBuild.AnyEventRaised += _anyEventHandler;
                 _eventSourceForBuild.BuildFinished += _buildFinishedEventHandler;
@@ -1276,6 +1319,7 @@ namespace Microsoft.Build.Utilities
                 _eventSourceForBuild.TaskFinished += _taskFinishedEventHandler;
                 _eventSourceForBuild.TaskStarted += _taskStartedEventHandler;
                 _eventSourceForBuild.WarningRaised += _buildWarningEventHandler;
+                _eventSourceForBuild.TelemetrySent += _telemetrySentEventHandler;
             }
 
             /// <summary>
@@ -1297,6 +1341,7 @@ namespace Microsoft.Build.Utilities
                 _eventSourceForBuild.TaskFinished -= _taskFinishedEventHandler;
                 _eventSourceForBuild.TaskStarted -= _taskStartedEventHandler;
                 _eventSourceForBuild.WarningRaised -= _buildWarningEventHandler;
+                _eventSourceForBuild.TelemetrySent -= _telemetrySentEventHandler;
 
                 MessageRaised = null;
                 ErrorRaised = null;
@@ -1312,6 +1357,7 @@ namespace Microsoft.Build.Utilities
                 CustomEventRaised = null;
                 StatusEventRaised = null;
                 AnyEventRaised = null;
+                TelemetrySent = null;
             }
             #endregion
         }

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Build.Utilities
             /// <summary>
             /// Handle telemetry events.
             /// </summary>
-            private TelemetryEventHandler _telemetrySentEventHandler;
+            private TelemetryEventHandler _telemetryEventHandler;
 
             #endregion
 
@@ -544,7 +544,7 @@ namespace Microsoft.Build.Utilities
             /// <summary>
             /// This event is raised when telemetry is sent.
             /// </summary>
-            public event TelemetryEventHandler TelemetrySent;
+            public event TelemetryEventHandler TelemetryLogged;
 
             #endregion
 
@@ -1258,11 +1258,11 @@ namespace Microsoft.Build.Utilities
             {
                 lock (_syncLock)
                 {
-                    if (TelemetrySent != null)
+                    if (TelemetryLogged != null)
                     {
                         try
                         {
-                            TelemetrySent(sender, buildEvent);
+                            TelemetryLogged(sender, buildEvent);
                         }
                         catch (LoggerException)
                         {
@@ -1303,7 +1303,7 @@ namespace Microsoft.Build.Utilities
                 _taskFinishedEventHandler = new TaskFinishedEventHandler(RaiseTaskFinishedEvent);
                 _taskStartedEventHandler = new TaskStartedEventHandler(RaiseTaskStartedEvent);
                 _buildWarningEventHandler = new BuildWarningEventHandler(RaiseWarningEvent);
-                _telemetrySentEventHandler = new TelemetryEventHandler(RaiseTelemetryEvent);
+                _telemetryEventHandler = new TelemetryEventHandler(RaiseTelemetryEvent);
 
                 _eventSourceForBuild.AnyEventRaised += _anyEventHandler;
                 _eventSourceForBuild.BuildFinished += _buildFinishedEventHandler;
@@ -1319,7 +1319,7 @@ namespace Microsoft.Build.Utilities
                 _eventSourceForBuild.TaskFinished += _taskFinishedEventHandler;
                 _eventSourceForBuild.TaskStarted += _taskStartedEventHandler;
                 _eventSourceForBuild.WarningRaised += _buildWarningEventHandler;
-                _eventSourceForBuild.TelemetrySent += _telemetrySentEventHandler;
+                _eventSourceForBuild.TelemetryLogged += _telemetryEventHandler;
             }
 
             /// <summary>
@@ -1341,7 +1341,7 @@ namespace Microsoft.Build.Utilities
                 _eventSourceForBuild.TaskFinished -= _taskFinishedEventHandler;
                 _eventSourceForBuild.TaskStarted -= _taskStartedEventHandler;
                 _eventSourceForBuild.WarningRaised -= _buildWarningEventHandler;
-                _eventSourceForBuild.TelemetrySent -= _telemetrySentEventHandler;
+                _eventSourceForBuild.TelemetryLogged -= _telemetryEventHandler;
 
                 MessageRaised = null;
                 ErrorRaised = null;
@@ -1357,7 +1357,7 @@ namespace Microsoft.Build.Utilities
                 CustomEventRaised = null;
                 StatusEventRaised = null;
                 AnyEventRaised = null;
-                TelemetrySent = null;
+                TelemetryLogged = null;
             }
             #endregion
         }

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/CentralForwardingLogger.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/CentralForwardingLogger.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Build.BackEnd.Logging
             eventSource.AnyEventRaised += new AnyEventHandler(EventSource_AnyEventRaised);
 
             // Telemetry events aren't part of "all" so they need to be forwarded separately
-            eventSource.TelemetrySent += EventSource_AnyEventRaised;
+            eventSource.TelemetryLogged += EventSource_AnyEventRaised;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/CentralForwardingLogger.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/CentralForwardingLogger.cs
@@ -86,6 +86,9 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(eventSource != null, "eventSource is null");
             eventSource.AnyEventRaised += new AnyEventHandler(EventSource_AnyEventRaised);
+
+            // Telemetry events aren't part of "all" so they need to be forwarded separately
+            eventSource.TelemetrySent += EventSource_AnyEventRaised;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/EventSourceSink.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// This event is raised to log telemetry.
         /// </summary>
-        public event TelemetryEventHandler TelemetrySent;
+        public event TelemetryEventHandler TelemetryLogged;
         #endregion
 
         #region Properties
@@ -249,7 +249,7 @@ namespace Microsoft.Build.BackEnd.Logging
             CustomEventRaised = null;
             StatusEventRaised = null;
             AnyEventRaised = null;
-            TelemetrySent = null;
+            TelemetryLogged = null;
         }
 
         #endregion
@@ -858,11 +858,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         private void RaiseTelemetryEvent(object sender, TelemetryEventArgs buildEvent)
         {
-            if (TelemetrySent != null)
+            if (TelemetryLogged != null)
             {
                 try
                 {
-                    TelemetrySent(sender, buildEvent);
+                    TelemetryLogged(sender, buildEvent);
                 }
                 catch (LoggerException)
                 {

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/EventSourceSink.cs
@@ -94,7 +94,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// occurred.  It is raised on every event.
         /// </summary>
         public event AnyEventHandler AnyEventRaised;
-
+        
+        /// <summary>
+        /// This event is raised to log telemetry.
+        /// </summary>
+        public event TelemetryEventHandler TelemetrySent;
         #endregion
 
         #region Properties
@@ -205,6 +209,10 @@ namespace Microsoft.Build.BackEnd.Logging
             {
                 this.RaiseErrorEvent(null, (BuildErrorEventArgs)buildEvent);
             }
+            else if (buildEvent is TelemetryEventArgs)
+            {
+                this.RaiseTelemetryEvent(null, (TelemetryEventArgs) buildEvent);
+            }
             else
             {
                 ErrorUtilities.VerifyThrow(false, "Unknown event args type.");
@@ -241,6 +249,7 @@ namespace Microsoft.Build.BackEnd.Logging
             CustomEventRaised = null;
             StatusEventRaised = null;
             AnyEventRaised = null;
+            TelemetrySent = null;
         }
 
         #endregion
@@ -833,6 +842,41 @@ namespace Microsoft.Build.BackEnd.Logging
                     // catch(Exception) block and not rethrowing it, there's the possibility that this exception could 
                     // just get silently eaten.  So better to have duplicates than to not log the problem at all. :) 
                     ExceptionHandling.DumpExceptionToFile(exception);
+
+                    if (ExceptionHandling.IsCriticalException(exception))
+                    {
+                        throw;
+                    }
+
+                    InternalLoggerException.Throw(exception, buildEvent, "FatalErrorWhileLogging", false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Raises the a telemetry event to all registered loggers.
+        /// </summary>
+        private void RaiseTelemetryEvent(object sender, TelemetryEventArgs buildEvent)
+        {
+            if (TelemetrySent != null)
+            {
+                try
+                {
+                    TelemetrySent(sender, buildEvent);
+                }
+                catch (LoggerException)
+                {
+                    // if a logger has failed politely, abort immediately
+                    // first unregister all loggers, since other loggers may receive remaining events in unexpected orderings
+                    // if a fellow logger is throwing in an event handler.
+                    this.UnregisterAllEventHandlers();
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    // first unregister all loggers, since other loggers may receive remaining events in unexpected orderings
+                    // if a fellow logger is throwing in an event handler.
+                    this.UnregisterAllEventHandlers();
 
                     if (ExceptionHandling.IsCriticalException(exception))
                     {

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/ILoggingService.cs
@@ -401,6 +401,16 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="success">True of the task finished successfully, false otherwise.</param>
         void LogTaskFinished(BuildEventContext taskBuildEventContext, string taskName, string projectFile, string projectFileOfTaskNode, bool success);
         #endregion
+
+        #region Log telemetry
+        /// <summary>
+        /// Logs telemetry.
+        /// </summary>
+        /// <param name="buildEventContext">The event context of the task which sent the telemetry.</param>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="properties">The list of properties associated with the event.</param>
+        void LogTelemetry(BuildEventContext buildEventContext, string eventName, IDictionary<string, string> properties);
+        #endregion
     }
 
     /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -809,5 +809,32 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         #endregion
+
+        #region Log telemetry
+
+        /// <summary>
+        /// Logs a telemetry event.
+        /// </summary>
+        /// <param name="buildEventContext">Event context information which describes who is logging the event</param>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="properties">The list of properties assocated with the event.</param>
+        public void LogTelemetry(BuildEventContext buildEventContext, string eventName, IDictionary<string, string> properties)
+        {
+            lock (_lockObject)
+            {
+                ErrorUtilities.VerifyThrow(eventName != null, "eventName is null");
+
+                TelemetryEventArgs telemetryEvent = new TelemetryEventArgs
+                {
+                    BuildEventContext = buildEventContext,
+                    EventName = eventName,
+                    Properties = properties == null ? new Dictionary<string, string>() : new Dictionary<string, string>(properties)
+                };
+
+                ProcessLoggingEvent(telemetryEvent);
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -1831,6 +1831,11 @@ namespace Microsoft.Build.Evaluation
             private BuildWarningEventHandler _buildWarningEventHandler;
 
             /// <summary>
+            ///  The telemetry event handler.
+            /// </summary>
+            private TelemetryEventHandler _telemetryEventHandler;
+
+            /// <summary>
             /// Constructor.
             /// </summary>
             public ReusableLogger(ILogger originalLogger)
@@ -1910,6 +1915,11 @@ namespace Microsoft.Build.Evaluation
             /// The Any logging event
             /// </summary>
             public event AnyEventHandler AnyEventRaised;
+
+            /// <summary>
+            /// The telemetry sent event.
+            /// </summary>
+            public event TelemetryEventHandler TelemetrySent;
 
 #endregion
 
@@ -2027,6 +2037,7 @@ namespace Microsoft.Build.Evaluation
                 _taskFinishedEventHandler = new TaskFinishedEventHandler(TaskFinishedHandler);
                 _taskStartedEventHandler = new TaskStartedEventHandler(TaskStartedHandler);
                 _buildWarningEventHandler = new BuildWarningEventHandler(WarningRaisedHandler);
+                _telemetryEventHandler = new TelemetryEventHandler(TelemetrySentHandler);
 
                 // Register for the events.
                 eventSource.AnyEventRaised += _anyEventHandler;
@@ -2043,6 +2054,7 @@ namespace Microsoft.Build.Evaluation
                 eventSource.TaskFinished += _taskFinishedEventHandler;
                 eventSource.TaskStarted += _taskStartedEventHandler;
                 eventSource.WarningRaised += _buildWarningEventHandler;
+                eventSource.TelemetrySent += _telemetryEventHandler;
             }
 
             /// <summary>
@@ -2065,6 +2077,7 @@ namespace Microsoft.Build.Evaluation
                 eventSource.TaskFinished -= _taskFinishedEventHandler;
                 eventSource.TaskStarted -= _taskStartedEventHandler;
                 eventSource.WarningRaised -= _buildWarningEventHandler;
+                eventSource.TelemetrySent -= _telemetryEventHandler;
 
                 // Null out the handlers.
                 _anyEventHandler = null;
@@ -2081,6 +2094,7 @@ namespace Microsoft.Build.Evaluation
                 _taskFinishedEventHandler = null;
                 _taskStartedEventHandler = null;
                 _buildWarningEventHandler = null;
+                _telemetryEventHandler = null;
             }
 
             /// <summary>
@@ -2234,6 +2248,17 @@ namespace Microsoft.Build.Evaluation
                 if (AnyEventRaised != null)
                 {
                     AnyEventRaised(sender, e);
+                }
+            }
+
+            /// <summary>
+            /// Handler for telemetry events.
+            /// </summary>
+            private void TelemetrySentHandler(object sender, TelemetryEventArgs e)
+            {
+                if (TelemetrySent != null)
+                {
+                    TelemetrySent(sender, e);
                 }
             }
         }

--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -1919,7 +1919,7 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             /// The telemetry sent event.
             /// </summary>
-            public event TelemetryEventHandler TelemetrySent;
+            public event TelemetryEventHandler TelemetryLogged;
 
 #endregion
 
@@ -2037,7 +2037,7 @@ namespace Microsoft.Build.Evaluation
                 _taskFinishedEventHandler = new TaskFinishedEventHandler(TaskFinishedHandler);
                 _taskStartedEventHandler = new TaskStartedEventHandler(TaskStartedHandler);
                 _buildWarningEventHandler = new BuildWarningEventHandler(WarningRaisedHandler);
-                _telemetryEventHandler = new TelemetryEventHandler(TelemetrySentHandler);
+                _telemetryEventHandler = new TelemetryEventHandler(TelemetryLoggedHandler);
 
                 // Register for the events.
                 eventSource.AnyEventRaised += _anyEventHandler;
@@ -2054,7 +2054,7 @@ namespace Microsoft.Build.Evaluation
                 eventSource.TaskFinished += _taskFinishedEventHandler;
                 eventSource.TaskStarted += _taskStartedEventHandler;
                 eventSource.WarningRaised += _buildWarningEventHandler;
-                eventSource.TelemetrySent += _telemetryEventHandler;
+                eventSource.TelemetryLogged += _telemetryEventHandler;
             }
 
             /// <summary>
@@ -2077,7 +2077,7 @@ namespace Microsoft.Build.Evaluation
                 eventSource.TaskFinished -= _taskFinishedEventHandler;
                 eventSource.TaskStarted -= _taskStartedEventHandler;
                 eventSource.WarningRaised -= _buildWarningEventHandler;
-                eventSource.TelemetrySent -= _telemetryEventHandler;
+                eventSource.TelemetryLogged -= _telemetryEventHandler;
 
                 // Null out the handlers.
                 _anyEventHandler = null;
@@ -2254,11 +2254,11 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             /// Handler for telemetry events.
             /// </summary>
-            private void TelemetrySentHandler(object sender, TelemetryEventArgs e)
+            private void TelemetryLoggedHandler(object sender, TelemetryEventArgs e)
             {
-                if (TelemetrySent != null)
+                if (TelemetryLogged != null)
                 {
-                    TelemetrySent(sender, e);
+                    TelemetryLogged(sender, e);
                 }
             }
         }

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -1170,10 +1170,7 @@ namespace Microsoft.Build.UnitTests.Logging
             TelemetryEventArgs actualEventArgs = (TelemetryEventArgs)service.ProcessedBuildEvent;
 
             Assert.Equal(expectedEventArgs.EventName, actualEventArgs.EventName);
-
-            Assert.True(expectedEventArgs.Properties.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).SequenceEqual(actualEventArgs.Properties.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)),
-                $"Properties are different: [{String.Join(", ", expectedEventArgs.Properties.OrderBy(kvp => kvp.Key).Select(i => $"{i.Key}={i.Value}"))}] != [{String.Join(", ", actualEventArgs.Properties.OrderBy(kvp => kvp.Key).Select(i => $"{i.Key}={i.Value}"))}]");
-
+            Assert.Equal(expectedEventArgs.Properties.OrderBy(kvp => kvp.Key, StringComparer.Ordinal), actualEventArgs.Properties.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase));
             Assert.Equal(expectedEventArgs.BuildEventContext, actualEventArgs.BuildEventContext);
 
             if (properties != null)

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -18,6 +18,7 @@ using Microsoft.Build.Execution;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 
 using MockHost = Microsoft.Build.UnitTests.BackEnd.MockHost;
@@ -1168,7 +1169,12 @@ namespace Microsoft.Build.UnitTests.Logging
 
             TelemetryEventArgs actualEventArgs = (TelemetryEventArgs)service.ProcessedBuildEvent;
 
-            Assert.True(actualEventArgs.IsEquivalent(expectedEventArgs));
+            Assert.Equal(expectedEventArgs.EventName, actualEventArgs.EventName);
+
+            Assert.True(expectedEventArgs.Properties.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).SequenceEqual(actualEventArgs.Properties.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)),
+                $"Properties are different: [{String.Join(", ", expectedEventArgs.Properties.OrderBy(kvp => kvp.Key).Select(i => $"{i.Key}={i.Value}"))}] != [{String.Join(", ", actualEventArgs.Properties.OrderBy(kvp => kvp.Key).Select(i => $"{i.Key}={i.Value}"))}]");
+
+            Assert.Equal(expectedEventArgs.BuildEventContext, actualEventArgs.BuildEventContext);
 
             if (properties != null)
             {

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/MockLoggingService.cs
@@ -465,6 +465,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
         }
 
+        /// <summary>
+        /// Logs a telemetry event.
+        /// </summary>
+        /// <param name="buildEventContext">The task's build event context</param>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="properties">The list of properties associated with the event.</param>
+        public void LogTelemetry(BuildEventContext buildEventContext, string eventName, IDictionary<string, string> properties)
+        {
+        }
+
         #endregion
     }
 }

--- a/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
+++ b/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
@@ -2412,6 +2412,16 @@ elementFormDefault="qualified">
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
+  <xs:element name="Telemetry" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="EventName" use="required" />
+          <xs:attribute name="Data" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
     <xs:element name="TlbImp" substitutionGroup="msb:Task">
         <xs:complexType>
             <xs:complexContent>

--- a/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
+++ b/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
@@ -2417,7 +2417,7 @@ elementFormDefault="qualified">
       <xs:complexContent>
         <xs:extension base="msb:TaskType">
           <xs:attribute name="EventName" use="required" />
-          <xs:attribute name="Data" />
+          <xs:attribute name="EventData" />
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>

--- a/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
+++ b/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
@@ -2412,16 +2412,16 @@ elementFormDefault="qualified">
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
-  <xs:element name="Telemetry" substitutionGroup="msb:Task">
-    <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="msb:TaskType">
-          <xs:attribute name="EventName" use="required" />
-          <xs:attribute name="EventData" />
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-  </xs:element>
+    <xs:element name="Telemetry" substitutionGroup="msb:Task">
+      <xs:complexType>
+        <xs:complexContent>
+          <xs:extension base="msb:TaskType">
+            <xs:attribute name="EventName" use="required" />
+            <xs:attribute name="EventData" />
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+    </xs:element>
     <xs:element name="TlbImp" substitutionGroup="msb:Task">
         <xs:complexType>
             <xs:complexContent>

--- a/src/XMakeCommandLine/OutOfProcTaskHostNode.cs
+++ b/src/XMakeCommandLine/OutOfProcTaskHostNode.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.CommandLine
 #if CLR2COMPATIBILITY
         IBuildEngine3
 #else
-        IBuildEngine4
+        IBuildEngine5
 #endif
     {
         /// <summary>
@@ -442,6 +442,25 @@ namespace Microsoft.Build.CommandLine
         }
 
         #endregion
+
+        #region IBuildEngine5 Implementation
+
+        /// <summary>
+        /// Logs a telemetry event.
+        /// </summary>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="properties">The list of properties associated with the event.</param>
+        public void LogTelemetry(string eventName, IDictionary<string, string> properties)
+        {
+            SendBuildEvent(new TelemetryEventArgs
+            {
+                EventName = eventName,
+                Properties = properties == null ? new Dictionary<string, string>() : new Dictionary<string, string>(properties),
+            });
+        }
+
+        #endregion
+
 #endif
 
         #region INodePacketFactory Members

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" Condition="!$(Configuration.EndsWith('MONO'))"/>
@@ -24,7 +24,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'" />
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-MONO|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-MONO|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-MONO|AnyCPU'" />
   <ItemGroup>
     <EmbeddedResource Include="system.design\system.design.txt">
@@ -501,6 +501,7 @@
     <Compile Include="TaskExtension.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Telemetry.cs" />
     <Compile Include="ToolTaskExtension.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -697,7 +698,6 @@
     <Compile Include="XmlPeek.cs" />
     <Compile Include="XmlPoke.cs" />
     <Compile Include="XslTransformation.cs" />
-
     <!-- Shim targets only work when the destination targets are installed. -->
     <Content Include="Microsoft.Data.Entity.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/XMakeTasks/Microsoft.Common.tasks
+++ b/src/XMakeTasks/Microsoft.Common.tasks
@@ -152,6 +152,7 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.ResolveNonMSBuildProjectOutput"        AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.SGen"                                  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.SignFile"                              AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.Telemetry"                             AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.Touch"                                 AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
 
     <UsingTask TaskName="Microsoft.Build.Tasks.UnregisterAssembly"                    AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' != ''" />

--- a/src/XMakeTasks/Resources/Strings.resx
+++ b/src/XMakeTasks/Resources/Strings.resx
@@ -2614,9 +2614,6 @@
   <data name="Telemetry.IllegalEventDataString">
     <value>The property "{0}" in the telemetry event data property list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "Property1=Value1;Property2=Value2".</value>
   </data>
-  <data name="Telemetry.DuplicateEventProperty">
-    <value>The property "{0}" is specified multiple times for the telemetry event "{1}".  Please remove the duplicate property.</value>
-  </data>
 
 
   <!--

--- a/src/XMakeTasks/Resources/Strings.resx
+++ b/src/XMakeTasks/Resources/Strings.resx
@@ -2606,7 +2606,19 @@
   <data name="Copy.ExactlyOneTypeOfLink">
     <value>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</value>    
   </data>
-  
+
+  <!--
+        MSB3901 - MSB3910   Task: Telemetry
+        If this bucket overflows, pls. contact 'vsppbdev'.
+  -->
+  <data name="Telemetry.IllegalEventDataString">
+    <value>The property "{0}" in the telemetry event data property list "{1}" is malformed.  Please only pass in a semicolon-delimited list of constant string values separated by "=", e.g., "Property1=Value1;Property2=Value2".</value>
+  </data>
+  <data name="Telemetry.DuplicateEventProperty">
+    <value>The property "{0}" is specified multiple times for the telemetry event "{1}".  Please remove the duplicate property.</value>
+  </data>
+
+
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 
@@ -2684,6 +2696,7 @@
             MSB3871 - MSB3880   Targets: Code sharing
             MSB3881 - MSB3890   Task: Compiler
             MSB3891 - MSB3900   Overflow: Copy
+            MSB3901 - MSB3910   Task: Telemetry
 
             MSB4000 - MSB4200   Portable targets & tasks (vsproject\flavors\portable\msbuild)
             MSB9000 - MSB9900   MSBuild targets files (C++)

--- a/src/XMakeTasks/Telemetry.cs
+++ b/src/XMakeTasks/Telemetry.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Build.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Tasks
+{
+    public sealed class Telemetry : TaskExtension
+    {
+        [Required]
+        public string EventName { get; set; }
+
+        public string EventData { get; set; }
+
+        public override bool Execute()
+        {
+            // TODO: Error checking
+
+            IDictionary<string, string> properties = new Dictionary<string, string>();
+
+            if (!String.IsNullOrEmpty(EventData))
+            {
+                foreach (string pair in EventData.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var item = pair.Split(new[] {'='}, 2, StringSplitOptions.RemoveEmptyEntries);
+
+                    properties.Add(item[0], item[1]);
+                }
+            }
+
+            Log.LogTelemetry(EventName, properties);
+
+            return true;
+        }
+    }
+}

--- a/src/XMakeTasks/Telemetry.cs
+++ b/src/XMakeTasks/Telemetry.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Build.Framework;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
 using System;
 using System.Collections.Generic;
 

--- a/src/XMakeTasks/Telemetry.cs
+++ b/src/XMakeTasks/Telemetry.cs
@@ -42,21 +42,15 @@ namespace Microsoft.Build.Tasks
                         return false;
                     }
 
-                    try
-                    {
-                        properties.Add(item[0], item[1]);
-                    }
-                    catch (ArgumentException)
-                    {
-                        Log.LogMessageFromResources(MessageImportance.Low, "Telemetry.DuplicateEventProperty", item[0], EventName);
-                        return false;
-                    }
+                    // Last value added wins
+                    //
+                    properties[item[0]] = item[1];
                 }
             }
 
             Log.LogTelemetry(EventName, properties);
 
-            return true;
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" Condition="!$(Configuration.EndsWith('MONO'))"/>
@@ -84,6 +84,7 @@
     <Compile Include="ResolveCodeAnalysisRuleSet_Tests.cs" />
     <Compile Include="StreamHelpers.cs" />
     <Compile Include="StreamMappedString_Tests.cs" />
+    <Compile Include="TelemetryTaskTests.cs" />
     <Compile Include="ToolTaskExtension_Tests.cs" />
     <Compile Include="Touch_Tests.cs" />
     <Compile Include="TrustInfo_Tests.cs" />

--- a/src/XMakeTasks/UnitTests/TelemetryTaskTests.cs
+++ b/src/XMakeTasks/UnitTests/TelemetryTaskTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.Build.UnitTests;
+using Xunit;
+
+namespace Microsoft.Build.Tasks.UnitTests
+{
+    public sealed class TelemetryTaskTests
+    {
+        [Fact]
+        public void TelemetryTaskSendsEvents()
+        {
+            MockEngine engine = new MockEngine();
+
+            Telemetry telemetryTask = new Telemetry
+            {
+                BuildEngine = engine,
+                EventName = "My event name",
+            };
+
+            bool retVal = telemetryTask.Execute();
+
+            Assert.True(retVal);
+
+            Assert.True(engine.Log.Contains(telemetryTask.EventName));
+        }
+
+        [Fact]
+        public void TelemetryTaskSendsEventsWithProperties()
+        {
+            const string propertyName = "9B7DA92A89914E2CA1D88DCEB9DAAD72";
+            const string propertyValue = "68CB99868F2843B3B75230C1A0BFE358";
+
+            MockEngine engine = new MockEngine();
+
+            Telemetry telemetryTask = new Telemetry
+            {
+                BuildEngine = engine,
+                EventName = "My event name",
+                EventData = $"{propertyName}={propertyValue}",
+            };
+
+            bool retVal = telemetryTask.Execute();
+
+            Assert.True(retVal);
+
+            Assert.True(engine.Log.Contains(propertyName));
+
+            Assert.True(engine.Log.Contains(propertyValue));
+        }
+    }
+}

--- a/src/XMakeTasks/UnitTests/TelemetryTaskTests.cs
+++ b/src/XMakeTasks/UnitTests/TelemetryTaskTests.cs
@@ -68,6 +68,9 @@ namespace Microsoft.Build.Tasks.UnitTests
             Assert.True(engine.Log.Contains($"The property \"Property2\" in the telemetry event data property list \"{telemetryTask.EventData}\" is malformed."));
         }
 
+        /// <summary>
+        /// Verifies that when there are duplicate property names specified that the last one wins.
+        /// </summary>
         [Fact]
         public void TelemetryTaskDuplicateEventDataProperty()
         {
@@ -77,13 +80,20 @@ namespace Microsoft.Build.Tasks.UnitTests
             {
                 BuildEngine = engine,
                 EventName = "My event name",
-                EventData = $"Property1=Value1;Property1=Value2",
+                EventData = $"Property1=EE2493A167D24F00996DE7C8E769EAE6;Property1=4ADE3D2622CA400B8B95A039DF540037",
             };
 
             bool retVal = telemetryTask.Execute();
 
-            Assert.False(retVal);
-            Assert.Equal($"The property \"Property1\" is specified multiple times for the telemetry event \"{telemetryTask.EventName}\".  Please remove the duplicate property.", engine.Log.Trim());
+            Assert.True(retVal);
+
+            // Should not contain the first value
+            //
+            Assert.False(engine.Log.Contains("EE2493A167D24F00996DE7C8E769EAE6"));
+            
+            // Should contain the second value
+            //
+            Assert.True(engine.Log.Contains("4ADE3D2622CA400B8B95A039DF540037"));
         }
     }
 }

--- a/src/XMakeTasks/UnitTests/TelemetryTaskTests.cs
+++ b/src/XMakeTasks/UnitTests/TelemetryTaskTests.cs
@@ -47,5 +47,41 @@ namespace Microsoft.Build.Tasks.UnitTests
 
             Assert.True(engine.Log.Contains(propertyValue));
         }
+
+        [Fact]
+        public void TelemetryTaskInvalidEventData()
+        {
+            MockEngine engine = new MockEngine();
+
+            Telemetry telemetryTask = new Telemetry
+            {
+                BuildEngine = engine,
+                EventName = "My event name",
+                EventData = $"Property1=Value1;Property2",
+            };
+
+            bool retVal = telemetryTask.Execute();
+
+            Assert.False(retVal);
+            Assert.True(engine.Log.Contains($"The property \"Property2\" in the telemetry event data property list \"{telemetryTask.EventData}\" is malformed."));
+        }
+
+        [Fact]
+        public void TelemetryTaskDuplicateEventDataProperty()
+        {
+            MockEngine engine = new MockEngine();
+
+            Telemetry telemetryTask = new Telemetry
+            {
+                BuildEngine = engine,
+                EventName = "My event name",
+                EventData = $"Property1=Value1;Property1=Value2",
+            };
+
+            bool retVal = telemetryTask.Execute();
+
+            Assert.False(retVal);
+            Assert.Equal($"The property \"Property1\" is specified multiple times for the telemetry event \"{telemetryTask.EventName}\".  Please remove the duplicate property.", engine.Log.Trim());
+        }
     }
 }

--- a/src/XMakeTasks/UnitTests/TelemetryTaskTests.cs
+++ b/src/XMakeTasks/UnitTests/TelemetryTaskTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.Build.UnitTests;
 using Xunit;
 


### PR DESCRIPTION
1. Telemetry is available to us via the LoggingService
2. Telemetry is available to task authors via IBuildEngine5.LogTelemetry() or TaskLoggingHelper.LogTelemetry()
3. Telemetry is available to target authors via the <Telemetry /> task.

To receive telemetry, consumers will need to implement an ILogger and attach to the TelemetrySent.  They can specify loggers to constructors in the object model or specify them at the command-line.

Closes #1191