### PR TITLE
Signing specific loc targets use DependsOnTargets

### DIFF
--- a/src/UpdateLocalizedResources.targets
+++ b/src/UpdateLocalizedResources.targets
@@ -111,7 +111,7 @@
   -->
   <Target Name="OpenSourceSignSatelliteAssemblies"
           Condition="'$(DelaySign)' == 'true' and '@(IntermediateSatelliteAssembliesWithTargetPath)' != '' and '$(SkipSigning)' != 'true' and '$(SignType)' == 'oss'"
-          AfterTargets="CreateSatelliteAssemblies"
+          DependsOnTargets="ComputeIntermediateSatelliteAssemblies"
           BeforeTargets="CopyFilesToOutputDirectory"
           Inputs="@(IntermediateSatelliteAssembliesWithTargetPath)"
           Outputs="%(IntermediateSatelliteAssembliesWithTargetPath.Identity).oss_signed"
@@ -126,8 +126,8 @@
   <!-- Target SignFiles from MicroBuild.Plugins.Signing.targets signs @(FilesToSign) -->
   <Target Name="AddSatelliteAssembliesToFilesToSignItem"
           Condition="('$(SignType)' == 'real' OR '$(SignType)' == 'test')"
-          BeforeTargets="@(SignFilesDependsOn);SignFiles"
-          AfterTargets="CreateSatelliteAssemblies"
+          DependsOnTargets="ComputeIntermediateSatelliteAssemblies"
+          BeforeTargets="SignFiles"
           >
 
     <ItemGroup>


### PR DESCRIPTION
Because AfterTargets does not guarantee that the target will be executed
after its AfterTargets, but DependsOnTargets does.

This lead to the `AddSatelliteAssembliesToFilesToSignItem` target being executed before the item it read got computed.