### PR TITLE
Keep path in invalid project exceptions

### DIFF
--- a/src/Shared/BuildEventFileInfo.cs
+++ b/src/Shared/BuildEventFileInfo.cs
@@ -97,6 +97,16 @@ namespace Microsoft.Build.Shared
             _endColumn = 0;
         }
 
+        /// <summary>
+        /// Creates an instance of this class using the information in the given XmlException and file location.
+        /// </summary>
+        internal BuildEventFileInfo(string file, XmlException e) : this(e)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(file, nameof(file));
+
+            _file = file;
+        }
+
         #endregion
 
         #region Properties

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -2059,7 +2059,7 @@ namespace Microsoft.Build.Construction
 
                     if (xmlException != null)
                     {
-                        fileInfo = new BuildEventFileInfo(xmlException);
+                        fileInfo = new BuildEventFileInfo(fullPath, xmlException);
                     }
                     else
                     {

--- a/src/XMakeBuildEngine/Definition/Toolset.cs
+++ b/src/XMakeBuildEngine/Definition/Toolset.cs
@@ -1046,7 +1046,7 @@ namespace Microsoft.Build.Evaluation
                 catch (XmlException e)
                 {
                     // handle XML errors in the default tasks file
-                    ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(false, new BuildEventFileInfo(e), taskFileError, e.Message);
+                    ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(false, new BuildEventFileInfo(defaultTasksFile, e), taskFileError, e.Message);
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {


### PR DESCRIPTION
When #1004 moved the standard XML reading approach to be stream-based
rather than file-based, the exceptions thrown on malformed XML
changed--System.Xml no longer knows the path, so it isn't included in the
XmlException. That caused MSBuild to fail to report the location of the
XML error in a nice way as it had done before.

Almost every case where we constructed a BuildEventFileInfo object already
had access to the full path, so I added a constructor that accepted that
as an argument and overrides the possibly-empty path returned from
XmlException.SourceUri.

Fixes #1286.