### PR TITLE
Keep BuildEventContext.SubmissionId in serialization

### DIFF
--- a/src/Shared/NodePacketTranslator.cs
+++ b/src/Shared/NodePacketTranslator.cs
@@ -1318,7 +1318,7 @@ namespace Microsoft.Build.BackEnd
                         projectContextId = context.ProjectContextId;
                         taskId = context.TaskId;
                         projectInstanceId = context.ProjectInstanceId;
-                        submissionId = context.ProjectInstanceId;
+                        submissionId = context.SubmissionId;
                     }
 
                     translator.Translate(ref nodeId);


### PR DESCRIPTION
Fixes #651, which was occurring because the serialized SubmissionId
returned from the remote node didn't match the saved SubmissionId, so it
wasn't marked as complete in BuildManager.OnProjectFinished. Since there
was an incomplete submission, the build never finished.