### PR TITLE
Guard against null ref when a Glob exclude fails to match any files

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -722,9 +722,12 @@ namespace Microsoft.Build.Shared
                     filesToExclude = new HashSet<string>();
                     foreach (var excludeStep in excludeNextSteps)
                     {
-                        foreach (var file in excludeStep.Files)
+                        if (excludeStep.Files != null)
                         {
-                            filesToExclude.Add(file);
+                            foreach (var file in excludeStep.Files)
+                            {
+                                filesToExclude.Add(file);
+                            }
                         }
                     }
                 }

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -621,6 +621,22 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 @"a\foo",
                 "build.proj"
             })]
+        [InlineData(ItemWithIncludeAndExclude,
+            @"**\*",
+            @"a\af*\*",
+            new[]
+            {
+                @"a\foo",
+                @"a\a\foo",
+                @"a\b\foo",
+            },
+            new[]
+            {
+                @"a\a\foo",
+                @"a\b\foo",
+                @"a\foo",
+                "build.proj"
+            })]
         public void ExcludeVectorWithWildCards(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude)
         {
             TestIncludeExcludeWithDifferentSlashes(projectContents, includeString, excludeString, inputFiles, expectedInclude);


### PR DESCRIPTION
[test.txt](https://github.com/Microsoft/msbuild/files/593579/test.txt)

I've included a sample project file that would cause a null ref in src/Shared/FileMatcher.cs. I looked around inside GetFilesRecursiveStep to see if Files should have just been set to an empty array, but it didn't appear to match stylistically with the surrounding code so I just put the guard in GetFilesRecursive.