### PR TITLE
Remove "Extensions" folder from MSBuildExtensionsPath

### DIFF
--- a/src/XMakeBuildEngine/Resources/Constants.cs
+++ b/src/XMakeBuildEngine/Resources/Constants.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Build.Internal
         internal const string buildNodeCount = "MSBuildNodeCount";
         internal const string lastTaskResult = "MSBuildLastTaskResult";
         internal const string extensionsPathSuffix = "MSBuild";
-        internal const string appLocalExtensionsPathSuffix = "Extensions";
         internal const string userExtensionsPathSuffix = "Microsoft\\MSBuild";
         internal const string programFiles32 = "MSBuildProgramFiles32";
         internal const string localAppData = "LocalAppData";

--- a/src/XMakeBuildEngine/Utilities/Utilities.cs
+++ b/src/XMakeBuildEngine/Utilities/Utilities.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Build.Internal
             // environment or as a global property.  
 
 #if !FEATURE_INSTALLED_MSBUILD
-            string extensionsPath = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, ReservedPropertyNames.appLocalExtensionsPathSuffix);
+            string extensionsPath = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
             string extensionsPath32 = extensionsPath;
 #else
             // "MSBuildExtensionsPath32". This points to whatever the value of "Program Files (x86)" environment variable is;


### PR DESCRIPTION
This only applies for "app local" MSBuild.  Our NuGet package does not have the Extensions folder and the dotnet CLI is already setting this so property.

Closes #1335