### PR TITLE
Implement /NoWarn functionality

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -941,6 +941,7 @@ namespace Microsoft.Build.Execution
         public System.Globalization.CultureInfo UICulture { get { throw null; } set { } }
         public bool UseSynchronousLogging { get { throw null; } set { } }
         public System.Collections.Generic.ISet<string> WarningsAsErrors { get { throw null; } set { } }
+        public System.Collections.Generic.ISet<string> WarningsAsMessages { get { throw null; } set { } }
         public Microsoft.Build.Execution.BuildParameters Clone() { throw null; }
         public Microsoft.Build.Evaluation.Toolset GetToolset(string toolsVersion) { throw null; }
     }

--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
@@ -424,7 +424,7 @@ namespace Microsoft.Build.Execution
                 }
 
                 // Set up the logging service.
-                ILoggingService loggingService = CreateLoggingService(_buildParameters.Loggers, _buildParameters.ForwardingLoggers, _buildParameters.WarningsAsErrors);
+                ILoggingService loggingService = CreateLoggingService(_buildParameters.Loggers, _buildParameters.ForwardingLoggers, _buildParameters.WarningsAsErrors, _buildParameters.WarningsAsMessages);
 
                 _nodeManager.RegisterPacketHandler(NodePacketType.LogMessage, LogMessagePacket.FactoryForDeserialization, loggingService as INodePacketHandler);
                 try
@@ -1736,7 +1736,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Creates a logging service around the specified set of loggers.
         /// </summary>
-        private ILoggingService CreateLoggingService(IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> forwardingLoggers, ISet<string> warningsAsErrors)
+        private ILoggingService CreateLoggingService(IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> forwardingLoggers, ISet<string> warningsAsErrors, ISet<string> warningsAsMessages)
         {
             int cpuCount = _buildParameters.MaxNodeCount;
 
@@ -1764,6 +1764,7 @@ namespace Microsoft.Build.Execution
             loggingService.OnProjectStarted += _projectStartedEventHandler;
             loggingService.OnProjectFinished += _projectFinishedEventHandler;
             loggingService.WarningsAsErrors = warningsAsErrors;
+            loggingService.WarningsAsMessages = warningsAsMessages;
 
             try
             {

--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
@@ -206,6 +206,11 @@ namespace Microsoft.Build.Execution
         private ISet<string> _warningsAsErrors = null;
 
         /// <summary>
+        /// A list of warnings to treat as low importance messages.
+        /// </summary>
+        private ISet<string> _warningsAsMessages = null;
+
+        /// <summary>
         /// The location of the toolset definitions.
         /// </summary>
         private ToolsetDefinitionLocations _toolsetDefinitionLocations = ToolsetDefinitionLocations.Default;
@@ -326,6 +331,7 @@ namespace Microsoft.Build.Execution
             _logTaskInputs = other._logTaskInputs;
             _logInitialPropertiesAndItems = other._logInitialPropertiesAndItems;
             _warningsAsErrors = other._warningsAsErrors == null ? null : new HashSet<string>(other._warningsAsErrors, StringComparer.OrdinalIgnoreCase);
+            _warningsAsMessages = other._warningsAsMessages == null ? null : new HashSet<string>(other._warningsAsMessages, StringComparer.OrdinalIgnoreCase);
         }
 
 #if FEATURE_THREAD_PRIORITY
@@ -596,6 +602,15 @@ namespace Microsoft.Build.Execution
         {
             get { return _warningsAsErrors; }
             set { _warningsAsErrors = value; }
+        }
+
+        /// <summary>
+        /// A list of warnings to treat as low importance messages.
+        /// </summary>
+        public ISet<string> WarningsAsMessages
+        {
+            get { return _warningsAsMessages; }
+            set { _warningsAsMessages = value; }
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/BuildEventArgTransportSink.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/BuildEventArgTransportSink.cs
@@ -91,6 +91,16 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
+        /// This property is ignored by this event sink and relies on the receiver to treat warnings as low importance messages.
+        /// </summary>
+        public ISet<string> WarningsAsMessages
+        {
+            get;
+            set;
+        }
+
+
+        /// <summary>
         /// This property is ignored by this event sink and relies on the receiver to keep track of whether or not any errors have been logged.
         /// </summary>
         public ISet<int> BuildSubmissionIdsThatHaveLoggedErrors { get; } = null;

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/ILoggingService.cs
@@ -162,6 +162,15 @@ namespace Microsoft.Build.BackEnd.Logging
             get;
             set;
         }
+
+        /// <summary>
+        /// A list of warnings to treat as low importance messages.
+        /// </summary>
+        ISet<string> WarningsAsMessages
+        {
+            get;
+            set;
+        }
         #endregion
 
         /// <summary>
@@ -467,6 +476,15 @@ namespace Microsoft.Build.BackEnd.Logging
         /// A list of warnings to treat as errors.  If null, nothing is treated as an error.  If an empty set, all warnings are treated as errors.
         /// </summary>
         ISet<string> WarningsAsErrors
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// A list of warnings to treat as low importance messages.
+        /// </summary>
+        ISet<string> WarningsAsMessages
         {
             get;
             set;

--- a/src/XMakeBuildEngine/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Logging/LoggingService.cs
@@ -224,6 +224,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         private ISet<string> _warningsAsErrors = null;
 
+        /// <summary>
+        /// A list of warnings to treat as low importance messages.
+        /// </summary>
+        private ISet<string> _warningsAsMessages = null;
+
         #endregion
 
         #endregion
@@ -457,6 +462,15 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             get { return _warningsAsErrors; }
             set { _warningsAsErrors = value; }
+        }
+
+        /// <summary>
+        /// A list of warnings to treat as low importance messages.
+        /// </summary>
+        public ISet<string> WarningsAsMessages
+        {
+            get { return _warningsAsMessages; }
+            set { _warningsAsMessages = value; }
         }
 
         /// <summary>
@@ -819,7 +833,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 // create an eventSourceSink which the central logger will register with to receive the events from the forwarding logger
                 EventSourceSink eventSourceSink = new EventSourceSink
                 {
-                    WarningsAsErrors = WarningsAsErrors == null ? null : new HashSet<string>(WarningsAsErrors, StringComparer.OrdinalIgnoreCase)
+                    WarningsAsErrors = WarningsAsErrors == null ? null : new HashSet<string>(WarningsAsErrors, StringComparer.OrdinalIgnoreCase),
+                    WarningsAsMessages = WarningsAsMessages == null ? null : new HashSet<string>(WarningsAsMessages, StringComparer.OrdinalIgnoreCase),
                 };
 
                 // If the logger is already in the list it should not be registered again.
@@ -1135,7 +1150,8 @@ namespace Microsoft.Build.BackEnd.Logging
                 _filterEventSource = new EventSourceSink
                 {
                     Name = "Sink for Distributed/Filter loggers",
-                    WarningsAsErrors = WarningsAsErrors == null ? null : new HashSet<string>(WarningsAsErrors, StringComparer.OrdinalIgnoreCase)
+                    WarningsAsErrors = WarningsAsErrors == null ? null : new HashSet<string>(WarningsAsErrors, StringComparer.OrdinalIgnoreCase),
+                    WarningsAsMessages = WarningsAsMessages == null ? null : new HashSet<string>(WarningsAsMessages, StringComparer.OrdinalIgnoreCase),
                 };
             }
         }

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/EventSourceSink_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/EventSourceSink_Tests.cs
@@ -170,6 +170,75 @@ namespace Microsoft.Build.UnitTests.Logging
             Assert.IsType<BuildErrorEventArgs>(eventHandlerHelper.RaisedEvent);
         }
 
+        /// <summary>
+        /// Verifies that a warning is logged as a low importance message when it's warning code is specified.
+        /// </summary>
+        [Fact]
+        public void TreatWarningsAsMessagesWhenSpecified()
+        {
+            BuildWarningEventArgs expectedBuildEvent = RaiseEventHelper.Warning;
+
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsMessages = new HashSet<string>
+                {
+                    "FOO",
+                    expectedBuildEvent.Code,
+                    "BAR",
+                },
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.IsType<BuildMessageEventArgs>(eventHandlerHelper.RaisedEvent);
+
+            BuildMessageEventArgs actualBuildEvent = (BuildMessageEventArgs)eventHandlerHelper.RaisedEvent;
+
+            Assert.Equal(expectedBuildEvent.BuildEventContext, actualBuildEvent.BuildEventContext);
+            Assert.Equal(expectedBuildEvent.Code, actualBuildEvent.Code);
+            Assert.Equal(expectedBuildEvent.ColumnNumber, actualBuildEvent.ColumnNumber);
+            Assert.Equal(expectedBuildEvent.EndColumnNumber, actualBuildEvent.EndColumnNumber);
+            Assert.Equal(expectedBuildEvent.EndLineNumber, actualBuildEvent.EndLineNumber);
+            Assert.Equal(expectedBuildEvent.File, actualBuildEvent.File);
+            Assert.Equal(expectedBuildEvent.HelpKeyword, actualBuildEvent.HelpKeyword);
+            Assert.Equal(MessageImportance.Low, actualBuildEvent.Importance);
+            Assert.Equal(expectedBuildEvent.LineNumber, actualBuildEvent.LineNumber);
+            Assert.Equal(expectedBuildEvent.Message, actualBuildEvent.Message);
+            Assert.Equal(expectedBuildEvent.ProjectFile, actualBuildEvent.ProjectFile);
+            Assert.Equal(expectedBuildEvent.SenderName, actualBuildEvent.SenderName);
+            Assert.Equal(expectedBuildEvent.Subcategory, actualBuildEvent.Subcategory);
+            Assert.Equal(expectedBuildEvent.ThreadId, actualBuildEvent.ThreadId);
+            Assert.Equal(expectedBuildEvent.Timestamp, actualBuildEvent.Timestamp);
+        }
+
+        /// <summary>
+        /// Verifies that a warning is not treated as a low importance message when other warning codes are specified.
+        /// </summary>
+        [Fact]
+        public void NotTreatWarningsAsMessagesWhenNotSpecified()
+        {
+            BuildWarningEventArgs expectedBuildEvent = RaiseEventHelper.Warning;
+
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsMessages = new HashSet<string>
+                {
+                    "123",
+                    "ABC",
+                },
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.Equal(expectedBuildEvent, eventHandlerHelper.RaisedEvent);
+        }
+
         #region TestsThrowingLoggingExceptions
 
         /// <summary>

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/MockLoggingService.cs
@@ -156,6 +156,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set;
         }
 
+        /// <summary>
+        /// List of warnings to treat as low importance messages.
+        /// </summary>
+        public ISet<string> WarningsAsMessages
+        {
+            get;
+            set;
+        }
 
         /// <summary>
         /// Is the logging service on a remote node, this is used to determine if properties need to be serialized

--- a/src/XMakeCommandLine/CommandLineSwitches.cs
+++ b/src/XMakeCommandLine/CommandLineSwitches.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Build.CommandLine
             ServerToClientPipeHandle,
 #endif
             WarningsAsErrors,
+            WarningsAsMessages,
             NumberOfParameterizedSwitches
         }
 
@@ -281,6 +282,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "serverToClientPipeHandle", "s2c" },   ParameterizedSwitch.ServerToClientPipeHandle,   null,                           false,          null,                                  true,   false  ),
 #endif
             new ParameterizedSwitchInfo(  new string[] { "warnaserror", "err" },                ParameterizedSwitch.WarningsAsErrors,           null,                           true,           null,                                  true,   true  ),
+            new ParameterizedSwitchInfo(  new string[] { "warnasmessage", "nowarn" },           ParameterizedSwitch.WarningsAsMessages,         null,                           true,           "MissingWarnAsMessageParameterError",  true,   false ),
         };
 
         /// <summary>

--- a/src/XMakeCommandLine/Resources/Strings.resx
+++ b/src/XMakeCommandLine/Resources/Strings.resx
@@ -601,7 +601,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      build will fail.
     </value>
     <comment>
-      LOCALIZATION: "warnaserror" should not be localized.
+      LOCALIZATION: "/warnaserror" and "/err" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </comment>
+  </data>
+  <data name="HelpMessage_29_WarnAsMessageSwitch" UESanitized="false" Visibility="Public">
+    <value>  /warnasmessage[:code[;code2]]
+                     List of warning codes to treats as low importance
+                     messages.  Use a semicolon or a comma to separate
+                     multiple warning codes.
+                     (Short form: /nowarn[:c;[c2]])
+
+                     Example:
+                       /warnasmessage:MSB3026
+    </value>
+    <comment>
+      LOCALIZATION: "/warnasmessage" and "/nowarn" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </comment>
   </data>
@@ -974,6 +989,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <data name="FileLocation" UESanitized="false" Visibility="Public">
     <value>{0} ({1},{2})</value>
     <comment>A file location to be embedded in a string.</comment>
+  </data>
+  <data name="MissingWarnAsMessageParameterError" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : error MSB1050: Specify one or more warning codes to treat as low importance messages when using the /warnasmessage switch.</value>
+    <comment>
+      {StrBegin="MSBUILD : error MSB1050: "}
+      UE: This happens if the user does something like "msbuild.exe /warnasmessage:" without any codes.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
   </data>
 
     <!--


### PR DESCRIPTION
You cannot suppress all warnings, if you specify empty `/warnasmessage` or `/nowarn`, you get an error message.
Warnings are mutated into just a message.
Ignore the first commit which is the implementation of /WarnAsError

Closes #68
Closes #47
Closes #910 

So this:
```
MyProject.proj(3,18): warning MSB4130: The condition "true or true and true" may have been evaluated incorrectly 
in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To 
avoid this warning, add parentheses to make the evaluation order explicit.
```
Becomes this in with Verbosity=Detailed 
```
MyProject.proj(3,18): message MSB4130: The condition "true or true and true" may have been evaluated incorrectly
in an earlier version of MSBuild. Please verify that the order of the AND and OR clauses is written as intended. To
avoid this warning, add parentheses to make the evaluation order explicit.
```

Here is the help message for review:
```
  /warnasmessage[:code[;code2]]
                     List of warning codes to treats as low importance
                     messages.  Use a semicolon or a comma to separate
                     multiple warning codes.
                     (Short form: /nowarn[:c;[c2]])

                     Example:
                       /warnasmessage:MSB3026
```