### PR TITLE
Add fallback search path inside $(VsInstallRoot) for Target Frameworks

### DIFF
--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -67,6 +67,7 @@
         <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath" value="$(VsInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath32" value="$(VsInstallRoot)\MSBuild" />
+        <property name="TargetFrameworkRootPathSearchPathsWindows" value="$(VsInstallRoot)\Common7\IDE\ReferenceAssemblies\Microsoft\Framework" />
 
         <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
 


### PR DESCRIPTION
dev15 added support for VSIXes to install custom target frameworks in an app-local
way, allowing for much better SxS support for tools like Xamarin.