### PR TITLE
Remove escape-hatch for NoReferenceAssemblyDirectoryFound

### DIFF
--- a/src/XMakeTasks/GetReferenceAssemblyPaths.cs
+++ b/src/XMakeTasks/GetReferenceAssemblyPaths.cs
@@ -22,10 +22,6 @@ namespace Microsoft.Build.Tasks
     {
         #region Data
         /// <summary>
-        /// Environment variable name for the override error on missing reference assembly directory.
-        /// </summary>
-        private const string WARNONNOREFERENCEASSEMBLYDIRECTORY = "MSBUILDWARNONNOREFERENCEASSEMBLYDIRECTORY";
-
 #if FEATURE_GAC
         /// <summary>
         /// This is the sentinel assembly for .NET FX 3.5 SP1

--- a/src/XMakeTasks/GetReferenceAssemblyPaths.cs
+++ b/src/XMakeTasks/GetReferenceAssemblyPaths.cs
@@ -291,21 +291,10 @@ namespace Microsoft.Build.Tasks
             }
 
             // No reference assembly paths could be found, log an error so an invalid build will not be produced.
-            // 1/26/16: Note this was changed from a warning to an error (see GitHub #173). Also added the escape hatch 
-            // (set MSBUILDWARNONNOREFERENCEASSEMBLYDIRECTORY = 1) in case this causes issues.
-            // TODO: This should be removed for Dev15
+            // 1/26/16: Note this was changed from a warning to an error (see GitHub #173).
             if (pathsToReturn.Count == 0)
             {
-                var warn = Environment.GetEnvironmentVariable(WARNONNOREFERENCEASSEMBLYDIRECTORY);
-
-                if (string.Equals(warn, "1", StringComparison.Ordinal))
-                {
-                    Log.LogWarningWithCodeFromResources("GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound", frameworkmoniker.ToString());
-                }
-                else
-                {
-                    Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound", frameworkmoniker.ToString());
-                }
+                Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound", frameworkmoniker.ToString());
             }
 
             return pathsToReturn;

--- a/src/XMakeTasks/UnitTests/GetReferencePaths_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GetReferencePaths_Tests.cs
@@ -172,40 +172,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Test the case where the target framework moniker is empty when using MSBUILDWARNONNOREFERENCEASSEMBLYDIRECTORY
-        /// override. Expect there to be a warning logged.
-        /// TODO: This should be removed for Dev15 (override feature removed)
-        /// </summary>
-        [Fact]
-        public void TestGeneralFrameworkMonikerNonExistentOverrideError()
-        {
-            MockEngine engine = new MockEngine();
-            GetReferenceAssemblyPaths getReferencePaths = new GetReferenceAssemblyPaths();
-            getReferencePaths.BuildEngine = engine;
-            // Make a framework which does not exist, intentional misspelling of framework
-            getReferencePaths.TargetFrameworkMoniker = ".NetFramewok, Version=v99.0";
-            
-            try
-            {
-                Environment.SetEnvironmentVariable("MSBUILDWARNONNOREFERENCEASSEMBLYDIRECTORY", "1");
-                bool success = getReferencePaths.Execute();
-                Assert.True(success);
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("MSBUILDWARNONNOREFERENCEASSEMBLYDIRECTORY", null);
-            }
-            
-            string[] returnedPaths = getReferencePaths.ReferenceAssemblyPaths;
-            Assert.Equal(0, returnedPaths.Length);
-            string displayName = getReferencePaths.TargetFrameworkMonikerDisplayName;
-            Assert.Null(displayName);
-            FrameworkNameVersioning frameworkMoniker = new FrameworkNameVersioning(getReferencePaths.TargetFrameworkMoniker);
-            string message = ResourceUtilities.FormatResourceString("GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound", frameworkMoniker.ToString());
-            engine.AssertLogContains("WARNING MSB3644: " + message);
-        }
-
-        /// <summary>
         /// Test the case where there is a good target framework moniker passed in.
         /// </summary>
         [Fact]


### PR DESCRIPTION
When this message was converted to a warning (for #173), we added an escape-hatch environment variable to revert to the previous warning-only behavior. A comment indicated that the escape hatch should be removed before the next major release, so I'm removing it.

@AndyGerlicher 