### PR TITLE
GetItemProvenance should not unescape input

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
+++ b/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Evaluation
                         var containsRealWildcards = FileMatcher.HasWildcards(splitEscaped);
 
                         // '*' is an illegal character to have in a filename.
-                        // todo file-system assumption on legal path characters: https://github.com/Microsoft/msbuild/issues/781
+                        // todo: file-system assumption on legal path characters: https://github.com/Microsoft/msbuild/issues/781
                         if (containsEscapedWildcards && containsRealWildcards)
                         {
 
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Evaluation
             : this(
                 itemSpecFragment,
                 projectPath,
-                new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetMatchTester(itemSpecFragment, projectPath)))
+                new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(itemSpecFragment, projectPath)))
         {
         }
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.Build.Construction;
 using System.Collections.Immutable;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -54,7 +55,7 @@ namespace Microsoft.Build.Evaluation
 
                     if (excludePatterns.Any())
                     {
-                        excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetMatchTester(excludePatterns, _rootDirectory));
+                        excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory));
                     }
                 }
 
@@ -84,7 +85,7 @@ namespace Microsoft.Build.Evaluation
                         string value = ((ValueFragment)fragment).ItemSpecFragment;
 
                         if (excludeTester == null ||
-                            !excludeTester.Value(value))
+                            !excludeTester.Value(EscapingUtilities.UnescapeAll(value)))
                         {
                             var item = _itemFactory.CreateItem(value, value, _itemElement.ContainingProject.FullPath);
                             itemsToAdd.Add(item);

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -479,13 +479,13 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             "b",
             new string[0],
             new[] { "a" })]
-        //// items as strings: escaped include matches non-escaped exclude
+        // items as strings: escaped include matches non-escaped exclude
         [InlineData(ItemWithIncludeAndExclude,
             "%61",
             "a",
             new string[0],
             new string[0])]
-        //// items as strings: non-escaped include matches escaped exclude
+        // items as strings: non-escaped include matches escaped exclude
         [InlineData(ItemWithIncludeAndExclude,
             "a",
             "%61",


### PR DESCRIPTION
Resolves #1106.

Also fixes various issues with slash normalization which got exposed by the fix for #1106:
- slashes are normalized only when the string is a path
- checking whether a string is a valid path uses a union of Windows and !Windows characters, based on: https://github.com/Microsoft/msbuild/issues/781#issuecomment-243942514
- Re-implement Path.GetFileName so it works with potentially malformed paths.
- Normalize the slashes before normalizing the path. Otherwise .Net's implementation of GetFullPath does not work.