### PR TITLE
Add new method GetSDKContentFolderPath()

### DIFF
--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1075,7 +1075,7 @@ namespace Microsoft.Build.Utilities
             TargetPlatformSDK matchingSdk = GetMatchingPlatformSDK(targetPlatformIdentifier, targetPlatformVersion, diskRoots, null, registryRoot);
             string platformKey = TargetPlatformSDK.GetSdkKey(targetPlatformIdentifier, targetPlatformVersion);
             PlatformManifest manifest;
-            if(TryGetPlatformManifest(matchingSdk, platformKey, out manifest))
+            if (TryGetPlatformManifest(matchingSdk, platformKey, out manifest))
             {
                 if (manifest.VersionedContent)
                 {
@@ -1085,7 +1085,7 @@ namespace Microsoft.Build.Utilities
                 {
                     contractWinMDs = GetApiContractReferences(manifest.ApiContracts, matchingSdk.Path);
                 }
-            };
+            }
 
             return contractWinMDs;
         }

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1153,7 +1153,7 @@ namespace Microsoft.Build.Utilities
                 }
                 else
                 {
-                    ErrorUtilities.DebugTraceMessage("GetValueUsingMatchingSDKManifest", "Could not find root SDK for SDKI = '{0}', SDKV = '{1}'", matchingSdk.TargetPlatformIdentifier, matchingSdk.TargetPlatformVersion);
+                    ErrorUtilities.DebugTraceMessage("GetValueUsingMatchingSDKManifest", "Could not find root SDK for '{0}'", platformKey);
                 }
 
                 if (!String.IsNullOrEmpty(platformManifestLocation))
@@ -1212,7 +1212,6 @@ namespace Microsoft.Build.Utilities
             string sdkContentFolderPath = null;
 
             TargetPlatformSDK matchingSdk = GetMatchingPlatformSDK(targetPlatformIdentifier, targetPlatformVersion, null, null, null);
-
             string platformKey = TargetPlatformSDK.GetSdkKey(targetPlatformIdentifier, targetPlatformVersion);
             GetValueUsingMatchingSDKManifest(matchingSdk, platformKey, (manifest) =>
             {

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1192,7 +1192,8 @@ namespace Microsoft.Build.Utilities
               string targetPlatformIdentifier,
               string targetPlatformMinVersion,
               string targetPlatformVersion,
-              string folderName)
+              string folderName,
+              string diskRoot = null)
         {
             ErrorUtilities.VerifyThrowArgumentLength(sdkIdentifier, "sdkIdentifier");
             ErrorUtilities.VerifyThrowArgumentLength(sdkVersion, "sdkVersion");
@@ -1215,7 +1216,7 @@ namespace Microsoft.Build.Utilities
 
             string sdkContentFolderPath = null;
 
-            TargetPlatformSDK matchingSdk = GetMatchingPlatformSDK(targetPlatformIdentifier, targetPlatformVersion, null, null, null);
+            TargetPlatformSDK matchingSdk = GetMatchingPlatformSDK(targetPlatformIdentifier, targetPlatformVersion, diskRoot, null, null);
             string platformKey = TargetPlatformSDK.GetSdkKey(targetPlatformIdentifier, targetPlatformVersion);
             PlatformManifest manifest;
             if (TryGetPlatformManifest(matchingSdk, platformKey, out manifest))

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -103,6 +103,55 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void GetWinBlueSDKLocation()
+        {
+            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "8.1");
+
+            string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "8.1", null, null, null, null);
+            Assert.True(string.Equals(returnValue, sdkRootPath));
+        }
+
+        [Fact]
+        public void GetWinBlueContentFolderPath()
+        {
+            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "8.1");
+
+            string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "8.1", null, null, null, @"DesignTime\CommonConfiguration\Neutral");
+            Assert.True(string.Equals(returnValue, Path.Combine(sdkRootPath, @"DesignTime\CommonConfiguration\Neutral")));
+        }
+
+        [Fact]
+        public void GetSDKRootLocation()
+        {
+            string expectedValue = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
+
+            string versionedSDKValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", null);
+            Assert.True(string.Equals(versionedSDKValue, expectedValue));
+
+            string unversionedSDKValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.10586.0", "10.0.10586.0", null);
+            Assert.True(string.Equals(unversionedSDKValue, expectedValue));
+        }
+
+        [Fact]
+        public void GetUnversionedSDKUnionMetadataLocation()
+        {
+            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
+
+            string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.10586.0", "10.0.10586.0", "UnionMetadata");
+            Assert.False(returnValue.Contains("10.0.10586.0"));
+            Assert.True(string.Equals(returnValue, Path.Combine(sdkRootPath, "UnionMetadata")));
+        }
+
+        [Fact]
+        public void GetVersionedSDKUnionMetadataLocation()
+        {
+            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
+
+            string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", "UnionMetadata");
+            Assert.True(string.Equals(returnValue, Path.Combine(sdkRootPath, "UnionMetadata", "10.0.14944.0")));
+        }
+
+        [Fact]
         public void GatherExtensionSDKsInvalidVersionDirectory()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -117,38 +117,38 @@ namespace Microsoft.Build.UnitTests
             string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "8.1");
 
             string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "8.1", null, null, null, @"DesignTime\CommonConfiguration\Neutral");
-            Assert.Equal(returnValue, Path.Combine(sdkRootPath, @"DesignTime\CommonConfiguration\Neutral"));
+            Assert.Equal(Path.Combine(sdkRootPath, @"DesignTime\CommonConfiguration\Neutral"), returnValue);
         }
 
         [Fact]
         public void GetSDKRootLocation()
         {
-            string expectedValue = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
+            string expectedValue = ToolLocationHelper.GetPlatformSDKLocation("UAP", "10.0.10586.0");
 
             string versionedSDKValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", null);
             Assert.Equal(versionedSDKValue, expectedValue);
 
             string unversionedSDKValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.10586.0", "10.0.10586.0", null);
-            Assert.Equal(unversionedSDKValue, expectedValue);
+            Assert.Equal(expectedValue, unversionedSDKValue);
         }
 
         [Fact]
         public void GetUnversionedSDKUnionMetadataLocation()
         {
-            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
+            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("UAP", "10.0.10586.0");
 
             string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.10586.0", "10.0.10586.0", "UnionMetadata");
             Assert.False(returnValue.Contains("10.0.10586.0"));
-            Assert.Equal(returnValue, Path.Combine(sdkRootPath, "UnionMetadata"));
+            Assert.Equal(Path.Combine(sdkRootPath, "UnionMetadata"), returnValue);
         }
 
         [Fact]
         public void GetVersionedSDKUnionMetadataLocation()
         {
-            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
+            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("UAP", "10.0.10586.0");
 
             string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", "UnionMetadata");
-            Assert.Equal(returnValue, Path.Combine(sdkRootPath, "UnionMetadata", "10.0.14944.0"));
+            Assert.Equal(Path.Combine(sdkRootPath, "UnionMetadata", "10.0.14944.0"), returnValue);
         }
 
         [Fact]

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void GetSDKRootLocation()
         {
-            string expectedValue = ToolLocationHelper.GetPlatformSDKLocation("UAP", "10.0.14944.0");
+            string expectedValue = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
 
             string versionedSDKValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", null);
             Assert.Equal(expectedValue, versionedSDKValue);
@@ -135,7 +135,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void GetUnversionedSDKUnionMetadataLocation()
         {
-            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("UAP", "10.0.10586.0");
+            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
 
             string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.10586.0", "10.0.10586.0", "UnionMetadata");
             Assert.False(returnValue.Contains("10.0.10586.0"));
@@ -145,63 +145,59 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void GetVersionedSDKUnionMetadataLocation()
         {
-            string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
-
             // Create manifest file
-            string platformFolder = Path.Combine(sdkRootPath, @"Platforms\UAP\10.0.14944.0");
+            string platformRootFolder = Path.Combine(Path.GetTempPath(), @"MockSDK");
+            string sdkRooFolder = Path.Combine(platformRootFolder, @"Windows Kits\10");
+            string platformFolder = Path.Combine(sdkRooFolder, @"Platforms\UAP\10.0.14944.0");
             string platformFilePath = Path.Combine(platformFolder, "Platform.xml");
+            string sdkManifestFilePath = Path.Combine(sdkRooFolder, "SDKManifest.xml");
 
             bool useTempPlatformFile = false;
             try
             {
-                if(!File.Exists(platformFilePath))
+                if (!File.Exists(platformFilePath))
                 {
+                    if (!Directory.Exists(sdkRooFolder))
+                    {
+                        Directory.CreateDirectory(sdkRooFolder);
+                    }
+
                     if (!Directory.Exists(platformFolder))
                     {
                         Directory.CreateDirectory(platformFolder);
                     }
 
+                    string sdkManifestFileContent = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<FileList 
+  TargetPlatform=""UAP""
+  TargetPlatformMinVersion=""10.0.0.0""
+  TargetPlatformVersion=""10.0.14944.0""
+  DisplayName = ""Microsoft Mock SDK for UAP 10.0.14944.0""
+  AppliesTo = ""WindowsAppContainer + (Managed | Javascript | Native)""
+  MinVSVersion = ""14.0""
+  SupportsMultipleVersions=""Error""
+  SupportedArchitectures=""x86;x64;ARM;ARM64"">
+</FileList>";
                     string platformFileContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <ApplicationPlatform name=""UAP"" friendlyName=""Windows 10 Anniversary Edition Insider Preview"" version=""10.0.14944.0"">
-   <MinimumVisualStudioVersion>14.0.22213.01</MinimumVisualStudioVersion>
    <VersionedContent>true</VersionedContent>
-   <ContainedApiContracts>
-      <ApiContract name=""Windows.ApplicationModel.Calls.CallsVoipContract"" version=""1.0.0.0"" />
-      <ApiContract name=""Windows.ApplicationModel.SocialInfo.SocialInfoContract"" version=""1.0.0.0""/>
-      <ApiContract name=""Windows.Devices.DevicesLowLevelContract"" version=""3.0.0.0"" />
-      <ApiContract name=""Windows.Devices.Printers.PrintersContract"" version=""1.0.0.0"" />  
-      <ApiContract name=""Windows.Foundation.FoundationContract"" version=""2.0.0.0"" />  
-      <ApiContract name=""Windows.Foundation.UniversalApiContract"" version=""4.0.0.0"" />  
-      <ApiContract name=""Windows.Graphics.Printing3D.Printing3DContract"" version=""3.0.0.0"" />   
-      <ApiContract name=""Windows.Networking.Connectivity.WwanContract"" version=""1.0.0.0"" />  
-      <ApiContract name=""Windows.Services.Store.StoreContract"" version=""1.0.0.0"" />  
-      <ApiContract name=""Windows.Services.TargetedContent.TargetedContentContract"" version=""1.0.0.0"" /> 
-      <ApiContract name=""Windows.System.Profile.ProfileHardwareTokenContract"" version=""1.0.0.0"" /> 
-      <ApiContract name=""Windows.System.Profile.ProfileSharedModeContract"" version=""1.0.0.0"" />
-      <ApiContract name=""Windows.UI.ViewManagement.ViewManagementViewScalingContract"" version=""1.0.0.0"" /> 
-   </ContainedApiContracts>  
 </ApplicationPlatform>";
 
                     File.WriteAllText(platformFilePath, platformFileContent);
+                    File.WriteAllText(sdkManifestFilePath, sdkManifestFileContent);
 
-                    ToolLocationHelper.ClearSDKStaticCache();
                     useTempPlatformFile = true;
                 }
 
                 // Get and verify return value
-                string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", "UnionMetadata");
-                Assert.Equal(Path.Combine(sdkRootPath, "UnionMetadata", "10.0.14944.0"), returnValue);
+                string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", "UnionMetadata", platformRootFolder);
+                Assert.Equal(Path.Combine(sdkRooFolder, "UnionMetadata", "10.0.14944.0"), returnValue);
             }
             finally
             {
-                if(useTempPlatformFile)
+                if (useTempPlatformFile)
                 {
-                    ToolLocationHelper.ClearSDKStaticCache();
-
-                    if (File.Exists(platformFilePath))
-                    {
-                        FileUtilities.DeleteNoThrow(platformFilePath);
-                    }
+                    FileUtilities.DeleteDirectoryNoThrow(platformRootFolder, true);
                 }
             }
         }

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -147,19 +147,19 @@ namespace Microsoft.Build.UnitTests
         {
             // Create manifest file
             string platformRootFolder = Path.Combine(Path.GetTempPath(), @"MockSDK");
-            string sdkRooFolder = Path.Combine(platformRootFolder, @"Windows Kits\10");
-            string platformFolder = Path.Combine(sdkRooFolder, @"Platforms\UAP\10.0.14944.0");
+            string sdkRootFolder = Path.Combine(platformRootFolder, @"Windows Kits\10");
+            string platformFolder = Path.Combine(sdkRootFolder, @"Platforms\UAP\10.0.14944.0");
             string platformFilePath = Path.Combine(platformFolder, "Platform.xml");
-            string sdkManifestFilePath = Path.Combine(sdkRooFolder, "SDKManifest.xml");
+            string sdkManifestFilePath = Path.Combine(sdkRootFolder, "SDKManifest.xml");
 
             bool useTempPlatformFile = false;
             try
             {
                 if (!File.Exists(platformFilePath))
                 {
-                    if (!Directory.Exists(sdkRooFolder))
+                    if (!Directory.Exists(sdkRootFolder))
                     {
-                        Directory.CreateDirectory(sdkRooFolder);
+                        Directory.CreateDirectory(sdkRootFolder);
                     }
 
                     if (!Directory.Exists(platformFolder))
@@ -191,7 +191,7 @@ namespace Microsoft.Build.UnitTests
 
                 // Get and verify return value
                 string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", "UnionMetadata", platformRootFolder);
-                Assert.Equal(Path.Combine(sdkRooFolder, "UnionMetadata", "10.0.14944.0"), returnValue);
+                Assert.Equal(Path.Combine(sdkRootFolder, "UnionMetadata", "10.0.14944.0"), returnValue);
             }
             finally
             {

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Build.UnitTests
             string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "8.1");
 
             string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "8.1", null, null, null, null);
-            Assert.True(string.Equals(returnValue, sdkRootPath));
+            Assert.Equal(returnValue, sdkRootPath);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace Microsoft.Build.UnitTests
             string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "8.1");
 
             string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "8.1", null, null, null, @"DesignTime\CommonConfiguration\Neutral");
-            Assert.True(string.Equals(returnValue, Path.Combine(sdkRootPath, @"DesignTime\CommonConfiguration\Neutral")));
+            Assert.Equal(returnValue, Path.Combine(sdkRootPath, @"DesignTime\CommonConfiguration\Neutral"));
         }
 
         [Fact]
@@ -126,10 +126,10 @@ namespace Microsoft.Build.UnitTests
             string expectedValue = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
 
             string versionedSDKValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", null);
-            Assert.True(string.Equals(versionedSDKValue, expectedValue));
+            Assert.Equal(versionedSDKValue, expectedValue);
 
             string unversionedSDKValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.10586.0", "10.0.10586.0", null);
-            Assert.True(string.Equals(unversionedSDKValue, expectedValue));
+            Assert.Equal(unversionedSDKValue, expectedValue);
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace Microsoft.Build.UnitTests
 
             string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.10586.0", "10.0.10586.0", "UnionMetadata");
             Assert.False(returnValue.Contains("10.0.10586.0"));
-            Assert.True(string.Equals(returnValue, Path.Combine(sdkRootPath, "UnionMetadata")));
+            Assert.Equal(returnValue, Path.Combine(sdkRootPath, "UnionMetadata"));
         }
 
         [Fact]
@@ -148,7 +148,7 @@ namespace Microsoft.Build.UnitTests
             string sdkRootPath = ToolLocationHelper.GetPlatformSDKLocation("Windows", "10.0");
 
             string returnValue = ToolLocationHelper.GetSDKContentFolderPath("Windows", "10.0", "UAP", "10.0.14944.0", "10.0.14944.0", "UnionMetadata");
-            Assert.True(string.Equals(returnValue, Path.Combine(sdkRootPath, "UnionMetadata", "10.0.14944.0")));
+            Assert.Equal(returnValue, Path.Combine(sdkRootPath, "UnionMetadata", "10.0.14944.0"));
         }
 
         [Fact]


### PR DESCRIPTION
Add new method GetSDKContentFolderPath() to enable us retrieve content folder path from versioned path if needed. In RS2 SDK, we added version information in SDK path. This is the method to make sure we get correct path.