### PR TITLE
Enable Exec_Tests.Timeout

### DIFF
--- a/src/XMakeTasks/UnitTests/Exec_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Exec_Tests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Build.UnitTests
             bool result = exec.Execute();
 
             Assert.Equal(false, result);
-            Assert.Equal(-1, exec.ExitCode);
+            Assert.Equal(expectedExitCode, exec.ExitCode);
             ((MockEngine)exec.BuildEngine).AssertLogContains("MSB5002");
             Assert.Equal(1, ((MockEngine)exec.BuildEngine).Warnings);
 

--- a/src/XMakeTasks/UnitTests/Exec_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Exec_Tests.cs
@@ -88,9 +88,11 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // TODO: https://github.com/Microsoft/msbuild/issues/434
         public void Timeout()
         {
+            // On non-Windows the exit code of a killed process is SIGTERM (143)
+            int expectedExitCode = NativeMethodsShared.IsWindows ? -1 : 143;
+
             Exec exec = PrepareExec(NativeMethodsShared.IsWindows ? ":foo \n goto foo" : "while true; do sleep 1; done");
             exec.Timeout = 5;
             bool result = exec.Execute();


### PR DESCRIPTION
The issue was fixed by #886.  This is a revert of 2b3d4f1cd1cb50a3c942d77e316338e448385d2f with the expected exit code updated for cross-platform.

Closes #434 