### PR TITLE
OrcasEngine should not use ProductVersion

### DIFF
--- a/src/OrcasEngine/Engine/Engine.cs
+++ b/src/OrcasEngine/Engine/Engine.cs
@@ -584,20 +584,25 @@ namespace Microsoft.Build.BuildEngine
             {
                 if (engineVersion == null)
                 {
-                    // Get the file version from the currently executing assembly.
-                    // Use .CodeBase instead of .Location, because .Location doesn't
-                    // work when Microsoft.Build.Engine.dll has been shadow-copied, for example
-                    // in scenarios where NUnit is loading Microsoft.Build.Engine.
+                    string msbuildPath = null;
+
                     try
                     {
-                        engineVersion = new Version(FileVersionInfo.GetVersionInfo(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath).ProductVersion);
+                        // Get the file version from the currently executing assembly.
+                        // Use .CodeBase instead of .Location, because .Location doesn't
+                        // work when Microsoft.Build.Engine.dll has been shadow-copied, for example
+                        // in scenarios where NUnit is loading Microsoft.Build.Engine.
+                        msbuildPath = new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath;
                     }
                     catch (InvalidOperationException)
                     {
                         // Workaround for Watson Bug: #161292 people getting relative uri crash here.
                         // Last resort. We may have a problem when the assembly is shadow-copied.
-                        engineVersion = new Version(FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion);
+                        msbuildPath = Path.GetFullPath(typeof(Engine).Assembly.Location);
                     }
+
+                    var versionInfo = FileVersionInfo.GetVersionInfo(msbuildPath);
+                    engineVersion = new Version(versionInfo.FileMajorPart, versionInfo.FileMinorPart, versionInfo.FileBuildPart, versionInfo.FilePrivatePart);
                 }
 
                 return engineVersion;


### PR DESCRIPTION
Since we changed ProductVersion to include the git commit, the previous code was trying to call `new Version("15.1.318-preview5+gfd25bc9c7d")` 

Discovered while looking into https://devdiv.visualstudio.com/DevDiv/MSBuild/_workitems?id=286389&triage=true&_a=edit