### PR TITLE
Move design time targets import before Common targets

### DIFF
--- a/src/XMakeTasks/Microsoft.CSharp.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.CSharp.CrossTargeting.targets
@@ -11,13 +11,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
- 
-  <Import Project="Microsoft.Common.CrossTargeting.targets" />
 
   <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
+  <!-- Import design time targets before the common crosstargeting targets, which import targets from Nuget. -->
   <PropertyGroup>
      <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
   </PropertyGroup>
   <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
+
+  <Import Project="Microsoft.Common.CrossTargeting.targets" />
 
 </Project>

--- a/src/XMakeTasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.CSharp.CurrentVersion.targets
@@ -319,6 +319,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
 
     <Import Project="$(CSharpCoreTargetsPath)" />
+    
+    <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
+    <!-- Import design time targets before the common targets, which import targets from Nuget. -->
+    <PropertyGroup>
+       <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
+    </PropertyGroup>
+    <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
 
     <Import Project="Microsoft.Common.targets" />
     <Import Project="$(MSBuildToolsPath)\Microsoft.ServiceModel.targets" Condition="('$(TargetFrameworkVersion)' != 'v2.0' and '$(TargetFrameworkVersion)' != 'v3.0' and '$(TargetFrameworkVersion)' != 'v3.5') and Exists('$(MSBuildToolsPath)\Microsoft.ServiceModel.targets')"/>
@@ -360,12 +367,6 @@ using System.Reflection%3b
       -->
         <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
     </ItemGroup>
-
-    <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
-    <PropertyGroup>
-       <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
-    </PropertyGroup>
-    <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
 
     <Import Project="$(CustomAfterMicrosoftCSharpTargets)" Condition="'$(CustomAfterMicrosoftCSharpTargets)' != '' and Exists('$(CustomAfterMicrosoftCSharpTargets)')" />
 

--- a/src/XMakeTasks/Microsoft.VisualBasic.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.VisualBasic.CrossTargeting.targets
@@ -11,13 +11,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
- 
-  <Import Project="Microsoft.Common.CrossTargeting.targets" />
 
   <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
+  <!-- Import design time targets before the common crosstargeting targets, which import targets from Nuget. -->
   <PropertyGroup>
      <VisualBasicDesignTimeTargetsPath Condition="'$(VisualBasicDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.VisualBasic.DesignTime.targets</VisualBasicDesignTimeTargetsPath>
   </PropertyGroup>
   <Import Project="$(VisualBasicDesignTimeTargetsPath)" Condition="'$(VisualBasicDesignTimeTargetsPath)' != '' and Exists('$(VisualBasicDesignTimeTargetsPath)')" />
+
+  <Import Project="Microsoft.Common.CrossTargeting.targets" />
 
 </Project>

--- a/src/XMakeTasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -320,6 +320,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <Import Project="$(VisualBasicCoreTargetsPath)" />
 
+    <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
+    <!-- Import design time targets before the common targets, which import targets from Nuget. -->
+    <PropertyGroup>
+       <VisualBasicDesignTimeTargetsPath Condition="'$(VisualBasicDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.VisualBasic.DesignTime.targets</VisualBasicDesignTimeTargetsPath>
+    </PropertyGroup>
+    <Import Project="$(VisualBasicDesignTimeTargetsPath)" Condition="'$(VisualBasicDesignTimeTargetsPath)' != '' and Exists('$(VisualBasicDesignTimeTargetsPath)')" />
+
     <Import Project="Microsoft.Common.targets" />
     <Import Project="$(MSBuildToolsPath)\Microsoft.ServiceModel.targets" Condition="('$(TargetFrameworkVersion)' != 'v2.0' and '$(TargetFrameworkVersion)' != 'v3.0' and '$(TargetFrameworkVersion)' != 'v3.5') and Exists('$(MSBuildToolsPath)\Microsoft.ServiceModel.targets')"/>
 
@@ -363,12 +370,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       -->
         <_ExplicitReference Include="$(FrameworkPathOverride)\System.dll" />
     </ItemGroup>
-
-    <!-- Import design time targets for Roslyn Project System. These are only available if Visual Studio is installed. -->
-    <PropertyGroup>
-       <VisualBasicDesignTimeTargetsPath Condition="'$(VisualBasicDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.VisualBasic.DesignTime.targets</VisualBasicDesignTimeTargetsPath>
-    </PropertyGroup>
-    <Import Project="$(VisualBasicDesignTimeTargetsPath)" Condition="'$(VisualBasicDesignTimeTargetsPath)' != '' and Exists('$(VisualBasicDesignTimeTargetsPath)')" />
 
     <Import Project="$(CustomAfterMicrosoftVisualBasicTargets)" Condition="'$(CustomAfterMicrosoftVisualBasicTargets)' != '' and Exists('$(CustomAfterMicrosoftVisualBasicTargets)')" />
 


### PR DESCRIPTION
Imports for Design time targets is moved before common targets so that
targets that gets imported through common targets, like Nuget, will be
able to override the target and property values.

@Microsoft/build @srivatsn for review