### PR TITLE
Update ref assembly source and fix some warnings

### DIFF
--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Build.Construction
         protected internal virtual Microsoft.Build.Construction.ProjectElement Clone(Microsoft.Build.Construction.ProjectRootElement factory) { throw null; }
         public virtual void CopyFrom(Microsoft.Build.Construction.ProjectElement element) { }
         protected abstract Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner);
+        protected virtual bool ShouldCloneXmlAttribute(System.Xml.XmlAttribute attribute) { throw null; }
     }
     public abstract partial class ProjectElementContainer : Microsoft.Build.Construction.ProjectElement
     {
@@ -148,6 +149,7 @@ namespace Microsoft.Build.Construction
         public Microsoft.Build.Construction.ProjectMetadataElement AddMetadata(string name, string unevaluatedValue, bool expressAsAttribute) { throw null; }
         public override void CopyFrom(Microsoft.Build.Construction.ProjectElement element) { }
         protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
+        protected override bool ShouldCloneXmlAttribute(System.Xml.XmlAttribute attribute) { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("#Items={Count} Condition={Condition} Label={Label}")]
     public partial class ProjectItemGroupElement : Microsoft.Build.Construction.ProjectElementContainer

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -572,7 +572,7 @@ namespace Microsoft.Build.Shared
 
         /// <summary>
         /// Compare if two paths, relative to the given currentDirectory are equal.
-        /// Does not throw IO exceptions. See <see cref="GetFullPathNoThrow(string, string)"/>
+        /// Does not throw IO exceptions. See <see cref="GetFullPathNoThrow(string)"/>
         /// </summary>
         /// <param name="first"></param>
         /// <param name="second"></param>
@@ -594,7 +594,7 @@ namespace Microsoft.Build.Shared
 
         /// <summary>
         /// Normalizes a path for path comparison
-        /// Does not throw IO exceptions. See <see cref="GetFullPathNoThrow(string, string)"/>
+        /// Does not throw IO exceptions. See <see cref="GetFullPathNoThrow(string)"/>
         /// 
         /// </summary>
         internal static string NormalizePathForComparisonNoThrow(string path, string currentDirectory)

--- a/src/XMakeBuildEngine/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -840,14 +840,14 @@ namespace Microsoft.Build.BackEnd
         {
             if (!NativeMethodsShared.IsWindows || BuildEnvironmentHelper.Instance.RunningInVisualStudio)
             {
-                /// Since this causes synchronous I/O and a stop-the-world GC, it can be very expensive. If
-                /// something other than build results is taking up the bulk of the memory space, it may not
-                /// free any space. That's caused customer reports of VS hangs resulting from build requests
-                /// that are very slow because something in VS is taking all of the memory, but every
-                /// project build is slowed down by this codepath. To mitigate this, don't perform these
-                /// checks in devenv.exe. On the command line, 32-bit MSBuild may still need to cache build
-                /// results on very large builds, but build results are much more likely to be the bulk of
-                /// memory usage there.
+                // Since this causes synchronous I/O and a stop-the-world GC, it can be very expensive. If
+                // something other than build results is taking up the bulk of the memory space, it may not
+                // free any space. That's caused customer reports of VS hangs resulting from build requests
+                // that are very slow because something in VS is taking all of the memory, but every
+                // project build is slowed down by this codepath. To mitigate this, don't perform these
+                // checks in devenv.exe. On the command line, 32-bit MSBuild may still need to cache build
+                // results on very large builds, but build results are much more likely to be the bulk of
+                // memory usage there.
                 return;
             }
 


### PR DESCRIPTION
* `ShouldCloneXmlAttribute()` method
* BuildRequestEngine.cs(843,17): warning CS1587: XML comment is not placed on a valid language element
* FileUtilities.cs(575): warning CS1574: XML comment has cref attribute 'GetFullPathNoThrow(string, string)' that could not be resolved
* FileUtilities.cs(597): warning CS1574: XML comment has cref attribute 'GetFullPathNoThrow(string, string)' that could not be resolved