### PR TITLE
Run tests on Linux

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -35,6 +35,7 @@
   <PropertyGroup>
     <XunitOptions Condition="'$(OS)'=='Windows_NT'">$(XunitOptions) -notrait category=nonwindowstests</XunitOptions>
     <XunitOptions Condition="'$(OS)'=='Unix'">$(XunitOptions) -notrait category=nonlinuxtests</XunitOptions>
+    <XunitOptions Condition="'$(OS)'=='Unix' and '$(NetCoreBuild)'=='true'">-notrait category=nonlinuxtests -notrait category=netcore-linux-failing</XunitOptions>
     <XunitOptions Condition="'$(OS)'=='OSX'">$(XunitOptions) -notrait category=nonosxtests</XunitOptions>
     <XunitOptions Condition="'$(OS)'=='OSX' and '$(NetCoreBuild)'=='true'">-notrait category=nonosxtests -notrait category=netcore-osx-failing</XunitOptions>
     <XunitOptions Condition="'$(OS)'=='FreeBSD'">$(XunitOptions) -notrait category=nonfreebsdtests</XunitOptions>

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetItemSpecModifier()
         {
             TestGetItemSpecModifier(Directory.GetCurrentDirectory());
@@ -85,6 +86,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void MakeRelativeTests()
         {
             if (NativeMethodsShared.IsWindows)
@@ -118,6 +120,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetItemSpecModifierOnBadPath()
         {
             Assert.Throws<InvalidOperationException>(() =>
@@ -132,6 +135,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetItemSpecModifierOnBadPath2()
         {
             Assert.Throws<InvalidOperationException>(() =>
@@ -184,6 +188,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void EndsWithSlash()
         {
             Assert.True(FileUtilities.EndsWithSlash(@"C:\foo\"));
@@ -208,6 +213,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetDirectoryWithTrailingSlash()
         {
             Assert.Equal(NativeMethodsShared.IsWindows ? @"c:\" : "/", FileUtilities.GetDirectory(NativeMethodsShared.IsWindows ? @"c:\" : "/"));
@@ -475,6 +481,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void FileOrDirectoryExistsNoThrow()
         {
             Assert.Equal(false, FileUtilities.FileOrDirectoryExistsNoThrow("||"));
@@ -785,6 +792,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GenerateTempBatchFileWithBadExtension()
         {
             Assert.Throws<IOException>(() =>
@@ -811,6 +819,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GenerateTempBatchFileWithBadDirectory()
         {
             Assert.Throws<IOException>(() =>

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetApiContractReferencesHandlesNonExistingLocation()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -226,6 +227,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GatherExtensionSDKsInvalidVersionDirectory()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -250,6 +252,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GatherExtensionSDKsNoManifest()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -274,6 +277,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GatherExtensionSDKsEmptyManifest()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -299,6 +303,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GatherExtensionSDKsGarbageManifest()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -633,6 +638,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ExerciseMiscToolLocationHelperMethods()
         {
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.Version11), FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV11);

--- a/src/Utilities/UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities/UnitTests/ToolTask_Tests.cs
@@ -220,6 +220,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void HandleExecutionErrorsWhenToolLogsError()
         {

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/BuildManager_Tests.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SimpleBuild()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -352,6 +353,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void InProcForwardPropertiesFromChild()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -404,6 +406,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void InProcMsBuildForwardAllPropertiesFromChild()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -861,6 +864,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SimpleBuildWithFailure()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -882,6 +886,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SimpleBuildWithFailureAndWarningOnlyLogCriticalEventsTrue()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -917,6 +922,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SimpleBuildWithFailureAndWarningOnlyLogCriticalEventsFalse()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1117,6 +1123,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void EndBuildBlocks()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1187,6 +1194,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SequentialBuild()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1224,6 +1232,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void OverlappingBuildSubmissions()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1267,6 +1276,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void OverlappingIdenticalBuildSubmissions()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1302,6 +1312,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void OverlappingBuildSubmissions_OnlyOneSucceeds()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1562,6 +1573,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SequentialBuildsOfTheSameProjectAllowed()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1592,6 +1604,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void OverlappingBuildsOfTheSameProjectDifferentTargetsAreAllowed()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1633,6 +1646,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void OverlappingBuildsOfTheSameProjectSameTargetsAreAllowed()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1732,6 +1746,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ProjectInstanceRetrievedAfterBuildMatchesSourceProject()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1759,6 +1774,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ResetCacheClearsInstances()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1792,6 +1808,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void DisablingCacheResetKeepsInstance()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1832,6 +1849,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GhostProjectRootElementCache()
         {
             string contents1 = ObjectModelHelpers.CleanupFileContents(@"
@@ -1987,6 +2005,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void Regress251333()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -2221,6 +2240,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void CacheLifetime()
         {
@@ -2337,6 +2357,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void FailedAfterTargetInP2PShouldCauseOverallBuildFailure_MultipleEntrypoints()
         {
             string projA = null;
@@ -2487,6 +2508,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void NonOverlappingEntrypointTargetsShouldNotInfluenceEachOthersResults()
         {
             string projA = null;
@@ -3139,6 +3161,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void VerifyMultipleRequestForSameProjectWithErrors_DifferentEntrypoints()
         {
             string projA = null;
@@ -3301,6 +3324,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void TestSimultaneousSubmissionsWithLegacyThreadingData_P2P()
         {
             string projectPath1 = null;

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -363,6 +363,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void TestCache2()
         {

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -2921,6 +2921,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void IncludeCheckOnMetadata_3()
         {

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -897,6 +897,7 @@ namespace Microsoft.Build.UnitTests.Logging
 
         [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/437")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void LogBuildStartedCriticalOnly()
         {

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -440,6 +440,7 @@ namespace ItemCreationTask
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void TasksCanAddRecursiveDirBuiltInMetadata()
         {

--- a/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -88,6 +88,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void FindBuildEnvironmentFromVisualStudioRoot()
         {
             using (var env = new EmptyBuildEnviroment())
@@ -104,6 +106,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentDetectsVisualStudioByEnvironment()
         {
             using (var env = new EmptyBuildEnviroment())
@@ -117,6 +121,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentDetectsVisualStudioByMSBuildProcess()
         {
             using (var env = new EmptyBuildEnviroment())
@@ -129,6 +135,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentDetectsVisualStudioByMSBuildProcessAmd64()
         {
             using (var env = new EmptyBuildEnviroment())
@@ -141,6 +149,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentDetectsVisualStudioFromSetupInstance()
         {
             using (var env = new EmptyBuildEnviroment())
@@ -189,6 +199,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentDetectsVisualStudioByProcessName()
         {
             using (var env = new EmptyBuildEnviroment())
@@ -201,6 +213,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentDetectsVisualStudioByBlendProcess()
         {
             using (var env = new EmptyBuildEnviroment())

--- a/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/ElementLocation_Tests.cs
@@ -289,6 +289,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void LocationStringsMedleyReadOnlyLoad()
         {
             string content = ObjectModelHelpers.CleanupFileContents(@"
@@ -355,6 +356,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SaveReadOnly2()
         {
             var doc = new XmlDocumentWithLocation(loadAsReadOnly: true);
@@ -379,6 +381,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SaveReadOnly3()
         {
             var doc = new XmlDocumentWithLocation(loadAsReadOnly: true);
@@ -404,6 +407,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SaveReadOnly4()
         {
             var doc = new XmlDocumentWithLocation(loadAsReadOnly: true);

--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Build.UnitTests.Construction
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ParseFirstProjectLine_VC()
         {
             Assert.Throws<InvalidProjectFileException>(() =>
@@ -457,6 +458,7 @@ namespace Microsoft.Build.UnitTests.Construction
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ParseNestedEtpProjectMultipleLevel()
         {
             string proj1Path = Path.Combine(Path.GetTempPath(), "someproj.etp");

--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Build.UnitTests.Construction
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void EmitToolsVersionAttributeToInMemoryProject9()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV35 == null)
@@ -149,6 +150,7 @@ namespace Microsoft.Build.UnitTests.Construction
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void EmitToolsVersionAttributeToInMemoryProject10()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV35 == null)
@@ -958,6 +960,7 @@ EndGlobal
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void Regress751742_SkipNonexistentProjects()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
@@ -1376,6 +1379,7 @@ EndGlobal
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void TestVenusConfigurationDefaults()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
@@ -1406,6 +1410,7 @@ EndGlobal
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void VenusSolutionDefaultTargetFrameworkVersion()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
@@ -1445,6 +1450,7 @@ EndGlobal
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void TestTargetFrameworkPaths0()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkSdkV20 != null)
@@ -1470,6 +1476,7 @@ EndGlobal
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void TestTargetFrameworkPaths1()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
@@ -1496,6 +1503,7 @@ EndGlobal
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void TestTargetFrameworkPaths2()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
@@ -1691,6 +1699,7 @@ EndGlobal
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void TestSkipInvalidConfigurationsCase()
         {

--- a/src/XMakeBuildEngine/UnitTests/Definition/Project_Internal_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/Project_Internal_Tests.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Build.UnitTests.Definition
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ProjectToolsVersion20Present()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
@@ -150,6 +151,7 @@ namespace Microsoft.Build.UnitTests.Definition
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void MSBuildToolsVersionProperty()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Evaluator_Tests.cs
@@ -134,6 +134,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void VerifyConditionsInsideOutsideTargets()
         {
@@ -2324,6 +2325,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void ReservedProjectProperties()
         {

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -227,6 +227,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ExpandItemVectorFunctionsGetDirectoryNameOfMetadataValueDistinct()
         {
             ProjectInstance project = ProjectHelpers.CreateEmptyProjectInstance();
@@ -252,6 +253,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void ExpandItemVectorFunctionsItemSpecModifier()
         {
@@ -312,6 +314,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void ExpandItemVectorFunctionsChained1()
         {
@@ -328,6 +331,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void ExpandItemVectorFunctionsChained2()
         {
@@ -355,6 +359,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void ExpandItemVectorFunctionsChainedProject1()
         {
@@ -631,6 +636,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void ExpandItemVectorFunctionsItemSpecModifier2()
         {
@@ -669,6 +675,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ExpandItemVectorFunctionsGetDirectoryNameOfMetadataValue()
         {
             ProjectInstance project = ProjectHelpers.CreateEmptyProjectInstance();
@@ -688,6 +695,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ExpandItemVectorFunctionsMetadataValueMultiItem()
         {
             ProjectInstance project = ProjectHelpers.CreateEmptyProjectInstance();
@@ -2011,6 +2019,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void PropertyFunctionDictionaryReturn()
         {
@@ -2234,6 +2243,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void PropertyFunctionStaticMethodMakeRelative()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2367,6 +2377,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void PropertyFunctionStaticMethodQuoted1()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2843,6 +2854,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void PropertyFunctionStaticMethodFileAttributes()
         {

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ProjectStringCache_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ProjectStringCache_Tests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ContentIsSameAcrossInstances()
         {
             string content = ObjectModelHelpers.CleanupFileContents(@"
@@ -91,6 +92,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ContentCanBeModified()
         {
             string content = ObjectModelHelpers.CleanupFileContents(@"
@@ -176,6 +178,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void RemovingFilesRemovesEntries()
         {
             string content = ObjectModelHelpers.CleanupFileContents(@"

--- a/src/XMakeBuildEngine/UnitTests/FileLogger_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/FileLogger_Tests.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void InvalidFile()
         {

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
@@ -389,6 +389,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ValidXmlXmlTextReaderNotCache()
         {
             string content = @"
@@ -677,6 +678,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/301")]
 #endif
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void EncodingGetterBasedOnActualEncodingWhenXmlDeclarationIsAbsent()
         {
             string projectFullPath = FileUtilities.GetTemporaryFile();

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -1599,6 +1599,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void RenameItemInProjectWithWildcards()
         {
             string projectDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectProperty_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectProperty_Tests.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void SetValueEnvironmentProperty()
         {
             Project project = new Project();
@@ -173,6 +174,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void IsEnvironmentVariable()
         {
             Project project = new Project();

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Instance/ProjectInstance_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Instance/ProjectInstance_Tests.cs
@@ -841,6 +841,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ImmutableProjectInstance_CloneImmutableFromMutable()
         {
             var protoInstance = GetSampleProjectInstance(false /* mutable */);
@@ -862,6 +863,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ImmutableProjectInstance_CloneImmutableFromImmutable()
         {
             var protoInstance = GetSampleProjectInstance(true /* immutable */);
@@ -886,6 +888,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ImmutableProjectInstance_CloneImmutableFromImmutable2()
         {
             var protoInstance = GetSampleProjectInstance(true /* immutable */);
@@ -907,6 +910,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ImmutableProjectInstance_CloneMutableFromMutable()
         {
             var protoInstance = GetSampleProjectInstance(false /* mutable */);

--- a/src/XMakeTasks/UnitTests/ConvertToAbsolutePath_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ConvertToAbsolutePath_Tests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void RelativePath()
         {
@@ -50,6 +51,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void RelativePathWithEscaping()
         {

--- a/src/XMakeTasks/UnitTests/Copy_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Copy_Tests.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void DoNotNormallyCopyOverReadOnlyFile()
         {
             string source = FileUtilities.GetTemporaryFile();
@@ -181,6 +182,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void CopyOverReadOnlyFileEnvironmentOverride()
         {
             string source = FileUtilities.GetTemporaryFile();
@@ -242,6 +244,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void AlwaysRetryCopyEnvironmentOverride()
         {
             string source = FileUtilities.GetTemporaryFile();
@@ -309,6 +312,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void CopyOverReadOnlyFileParameterIsSet()
         {
             string source = FileUtilities.GetTemporaryFile();
@@ -438,6 +442,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void DoCopyOverDifferentFile()
         {
             string sourceFile = FileUtilities.GetTemporaryFile();
@@ -673,6 +678,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void DoRetryWhenDestinationLocked()
         {
             string destinationFile = Path.GetTempFileName();
@@ -1107,6 +1113,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void CopyFileOnItselfAndFailACopy()
         {
             string temp = Path.GetTempPath();

--- a/src/XMakeTasks/UnitTests/Culture_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Culture_Tests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Build.UnitTests
         */
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void BogusEmbeddedCulture()
         {
             Culture.ItemCultureInfo info = Culture.GetItemCultureInfo("MyResource.notalocale.resx", null);

--- a/src/XMakeTasks/UnitTests/Exec_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Exec_Tests.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ExitCodeGetter()
         {
             Exec exec = PrepareExec("exit 120");
@@ -462,6 +463,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void InvalidWorkingDirectorySet()
         {
             Exec exec = PrepareExec("echo [%cd%]");

--- a/src/XMakeTasks/UnitTests/FileStateTests.cs
+++ b/src/XMakeTasks/UnitTests/FileStateTests.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void BadTooLongLastWriteTime()
         {
@@ -343,6 +344,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void LengthReset()
         {
@@ -425,6 +427,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void DoesNotExistLastWriteTime()
         {
             string file = Guid.NewGuid().ToString("N");
@@ -434,6 +437,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void DoesNotExistLastWriteTimeUtc()
         {
             string file = Guid.NewGuid().ToString("N");

--- a/src/XMakeTasks/UnitTests/FindUnderPath_Tests.cs
+++ b/src/XMakeTasks/UnitTests/FindUnderPath_Tests.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void VerifyFullPath()
         {
@@ -122,6 +123,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void VerifyFullPathNegative()
         {

--- a/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
@@ -156,6 +156,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// </summary>
         /// <remarks>System dll is not locked because it forces a new app domain</remarks> 
         [Fact]
+        [Trait("Category", "netcore-linux-failing")]
         public void ResX2ResourcesWithReferences()
         {
             string systemDll = Utilities.GetPathToCopiedSystemDLL();
@@ -388,6 +389,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         ///  Force partially out-of-date: should build only the out of date inputs
         /// </summary>
         [Fact]
+        [Trait("Category", "netcore-linux-failing")]
         public void ForceSomeOutOfDate()
         {
             string resxFile = null;
@@ -577,6 +579,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// </summary>
         /// <remarks>System dll is not locked because it forces a new app domain</remarks>
         [Fact]
+        [Trait("Category", "netcore-linux-failing")]
         public void NothingOutOfDateExceptReference()
         {
             string resxFile = null;

--- a/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
@@ -271,6 +271,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void ForceOutOfDate()
         {
             string resxFile = Utilities.WriteTestResX(false, null, null);
@@ -2481,7 +2482,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
     public class References
     {
         [Fact]
-        [Trait("Category", "netcore-osx-failing")] // https://github.com/Microsoft/msbuild/issues/309
+        [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")] // https://github.com/Microsoft/msbuild/issues/309
         public void DontLockP2PReferenceWhenResolvingSystemTypes()
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
@@ -2659,7 +2661,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// Assembly.LoadFrom instead.
         /// </summary>
         [Fact]
-        [Trait("Category", "netcore-osx-failing")] // https://github.com/Microsoft/msbuild/issues/309
+        [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")] // https://github.com/Microsoft/msbuild/issues/309
         public void ReferencedAssemblySpecifiedUsingRelativePath()
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting

--- a/src/XMakeTasks/UnitTests/Move_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Move_Tests.cs
@@ -462,6 +462,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void MoveLockedFile()
         {
             string file = null;

--- a/src/XMakeTasks/UnitTests/ResolveCodeAnalysisRuleSet_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveCodeAnalysisRuleSet_Tests.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetResolvedRuleSetPath_SimpleNameAndProjectDirectory_NonExistent()
         {
             MockEngine mockEngine = new MockEngine();
@@ -189,6 +190,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetResolvedRuleSetPath_SimpleNameAndDirectories_NonExistent()
         {
             MockEngine mockEngine = new MockEngine();
@@ -211,6 +213,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetResolvedRuleSetPath_RelativePath_WithProject_NonExistent()
         {
             MockEngine mockEngine = new MockEngine();
@@ -234,6 +237,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetResolvedRuleSetPath_RelativePath_WithProject_Existent()
         {
             MockEngine mockEngine = new MockEngine();
@@ -264,6 +268,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "netcore-osx-failing")]
+        [Trait("Category", "netcore-linux-failing")]
         public void GetResolvedRuleSetPath_RelativePath_NoProject()
         {
             MockEngine mockEngine = new MockEngine();


### PR DESCRIPTION
I copied all of the tests from netcore-ox-failing to netcore-linux-failing.

There were only 3 tests that failed which I disabled for now (5ea4730a530b12b256dcd71611c71808ce25c840):

1. ResX2ResourcesWithReferences
2. ForceSomeOutOfDate
3. NothingOutOfDateExceptReference