### PR TITLE
Add TargetFramework and PackageReference to the schema

### DIFF
--- a/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
+++ b/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
@@ -168,6 +168,51 @@ elementFormDefault="qualified">
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
+  <xs:element name="PackageReference" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PackageReference" _locComment="" -->Reference to a package
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="Version">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PackageReference_Version" _locComment="" -->Version of dependency
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="IncludeAssets">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PackageReference_IncludeAssets" _locComment="" -->Assets to include from this reference
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="ExcludeAssets">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PackageReference_ExcludeAssets" _locComment="" -->Assets to exclude from this reference
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="PrivateAssets">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PackageReference_PrivateAssets" _locComment="" -->Assets that are private in this reference
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="Xdcmake" substitutionGroup="msb:Item">
     <xs:complexType>
       <xs:complexContent>
@@ -1466,6 +1511,7 @@ elementFormDefault="qualified">
     <xs:element name="SupportUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="TargetFrameworkProfile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="TargetCulture" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="TargetFramework" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="TargetFrameworkVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>    
     <xs:element name="TargetPlatformIdentifier" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>  
     <xs:element name="TargetPlatformVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>   

--- a/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
+++ b/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
@@ -179,13 +179,6 @@ elementFormDefault="qualified">
         <xs:extension base="msb:SimpleItemType">
           <xs:sequence minOccurs="0" maxOccurs="unbounded">
             <xs:choice>
-              <xs:element name="Version">
-                <xs:annotation>
-                  <xs:documentation>
-                    <!-- _locID_text="PackageReference_Version" _locComment="" -->Version of dependency
-                  </xs:documentation>
-                </xs:annotation>
-              </xs:element>
               <xs:element name="IncludeAssets">
                 <xs:annotation>
                   <xs:documentation>
@@ -209,6 +202,13 @@ elementFormDefault="qualified">
               </xs:element>
             </xs:choice>
           </xs:sequence>
+          <xs:attribute name="Version" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="PackageReference_Version" _locComment="" -->Version of dependency
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>


### PR DESCRIPTION
Update schema to add TargetFramework to PropertyGroup, PackageReference to ItemGroup and the valid sub properties of PackageReference.

Related to #1317 