### PR TITLE
Print out prompt and process ID when waiting for a debugger to attach.

### DIFF
--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -491,6 +491,7 @@ namespace Microsoft.Build.CommandLine
 #endif
                 case "2":
                     // Sometimes easier to attach rather than deal with JIT prompt
+                    Console.WriteLine($"Waiting for debugger to attach (PID {Process.GetCurrentProcess().Id}).  Press enter to continue...");
                     Console.ReadLine();
                     break;
             }


### PR DESCRIPTION
If MSBUILDDEBUGONSTART=2 you will now see:

```
Waiting for debugger to attach (PID 21552).  Press enter to continue...
```

Closes #1118