### PR TITLE
Remove xml stuff from nuspecs

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Conversion.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Conversion.Core.nuspec
@@ -1,4 +1,5 @@
-﻿<package>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -13,7 +14,7 @@
     <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="net46">
+      <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build" version="[$version$]" />
         <dependency id="Microsoft.Build.Engine" version="[$version$]" />
       </group>

--- a/build/NuGetPackages/Microsoft.Build.Conversion.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Conversion.Core.nuspec
@@ -11,8 +11,8 @@
     <projectUrl>$projectUrl$</projectUrl>
     <iconUrl>$iconUrl$</iconUrl>
     <description>This package contains the $id$ assembly which contains logic for converting projects.  NOTE: This assembly is deprecated.</description>
-    <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build" version="[$version$]" />

--- a/build/NuGetPackages/Microsoft.Build.Conversion.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Conversion.Core.nuspec
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+﻿<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.Engine.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Engine.nuspec
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+﻿<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.Engine.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Engine.nuspec
@@ -1,4 +1,5 @@
-﻿<package>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -13,12 +14,12 @@
     <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="net46">
+      <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
       </group>
     </dependencies>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Xml" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.6" />
     </frameworkAssemblies>
   </metadata>
   <files>

--- a/build/NuGetPackages/Microsoft.Build.Engine.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Engine.nuspec
@@ -11,8 +11,8 @@
     <projectUrl>$projectUrl$</projectUrl>
     <iconUrl>$iconUrl$</iconUrl>
     <description>This package contains the $id$ assembly which contains the legacy compatibility shim for the MSBuild engine.  NOTE: This assembly is deprecated.</description>
-    <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -11,8 +11,8 @@
     <projectUrl>$projectUrl$</projectUrl>
     <iconUrl>$iconUrl$</iconUrl>
     <description>This package contains the $id$ assembly which is a common assembly used by other MSBuild assemblies.</description>
-    <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Collections" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+﻿<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -1,4 +1,5 @@
-﻿<package>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -14,7 +14,7 @@
     <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="netstandard1.3">
+      <group targetFramework=".NETStandard1.3">
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Globalization" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
@@ -1,4 +1,5 @@
-﻿<package>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -16,13 +17,13 @@
       <files include="**" buildAction="None" copyToOutput="true" flatten="false" />
     </contentFiles>
     <dependencies>
-      <group targetFramework="netstandard1.5">
+      <group targetFramework=".NETStandard1.5">
         <dependency id="Microsoft.Build" version="[$version$]" />
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Tasks.Core" version="[$version$]" />
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
       </group>
-      <group targetFramework="net46">
+      <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build" version="[$version$]" />
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Tasks.Core" version="[$version$]" />

--- a/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+﻿<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
@@ -11,11 +11,8 @@
     <projectUrl>$projectUrl$</projectUrl>
     <iconUrl>$iconUrl$</iconUrl>
     <description>This package contains the runtime of MSBuild.  Reference this package only if your application needs to load projects or execute in-process builds.</description>
-    <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
-    <contentFiles>
-      <files include="**" buildAction="None" copyToOutput="true" flatten="false" />
-    </contentFiles>
+    <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.5">
         <dependency id="Microsoft.Build" version="[$version$]" />
@@ -30,6 +27,9 @@
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
       </group>
     </dependencies>
+    <contentFiles>
+      <files include="**" buildAction="None" copyToOutput="true" flatten="false" />
+    </contentFiles>
   </metadata>
   <files>
     <!--

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -11,8 +11,8 @@
     <projectUrl>$projectUrl$</projectUrl>
     <iconUrl>$iconUrl$</iconUrl>
     <description>This package contains the $id$ assembly which implements the commonly used tasks of MSBuild.</description>
-    <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+﻿<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -14,7 +14,7 @@
     <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="netstandard1.3">
+      <group targetFramework=".NETStandard1.3">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
         <dependency id="System.Resources.Reader" version="4.0.0" />
@@ -60,7 +60,7 @@
         <dependency id="System.Xml.XDocument" version="4.0.11" />
         <dependency id="System.Xml.XmlDocument" version="4.0.1" />
       </group>
-      <group targetFramework="net46">
+      <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
       </group>

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -1,4 +1,5 @@
-﻿<package>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -14,7 +14,7 @@
     <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="netstandard1.3">
+      <group targetFramework=".NETStandard1.3">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="System.Resources.Reader" version="4.0.0" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
@@ -51,7 +51,7 @@
         <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
         <dependency id="System.Xml.XmlDocument" version="4.0.1" />
       </group>
-      <group targetFramework="net46">
+      <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
       </group>
     </dependencies>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+﻿<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -11,8 +11,8 @@
     <projectUrl>$projectUrl$</projectUrl>
     <iconUrl>$iconUrl$</iconUrl>
     <description>This package contains the $id$ assembly which is used to implement custom MSBuild tasks.</description>
-    <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -1,4 +1,5 @@
-﻿<package>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -11,8 +11,8 @@
     <projectUrl>$projectUrl$</projectUrl>
     <iconUrl>$iconUrl$</iconUrl>
     <description>This package contains the $id$ assembly which is used to create, edit, and evaluation MSBuild projects.</description>
-    <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.5">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+﻿<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -1,4 +1,5 @@
-﻿<package>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -14,7 +14,7 @@
     <tags>MSBuild</tags>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="netstandard1.5">
+      <group targetFramework=".NETStandard1.5">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
         <dependency id="System.AppContext" version="4.1.0" />
@@ -61,12 +61,12 @@
         <dependency id="System.Xml.XmlDocument" version="4.0.1" />
         <dependency id="System.Xml.XPath.XmlDocument" version="4.0.1" />
       </group>
-      <group targetFramework="net46">
+      <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
       </group>
     </dependencies>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Xml" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.6" />
     </frameworkAssemblies>
   </metadata>
   <files>

--- a/dir.props
+++ b/dir.props
@@ -243,7 +243,7 @@
     <DefineConstants>$(DefineConstants);RUNTIME_TYPE_NETCORE</DefineConstants>
     
     <!-- target framework for msbuild nuget packages. Used by Nuspec.ReferenceGenerator.targets to update corefx dependencies-->
-    <NuSpecTfm>netstandard$(TargetFrameworkVersion.TrimStart('v'))</NuSpecTfm>
+    <NuSpecTfm>.NETStandard$(TargetFrameworkVersion.TrimStart('v'))</NuSpecTfm>
 
   </PropertyGroup>
 

--- a/src/MSBuild.sln
+++ b/src/MSBuild.sln
@@ -48,13 +48,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PortableTask", "..\Samples\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetCoreCompileTest", "..\Samples\NetCoreCompileTest\NetCoreCompileTest.csproj", "{11B5D53E-90E4-4BD5-9883-B5921F7DE854}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{144F834D-9344-42E1-919D-4D1951F3E281}"
-	ProjectSection(SolutionItems) = preProject
-		nuget\Microsoft.Build.Framework.nuspec = nuget\Microsoft.Build.Framework.nuspec
-		nuget\Microsoft.Build.Tasks.Core.nuspec = nuget\Microsoft.Build.Tasks.Core.nuspec
-		nuget\Microsoft.Build.Utilities.Core.nuspec = nuget\Microsoft.Build.Utilities.Core.nuspec
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuildTaskHost", "XMakeCommandLine\MSBuildTaskHost\MSBuildTaskHost.csproj", "{53733ECF-0D81-43DA-B602-2AE9417F614F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dependency", "..\Samples\Dependency\Dependency.csproj", "{9EAE36C3-50CD-49A6-9CA2-94649125DCD1}"
@@ -66,6 +59,18 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrcasEngine", "OrcasEngine\OrcasEngine.csproj", "{D21C4BF9-E131-4ACB-8960-794797F19A39}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XMakeConversion", "XMakeConversion\XMakeConversion.csproj", "{5274C277-F122-4A44-B7A0-00A1B3F39803}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGetPackages", "NuGetPackages", "{B3A6667F-80C1-4264-874B-60AF572F641F}"
+	ProjectSection(SolutionItems) = preProject
+		..\build\NuGetPackages\CreateNuGetPackages.proj = ..\build\NuGetPackages\CreateNuGetPackages.proj
+		..\build\NuGetPackages\Microsoft.Build.Conversion.Core.nuspec = ..\build\NuGetPackages\Microsoft.Build.Conversion.Core.nuspec
+		..\build\NuGetPackages\Microsoft.Build.Engine.nuspec = ..\build\NuGetPackages\Microsoft.Build.Engine.nuspec
+		..\build\NuGetPackages\Microsoft.Build.Framework.nuspec = ..\build\NuGetPackages\Microsoft.Build.Framework.nuspec
+		..\build\NuGetPackages\Microsoft.Build.nuspec = ..\build\NuGetPackages\Microsoft.Build.nuspec
+		..\build\NuGetPackages\Microsoft.Build.Runtime.nuspec = ..\build\NuGetPackages\Microsoft.Build.Runtime.nuspec
+		..\build\NuGetPackages\Microsoft.Build.Tasks.Core.nuspec = ..\build\NuGetPackages\Microsoft.Build.Tasks.Core.nuspec
+		..\build\NuGetPackages\Microsoft.Build.Utilities.Core.nuspec = ..\build\NuGetPackages\Microsoft.Build.Utilities.Core.nuspec
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -25,7 +25,7 @@
         "System.Runtime.Loader": "4.0.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Threading.Tasks.Dataflow": "4.6.0",
-        "system.Threading.Thread": "4.0.0",
+        "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",
         "System.Xml.XmlDocument": "4.0.1",
         "System.Xml.XPath.XmlDocument": "4.0.1"


### PR DESCRIPTION
After our NuGet packages are pushed, the XMLNS is different in the downloaded one as well as the encoding/BOM.

I'm hoping just removing this stuff is enough to fix this problem.

I also updated the solution to include the new nuspecs and removed the old ones.