### PR TITLE
Only use RtlMoveMemory on Full Framework

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -309,6 +309,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_RESGEN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCE_EXPOSURE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESX_RESOURCE_READER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_RTLMOVEMEMORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUN_EXE_IN_TESTS</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_SECURITY_PERMISSIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SECURITY_PRINCIPAL_WINDOWS</DefineConstants>


### PR DESCRIPTION
RtlMoveMemory is not available on Nano Server, so the runtime check
introduced in 60a585c isn't quite right: Nano Server is Windows but
doesn't have this API exposed.

Introduce a new feature flag for RtlMoveMemory, used only when building
for Full Framework. For Mono and .NET Core builds, use the simpler (and I
guess slower? Would like to see a benchmark)
Environment.GetEnvironmentVariables codepath.

Related to #1233.