### PR TITLE
Introduce IEventSource2 to not break usages of IEventSource

### DIFF
--- a/src/Framework/IEventSource.cs
+++ b/src/Framework/IEventSource.cs
@@ -75,11 +75,6 @@ namespace Microsoft.Build.Framework
     /// </summary>
     public delegate void AnyEventHandler(object sender, BuildEventArgs e);
 
-    /// <summary>
-    /// Type of handler for TelemetryLogged events
-    /// </summary>
-    public delegate void TelemetryEventHandler(object sender, TelemetryEventArgs e);
-
     /// <summary> 
     /// This interface defines the events raised by the build engine.
     /// Loggers use this interface to subscribe to the events they
@@ -156,10 +151,5 @@ namespace Microsoft.Build.Framework
         /// this event is raised to log any build event.  These events do not include telemetry.  To receive telemetry, you must attach to the <see cref="TelemetryLogged"/> event.
         /// </summary>
         event AnyEventHandler AnyEventRaised;
-
-        /// <summary>
-        /// this event is raised to when telemetry is logged.
-        /// </summary>
-        event TelemetryEventHandler TelemetryLogged;
     }
 }

--- a/src/Framework/IEventSource2.cs
+++ b/src/Framework/IEventSource2.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Type of handler for TelemetryLogged events
+    /// </summary>
+    public delegate void TelemetryEventHandler(object sender, TelemetryEventArgs e);
+
+    /// <summary>
+    /// This interface defines the events raised by the build engine.
+    /// Loggers use this interface to subscribe to the events they
+    /// are interested in receiving.
+    /// </summary>
+    public interface IEventSource2 : IEventSource
+    {
+        /// <summary>
+        /// this event is raised to when telemetry is logged.
+        /// </summary>
+        event TelemetryEventHandler TelemetryLogged;
+    }
+}

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -61,6 +61,7 @@
     <Compile Include="IBuildEngine3.cs" />
     <Compile Include="IBuildEngine4.cs" />
     <Compile Include="IBuildEngine5.cs" />
+    <Compile Include="IEventSource2.cs" />
     <Compile Include="IGeneratedTask.cs" />
     <Compile Include="LazyFormattedBuildEventArgs.cs" />
     <Compile Include="IBuildEngine.cs">

--- a/src/OrcasEngine/Engine/EventSource.cs
+++ b/src/OrcasEngine/Engine/EventSource.cs
@@ -644,11 +644,5 @@ namespace Microsoft.Build.BuildEngine
         /// </summary>
         /// <owner> t-jeffv, sumedhk </owner>
         public event AnyEventHandler AnyEventRaised;
-
-        /// <summary>
-        /// This event is not used in OrcasEngine
-        /// </summary>
-        [Obsolete("This event is not available for the older engine.")]
-        public event TelemetryEventHandler TelemetryLogged;
     }
 }

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Build.Utilities
 #if FEATURE_APPDOMAIN
             MarshalByRefObject,
 #endif
-            IEventSource
+            IEventSource2
         {
             #region Fields
             /// <summary>
@@ -1319,7 +1319,12 @@ namespace Microsoft.Build.Utilities
                 _eventSourceForBuild.TaskFinished += _taskFinishedEventHandler;
                 _eventSourceForBuild.TaskStarted += _taskStartedEventHandler;
                 _eventSourceForBuild.WarningRaised += _buildWarningEventHandler;
-                _eventSourceForBuild.TelemetryLogged += _telemetryEventHandler;
+
+                if (_eventSourceForBuild is IEventSource2)
+                {
+                    ((IEventSource2)_eventSourceForBuild).TelemetryLogged += _telemetryEventHandler;
+                }
+                
             }
 
             /// <summary>
@@ -1341,7 +1346,11 @@ namespace Microsoft.Build.Utilities
                 _eventSourceForBuild.TaskFinished -= _taskFinishedEventHandler;
                 _eventSourceForBuild.TaskStarted -= _taskStartedEventHandler;
                 _eventSourceForBuild.WarningRaised -= _buildWarningEventHandler;
-                _eventSourceForBuild.TelemetryLogged -= _telemetryEventHandler;
+
+                if (_eventSourceForBuild is IEventSource2)
+                {
+                    ((IEventSource2)_eventSourceForBuild).TelemetryLogged -= _telemetryEventHandler;
+                }
 
                 MessageRaised = null;
                 ErrorRaised = null;

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -1320,9 +1320,10 @@ namespace Microsoft.Build.Utilities
                 _eventSourceForBuild.TaskStarted += _taskStartedEventHandler;
                 _eventSourceForBuild.WarningRaised += _buildWarningEventHandler;
 
-                if (_eventSourceForBuild is IEventSource2)
+                IEventSource2 eventSource2 = _eventSourceForBuild as IEventSource2;
+                if (eventSource2 != null)
                 {
-                    ((IEventSource2)_eventSourceForBuild).TelemetryLogged += _telemetryEventHandler;
+                    eventSource2.TelemetryLogged += _telemetryEventHandler;
                 }
                 
             }
@@ -1347,9 +1348,10 @@ namespace Microsoft.Build.Utilities
                 _eventSourceForBuild.TaskStarted -= _taskStartedEventHandler;
                 _eventSourceForBuild.WarningRaised -= _buildWarningEventHandler;
 
-                if (_eventSourceForBuild is IEventSource2)
+                IEventSource2 eventSource2 = _eventSourceForBuild as IEventSource2;
+                if (eventSource2 != null)
                 {
-                    ((IEventSource2)_eventSourceForBuild).TelemetryLogged -= _telemetryEventHandler;
+                    eventSource2.TelemetryLogged -= _telemetryEventHandler;
                 }
 
                 MessageRaised = null;

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -1325,7 +1325,6 @@ namespace Microsoft.Build.Utilities
                 {
                     eventSource2.TelemetryLogged += _telemetryEventHandler;
                 }
-                
             }
 
             /// <summary>

--- a/src/Utilities/Task.cs
+++ b/src/Utilities/Task.cs
@@ -111,6 +111,17 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
+        /// Retrieves the IBuildEngine5 version of the build engine interface provided by the host.
+        /// </summary>
+        public IBuildEngine5 BuildEngine5
+        {
+            get
+            {
+                return (IBuildEngine5)_buildEngine;
+            }
+        }
+
+        /// <summary>
         /// The build engine sets this property if the host IDE has associated a host object with this particular task.
         /// </summary>
         /// <value>The host object instance (can be null).</value>

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/CentralForwardingLogger.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/CentralForwardingLogger.cs
@@ -87,8 +87,11 @@ namespace Microsoft.Build.BackEnd.Logging
             ErrorUtilities.VerifyThrow(eventSource != null, "eventSource is null");
             eventSource.AnyEventRaised += new AnyEventHandler(EventSource_AnyEventRaised);
 
-            // Telemetry events aren't part of "all" so they need to be forwarded separately
-            eventSource.TelemetryLogged += EventSource_AnyEventRaised;
+            if (eventSource is IEventSource2)
+            {
+                // Telemetry events aren't part of "all" so they need to be forwarded separately
+                ((IEventSource2)eventSource).TelemetryLogged += EventSource_AnyEventRaised;
+            }
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/CentralForwardingLogger.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/CentralForwardingLogger.cs
@@ -87,10 +87,11 @@ namespace Microsoft.Build.BackEnd.Logging
             ErrorUtilities.VerifyThrow(eventSource != null, "eventSource is null");
             eventSource.AnyEventRaised += new AnyEventHandler(EventSource_AnyEventRaised);
 
-            if (eventSource is IEventSource2)
+            IEventSource2 eventSource2 = eventSource as IEventSource2;
+            if (eventSource2 != null)
             {
                 // Telemetry events aren't part of "all" so they need to be forwarded separately
-                ((IEventSource2)eventSource).TelemetryLogged += EventSource_AnyEventRaised;
+                eventSource2.TelemetryLogged += EventSource_AnyEventRaised;
             }
         }
 

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/EventSourceSink.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.BackEnd.Logging
 #if FEATURE_APPDOMAIN
         MarshalByRefObject,
 #endif
-        IEventSource, IBuildEventSink
+        IEventSource2, IBuildEventSink
     {
         #region Events
 

--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -2055,9 +2055,10 @@ namespace Microsoft.Build.Evaluation
                 eventSource.TaskStarted += _taskStartedEventHandler;
                 eventSource.WarningRaised += _buildWarningEventHandler;
 
-                if (eventSource is IEventSource2)
+                IEventSource2 eventSource2 = eventSource as IEventSource2;
+                if (eventSource2 != null)
                 {
-                    ((IEventSource2)eventSource).TelemetryLogged += _telemetryEventHandler;
+                    eventSource2.TelemetryLogged += _telemetryEventHandler;
                 }
             }
 
@@ -2082,9 +2083,10 @@ namespace Microsoft.Build.Evaluation
                 eventSource.TaskStarted -= _taskStartedEventHandler;
                 eventSource.WarningRaised -= _buildWarningEventHandler;
 
-                if (eventSource is IEventSource2)
+                IEventSource2 eventSource2 = eventSource as IEventSource2;
+                if (eventSource2 != null)
                 {
-                    ((IEventSource2)eventSource).TelemetryLogged -= _telemetryEventHandler;
+                    eventSource2.TelemetryLogged -= _telemetryEventHandler;
                 }
 
                 // Null out the handlers.

--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -1743,7 +1743,7 @@ namespace Microsoft.Build.Evaluation
         /// The ReusableLogger wraps a logger and allows it to be used for both design-time and build-time.  It internally swaps
         /// between the design-time and build-time event sources in response to Initialize and Shutdown events.
         /// </summary>
-        internal class ReusableLogger : INodeLogger, IEventSource
+        internal class ReusableLogger : INodeLogger, IEventSource2
         {
             /// <summary>
             /// The logger we are wrapping.
@@ -2054,7 +2054,11 @@ namespace Microsoft.Build.Evaluation
                 eventSource.TaskFinished += _taskFinishedEventHandler;
                 eventSource.TaskStarted += _taskStartedEventHandler;
                 eventSource.WarningRaised += _buildWarningEventHandler;
-                eventSource.TelemetryLogged += _telemetryEventHandler;
+
+                if (eventSource is IEventSource2)
+                {
+                    ((IEventSource2)eventSource).TelemetryLogged += _telemetryEventHandler;
+                }
             }
 
             /// <summary>
@@ -2077,7 +2081,11 @@ namespace Microsoft.Build.Evaluation
                 eventSource.TaskFinished -= _taskFinishedEventHandler;
                 eventSource.TaskStarted -= _taskStartedEventHandler;
                 eventSource.WarningRaised -= _buildWarningEventHandler;
-                eventSource.TelemetryLogged -= _telemetryEventHandler;
+
+                if (eventSource is IEventSource2)
+                {
+                    ((IEventSource2)eventSource).TelemetryLogged -= _telemetryEventHandler;
+                }
 
                 // Null out the handlers.
                 _anyEventHandler = null;


### PR DESCRIPTION
We can still improve on this by having an ILogger2 and update Logger but this will keep the telemetry stuff in without breaking people who implement IEventSource