### PR TITLE
Only have _CheckForInvalidConfigurationAndPlatform target run before …

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -14,7 +14,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project DefaultTargets="Build" InitialTargets="_CheckForInvalidConfigurationAndPlatform" TreatAsLocalProperty="OutDir" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" TreatAsLocalProperty="OutDir" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(MicrosoftCommonPropsHasBeenImported)' != 'true' and Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
 
@@ -715,12 +715,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
                                         _CheckForInvalidConfigurationAndPlatform
 
-    This target checks for errors in statically defined properties.  It always
-    gets executed before any other target.
+    This target checks for errors in statically defined properties.  By setting BeforeTargets, we
+    try to ensure that the target runs before any build related targets.  The only time this won't
+    run is if the user specifies a BeforeTargets of the first target in any of the DependsOn targets.
+    In this case, they'll want to set DependsOn to this target.
     ============================================================
     -->
   <Target
-      Name="_CheckForInvalidConfigurationAndPlatform">
+      Name="_CheckForInvalidConfigurationAndPlatform"
+      BeforeTargets="$(BuildDependsOn);$(RebuildDependsOn);$(CleanDependsOn)">
 
     <PropertyGroup>
       <_InvalidConfigurationMessageText>The OutputPath property is not set for project '$(MSBuildProjectFile)'.  Please check to make sure that you have specified a valid combination of Configuration and Platform for this project.  Configuration='$(_OriginalConfiguration)'  Platform='$(_OriginalPlatform)'.</_InvalidConfigurationMessageText>

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -715,10 +715,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
                                         _CheckForInvalidConfigurationAndPlatform
 
-    This target checks for errors in statically defined properties.  By setting BeforeTargets, we
-    try to ensure that the target runs before any build related targets.  The only time this won't
-    run is if the user specifies a BeforeTargets of the first target in any of the DependsOn targets.
-    In this case, they'll want to set DependsOn to this target.
+    This target checks for errors in statically defined properties.  By setting BeforeTargets, we try
+    to ensure that the target runs before any build related targets.  
+    If your target requires this check and is running as a BeforeTargets of one of the first targets
+    of $(BuildDependsOn), $(RebuildDependsOn), or $(CleanDependsOn) you will need to set your DependsOn
+    to this target.
     ============================================================
     -->
   <Target

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -724,7 +724,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target
       Name="_CheckForInvalidConfigurationAndPlatform"
-      BeforeTargets="$(BuildDependsOn);$(RebuildDependsOn);$(CleanDependsOn)">
+      BeforeTargets="$(BuildDependsOn);Build;$(RebuildDependsOn);Rebuild;$(CleanDependsOn);Clean">
 
     <PropertyGroup>
       <_InvalidConfigurationMessageText>The OutputPath property is not set for project '$(MSBuildProjectFile)'.  Please check to make sure that you have specified a valid combination of Configuration and Platform for this project.  Configuration='$(_OriginalConfiguration)'  Platform='$(_OriginalPlatform)'.</_InvalidConfigurationMessageText>


### PR DESCRIPTION
…any build related target

This target is running before targets like Restore which don't need the check.  This change removes `_CheckForInvalidConfigurationAndPlatform` from `InitialTargets` and instead injects it before any of the `BuildDependsOn`, `RebuildDependsOn`, or `CleanDependsOn` targets.  This will work except when a user specifies a `BeforeTargets` of the first target in those lists.  To get around that, the user must specify a `DependsOn` of `_CheckForInvalidConfigurationAndPlatform` if they want the check to run before their target.

Related to https://github.com/dotnet/sdk/issues/203