### PR TITLE
Re-order assmebly search paths in RAR

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -552,8 +552,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       $(ReferencePath);
       {HintPathFromItem};
       {TargetFrameworkDirectory};
-      {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
       $(AssemblyFoldersConfigFileSearchPath)
+      {Registry:$(FrameworkRegistryBase),$(TargetFrameworkVersion),$(AssemblyFoldersSuffix)$(AssemblyFoldersExConditions)};
       {AssemblyFolders};
       {GAC};
       {RawFileName};


### PR DESCRIPTION
We should select the AssemblyFolder.config before the AssemblyFolderEx
since the former will be used for new assemblies in Visual Studio "15"
going forward. If the registry implementation is searched first we risk
resolving assemblies from previous versions of Visual Studio before the
newer assemblies are considered.