### PR TITLE
Make SerializedException robust to load errors

### DIFF
--- a/src/Shared/NodePacketTranslator.cs
+++ b/src/Shared/NodePacketTranslator.cs
@@ -18,6 +18,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using System.Globalization;
 using System.Reflection;
@@ -1396,35 +1397,44 @@ namespace Microsoft.Build.BackEnd
 
             public static Exception ToException(SerializedException serializedException)
             {
-                var typeLoader = new TypeLoader((t, o) => true);
-
-                LoadedType loadedExceptionType = typeLoader.Load(serializedException.TypeFullName, serializedException.ExceptionAssembly);
-                Type exceptionType = loadedExceptionType.Type;
-
                 Exception innerException = null;
                 if (serializedException.InnerException != null)
                 {
                     innerException = ToException(serializedException.InnerException);
                 }
 
-                Type[] parameterTypes;
-                object[] constructorParameters;
-                if (innerException == null)
+                ConstructorInfo constructor = null;
+                object[] constructorParameters = null;
+
+                try
                 {
-                    parameterTypes = new[] { typeof(string) };
-                    constructorParameters = new object[] { serializedException.Message };
+                    var typeLoader = new TypeLoader((t, o) => true);
+
+                    LoadedType loadedExceptionType = typeLoader.Load(serializedException.TypeFullName, serializedException.ExceptionAssembly);
+                    Type exceptionType = loadedExceptionType.Type;
+
+                    Type[] parameterTypes;
+                    if (innerException == null)
+                    {
+                        parameterTypes = new[] { typeof(string) };
+                        constructorParameters = new object[] { serializedException.Message };
+                    }
+                    else
+                    {
+                        parameterTypes = new[] { typeof(string), typeof(Exception) };
+                        constructorParameters = new object[] { serializedException.Message, innerException };
+                    }
+
+                    constructor = exceptionType.GetConstructor(parameterTypes);
                 }
-                else
+                catch (FileLoadException e)
                 {
-                    parameterTypes = new[] { typeof(string), typeof(Exception) };
-                    constructorParameters = new object[] { serializedException.Message, innerException };
+                    CommunicationsUtilities.Trace($"Exception while attempting to deserialize an exception of type \"{serializedException.TypeFullName}\". Could not load from \"{serializedException.ExceptionAssembly.AssemblyLocation}\": {e}");
                 }
 
-                ConstructorInfo constructor = exceptionType.GetConstructor(parameterTypes);
                 if (constructor == null)
                 {
-                    //  Couldn't find appropriate constructor.  Fall back to creating an exception
-                    //  that will look the same as the original one when ToString() is called
+                    CommunicationsUtilities.Trace($"Could not find a constructor to deserialize an exception of type \"{serializedException.TypeFullName}\". Falling back to an exception that will look the same.");
                     return new FormattedException(serializedException.ExceptionToString);
                 }
 


### PR DESCRIPTION
`GetTypeInfo().Assembly` seems to produce bogus results at least some of
the time (noticed especially for XmlException). Since exceptions are
serialized by including the exception's type and assembly, and then
deserialized by reflecting over that assembly to find the type's
constructor, this could cause an unhandled exception if the assembly
couldn't be loaded.

This change wraps the attempt to find the constructor robust to
file-not-found errors--if the assembly can't be loaded, simply use the
preexisting FormattedError fallback case.

Fixes #1246.