### PR TITLE
Add stream buffering for named pipe reads

### DIFF
--- a/src/Shared/BufferedReadStream.cs
+++ b/src/Shared/BufferedReadStream.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+// <summary>Base class for the implementation of a node endpoint for out-of-proc nodes.</summary>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+
+namespace Microsoft.Build.BackEnd
+{
+    internal class BufferedReadStream : Stream
+    {
+        const int BUFFER_SIZE = 1024;
+
+        Stream _innerStream;
+        byte[] _buffer;
+
+        int _remainingBufferSize;
+        int _currentIndexInBuffer;
+
+        public BufferedReadStream(Stream innerStream)
+        {
+            _innerStream = innerStream;
+            _buffer = new byte[BUFFER_SIZE];
+
+            _remainingBufferSize = 0;
+        }
+
+        public override bool CanRead { get { return _innerStream.CanRead; } }
+
+        public override bool CanSeek { get { return false; } }
+
+        public override bool CanWrite { get { return _innerStream.CanWrite; } }
+
+        public override long Length { get { return _innerStream.Length; } }
+
+        public override long Position
+        {
+            get { return _innerStream.Position; }
+            set { _innerStream.Position = value; }
+        }
+
+        public override void Flush()
+        {
+            _innerStream.Flush();
+        }
+
+        public override int ReadByte()
+        {
+            if (_remainingBufferSize > 0)
+            {
+                int ret = _buffer[_currentIndexInBuffer];
+                _currentIndexInBuffer++;
+                _remainingBufferSize--;
+                return ret;
+            }
+            else
+            {
+                //  Let the base class handle it, which will end up calling the Read() method
+                return base.ReadByte();
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (count > BUFFER_SIZE)
+            {
+                //  Trying to read more data than the buffer can hold
+                int alreadyCopied = 0;
+                if (_remainingBufferSize > 0)
+                {
+                    Array.Copy(_buffer, _currentIndexInBuffer, buffer, offset, _remainingBufferSize);
+                    alreadyCopied = _remainingBufferSize;
+                    _currentIndexInBuffer = 0;
+                    _remainingBufferSize = 0;
+                }
+                int innerReadCount = _innerStream.Read(buffer, offset + alreadyCopied, count - alreadyCopied);
+                return innerReadCount + alreadyCopied;
+            }
+            else if (count <= _remainingBufferSize)
+            {
+                //  Enough data buffered to satisfy read request
+                Array.Copy(_buffer, _currentIndexInBuffer, buffer, offset, count);
+                _currentIndexInBuffer += count;
+                _remainingBufferSize -= count;
+                return count;
+            }
+            else
+            {
+                //  Need to read more data
+                int alreadyCopied = 0;
+                if (_remainingBufferSize > 0)
+                {
+                    Array.Copy(_buffer, _currentIndexInBuffer, buffer, offset, _remainingBufferSize);
+                    alreadyCopied = _remainingBufferSize;
+                    _currentIndexInBuffer = 0;
+                    _remainingBufferSize = 0;
+                }
+
+                int innerReadCount = _innerStream.Read(_buffer, 0, BUFFER_SIZE);
+                _currentIndexInBuffer = 0;
+                _remainingBufferSize = innerReadCount;
+
+                int remainingCopyCount;
+
+                if (alreadyCopied + innerReadCount >= count)
+                {
+                    remainingCopyCount = count - alreadyCopied;
+                }
+                else
+                {
+                    remainingCopyCount = innerReadCount;
+                }
+
+                Array.Copy(_buffer, 0, buffer, offset + alreadyCopied, remainingCopyCount);
+                _currentIndexInBuffer += remainingCopyCount;
+                _remainingBufferSize -= remainingCopyCount;
+
+                return alreadyCopied + remainingCopyCount;
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _innerStream.Write(buffer, offset, count);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _innerStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        
+    }
+}

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -507,6 +507,36 @@ namespace Microsoft.Build.BackEnd
             localWritePipe.WriteLongForHandshake(GetClientHandshake());
             ChangeLinkStatus(LinkStatus.Active);
 
+            RunReadLoop(
+                new BufferedReadStream(localReadPipe),
+                localWritePipe,
+                localPacketQueue, localPacketAvailable, localTerminatePacketPump);
+
+            CommunicationsUtilities.Trace("Ending read loop");
+
+            try
+            {
+#if FEATURE_NAMED_PIPES_FULL_DUPLEX
+                if (localPipeServer.IsConnected)
+                {
+                    localPipeServer.WaitForPipeDrain();
+                    localPipeServer.Disconnect();
+                }
+#else
+                localReadPipe.Dispose();
+                localWritePipe.WaitForPipeDrain();
+                localWritePipe.Dispose();
+#endif
+            }
+            catch (Exception)
+            {
+                // We don't really care if Disconnect somehow fails, but it gives us a chance to do the right thing.
+            }
+        }
+
+        private void RunReadLoop(Stream localReadPipe, Stream localWritePipe,
+            Queue<INodePacket> localPacketQueue, AutoResetEvent localPacketAvailable, AutoResetEvent localTerminatePacketPump)
+        {
             // Ordering of the wait handles is important.  The first signalled wait handle in the array 
             // will be returned by WaitAny if multiple wait handles are signalled.  We prefer to have the
             // terminate event triggered so that we cannot get into a situation where packets are being
@@ -514,7 +544,7 @@ namespace Microsoft.Build.BackEnd
             CommunicationsUtilities.Trace("Entering read loop.");
             byte[] headerByte = new byte[5];
 #if FEATURE_APM
-            IAsyncResult result = localPipeServer.BeginRead(headerByte, 0, headerByte.Length, null, null);
+            IAsyncResult result = localReadPipe.BeginRead(headerByte, 0, headerByte.Length, null, null);
 #else
             Task<int> readTask = CommunicationsUtilities.ReadAsync(localReadPipe, headerByte, headerByte.Length);
 #endif
@@ -541,7 +571,7 @@ namespace Microsoft.Build.BackEnd
                             try
                             {
 #if FEATURE_APM
-                                bytesRead = localPipeServer.EndRead(result);
+                                bytesRead = localReadPipe.EndRead(result);
 #else
                                 bytesRead = readTask.Result;
 #endif
@@ -591,7 +621,7 @@ namespace Microsoft.Build.BackEnd
                             }
 
 #if FEATURE_APM
-                            result = localPipeServer.BeginRead(headerByte, 0, headerByte.Length, null, null);
+                            result = localReadPipe.BeginRead(headerByte, 0, headerByte.Length, null, null);
 #else
                             readTask = CommunicationsUtilities.ReadAsync(localReadPipe, headerByte, headerByte.Length);
 #endif
@@ -630,7 +660,7 @@ namespace Microsoft.Build.BackEnd
                                 packetStream.Write(BitConverter.GetBytes((int)packetStream.Length - 5), 0, 4);
 
 #if FEATURE_MEMORYSTREAM_GETBUFFER
-                                localPipeServer.Write(packetStream.GetBuffer(), 0, (int)packetStream.Length);
+                                localWritePipe.Write(packetStream.GetBuffer(), 0, (int)packetStream.Length);
 #else
                                 ArraySegment<byte> packetStreamBuffer;
                                 if (packetStream.TryGetBuffer(out packetStreamBuffer))
@@ -671,27 +701,6 @@ namespace Microsoft.Build.BackEnd
                 }
             }
             while (!exitLoop);
-
-            CommunicationsUtilities.Trace("Ending read loop");
-
-            try
-            {
-#if FEATURE_NAMED_PIPES_FULL_DUPLEX
-                if (localPipeServer.IsConnected)
-                {
-                    localPipeServer.WaitForPipeDrain();
-                    localPipeServer.Disconnect();
-                }
-#else
-                localReadPipe.Dispose();
-                localWritePipe.WaitForPipeDrain();
-                localWritePipe.Dispose();
-#endif
-            }
-            catch (Exception)
-            {
-                // We don't really care if Disconnect somehow fails, but it gives us a chance to do the right thing.
-            }
         }
 
         #endregion

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -136,7 +136,8 @@ namespace Microsoft.Build.BackEnd
             // For all processes in the list, send signal to terminate if able to connect
             foreach (Process nodeProcess in nodeProcesses)
             {
-                NamedPipeClientStream nodeStream = TryConnectToProcess(nodeProcess.Id, 30/*verified to miss nodes if smaller*/, hostHandshake, clientHandshake);
+                Stream nodeStream = TryConnectToProcess(nodeProcess.Id, 30/*verified to miss nodes if smaller*/, hostHandshake, clientHandshake);
+
                 if (null != nodeStream)
                 {
                     // If we're able to connect to such a process, send a packet requesting its termination
@@ -219,7 +220,7 @@ namespace Microsoft.Build.BackEnd
                 _processesToIgnore.Add(nodeLookupKey);
 
                 // Attempt to connect to each process in turn.
-                NamedPipeClientStream nodeStream = TryConnectToProcess(nodeProcess.Id, 0 /* poll, don't wait for connections */, hostHandshake, clientHandshake);
+                Stream nodeStream = TryConnectToProcess(nodeProcess.Id, 0 /* poll, don't wait for connections */, hostHandshake, clientHandshake);
                 if (nodeStream != null)
                 {
                     // Connection successful, use this node.   
@@ -276,7 +277,7 @@ namespace Microsoft.Build.BackEnd
                 // to the debugger process. Instead, use MSBUILDDEBUGONSTART=1
 
                 // Now try to connect to it.
-                NamedPipeClientStream nodeStream = TryConnectToProcess(msbuildProcessId, TimeoutForNewNodeCreation, hostHandshake, clientHandshake);
+                Stream nodeStream = TryConnectToProcess(msbuildProcessId, TimeoutForNewNodeCreation, hostHandshake, clientHandshake);
                 if (nodeStream != null)
                 {
                     // Connection successful, use this node.
@@ -335,7 +336,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Attempts to connect to the specified process.
         /// </summary>
-        private NamedPipeClientStream TryConnectToProcess(int nodeProcessId, int timeout, long hostHandshake, long clientHandshake)
+        private Stream TryConnectToProcess(int nodeProcessId, int timeout, long hostHandshake, long clientHandshake)
         {
             // Try and connect to the process.
             string pipeName = "MSBuild" + nodeProcessId;
@@ -572,8 +573,8 @@ namespace Microsoft.Build.BackEnd
             private static bool s_trace = String.Equals(Environment.GetEnvironmentVariable("MSBUILDDEBUGCOMM"), "1", StringComparison.Ordinal);
 
             // The pipe(s) used to communicate with the node.
-            private PipeStream _clientToServerStream;
-            private PipeStream _serverToClientStream;
+            private Stream _clientToServerStream;
+            private Stream _serverToClientStream;
 
             /// <summary>
             /// The factory used to create packets from data read off the pipe.
@@ -620,7 +621,7 @@ namespace Microsoft.Build.BackEnd
             /// </summary>
             public NodeContext(int nodeId, int processId,
 #if FEATURE_NAMED_PIPES_FULL_DUPLEX
-                NamedPipeClientStream nodePipe,
+                Stream nodePipe,
 #else
                 AnonymousPipeServerStream clientToServerStream,
                 AnonymousPipeServerStream serverToClientStream,

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -137,6 +137,7 @@
     <Compile Include="..\Shared\StringBuilderCache.cs">
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\BufferedReadStream.cs" />
     <Compile Include="..\Shared\TaskHostConfiguration.cs" />
     <Compile Include="..\Shared\TaskHostTaskCancelled.cs" />
     <Compile Include="..\Shared\TaskHostTaskComplete.cs" />

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -99,6 +99,7 @@
     <Compile Include="..\Shared\Modifiers.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\BufferedReadStream.cs" />
     <Compile Include="..\Shared\CopyOnWriteDictionary.cs" />
     <Compile Include="..\Shared\HybridDictionary.cs" />
     <Compile Include="..\Shared\IKeyed.cs" />

--- a/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -57,6 +57,7 @@
       <Link>ITaskItem2.cs</Link>
     </Compile>
     <Compile Include="..\..\Shared\AssemblyUtilities.cs" />
+    <Compile Include="..\..\Shared\BufferedReadStream.cs" />
     <Compile Include="..\..\Shared\CollectionHelpers.cs" />
     <Compile Include="..\..\Shared\CopyOnWriteDictionary.cs">
       <Link>CopyOnWriteDictionary.cs</Link>


### PR DESCRIPTION
This change adds a read buffer for reads from the named pipe streams which are used to communicate between MSBuild processes.  As there are lots of short reads in the serialization code, this should improve performance of the communication.