### PR TITLE
Fix displayed version

### DIFF
--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Build.Evaluation
                     // work when Microsoft.Build.dll has been shadow-copied, for example
                     // in scenarios where NUnit is loading Microsoft.Build.
                     var versionInfo = FileVersionInfo.GetVersionInfo(FileUtilities.ExecutingAssemblyPath);
-                    s_engineVersion = new Version(versionInfo.FileMajorPart, versionInfo.FileMinorPart, versionInfo.FileBuildPart, versionInfo.FilePrivatePart);
+                    s_engineVersion = new Version(versionInfo.ProductMajorPart, versionInfo.ProductMinorPart, versionInfo.ProductBuildPart, versionInfo.ProductPrivatePart);
                 }
 
                 return s_engineVersion;

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectCollection_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectCollection_Tests.cs
@@ -1427,6 +1427,21 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         /// <summary>
+        /// Verifies that the <see cref="ProjectCollection.Version"/> is correct.
+        /// </summary>
+        /// <remarks>
+        /// This test was written because on OS X and Ubuntu, the version is showing "0.0.0.0"
+        /// while Windows was working just fine.
+        /// </remarks>
+        [Fact]
+        public void ProjectCollectionVersionIsCorrect()
+        {
+            Version expectedVersion = new Version(MSBuildConstants.CurrentAssemblyVersion);
+
+            Assert.Equal(expectedVersion, ProjectCollection.Version);
+        }
+
+        /// <summary>
         /// Create an empty project file and return the path
         /// </summary>
         private static string CreateProjectFile()


### PR DESCRIPTION
Since we're only setting `AssemblyVersion` but reading the "file version", then on non-Windows we display `0.0.0.0`.  Instead, this will now display the "product version" which comes from the `AssemblyVersionAttribute` and works on both Windows and non-Windows.

I've also added a unit test to ensure that this doesn't happen again.

Closes #1249 