### PR TITLE
Avoid x-targeting perf impact on vcxproj

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1504,14 +1504,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     ======================================================================================
   -->
-  <Target Name="_GetProjectReferenceTargetFrameworkProperties" Outputs="%(_MSBuildProjectReferenceExistent.Identity)">
+  <Target Name="_GetProjectReferenceTargetFrameworkProperties"
+          Outputs="%(_MSBuildProjectReferenceExistent.Identity)">
+    <!-- As a mitigation for https://github.com/Microsoft/msbuild/issues/1276
+       .vcxproj is treated specially to avoid the cost of double-evaluating
+       for easily-identifiable-as-not-cross-targeting C++ projects. -->
     <MSBuild
         Projects="%(_MSBuildProjectReferenceExistent.Identity)"
         Targets="GetTargetFrameworkProperties"
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(TargetFrameworkMoniker)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework">
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework"
+        Condition="'%(_MSBuildProjectReferenceExistent.Extension)' != '.vcxproj'">
 
       <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>


### PR DESCRIPTION
Targeted mitigation for #1276.

VC++ noticed a dramatic regression in solution-load performance related to
the time cost of ResolveProjectReferences. That affects all projects, but
we can safely assume that a .vcxproj is NOT using cross-targeting, while
it's impossible to detect from the outside whether a .csproj is.

This commit avoids the regression for C++ projects by just not calling the
MSBuild task again for .vcxproj references.

/cc @nguerrera @olgaark @srivatsn