### PR TITLE
Support Directory project path argument

### DIFF
--- a/src/XMakeCommandLine/InitializationException.cs
+++ b/src/XMakeCommandLine/InitializationException.cs
@@ -174,6 +174,23 @@ namespace Microsoft.Build.CommandLine
         }
 
         /// <summary>
+        /// Throws the exception if the specified condition is not met.
+        /// </summary>
+        internal static void VerifyThrow(bool condition, string messageResourceName, string invalidSwitch, params object[] args)
+        {
+            if (!condition)
+            {
+                string errorMessage = AssemblyResources.GetString(messageResourceName);
+
+                ErrorUtilities.VerifyThrow(errorMessage != null, "The resource string must exist.");
+
+                errorMessage = ResourceUtilities.FormatString(errorMessage, args);
+
+                InitializationException.Throw(errorMessage, invalidSwitch);
+            }
+        }
+
+        /// <summary>
         /// Throws the exception using the given exception context.
         /// </summary>
         /// <param name="messageResourceName"></param>

--- a/src/XMakeCommandLine/Resources/Strings.resx
+++ b/src/XMakeCommandLine/Resources/Strings.resx
@@ -65,6 +65,16 @@
       fire this error.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</comment>
   </data>
+  <data name="AmbiguousProjectDirectoryError" UESanitized="false" Visibility="Public">
+    <value>MSBUILD : error MSB1050: Specify which project or solution file to use because the folder "{0}" contains more than one project or solution file.</value>
+    <comment>
+      {StrBegin="MSBUILD : error MSB1050: "}UE: If no project or solution file is explicitly specified on the MSBuild.exe command-line, then the engine searches for a
+      project or solution file in the current directory by looking for *.*PROJ and *.SLN. If more than one file is found that matches this wildcard, we
+      fire this error.
+      LOCALIZATION: The prefix "MSB1050 : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
+  
   <data name="ConfigurationFailurePrefixNoErrorCode" UESanitized="false" Visibility="Public">
     <value>MSBUILD : Configuration error {0}: {1}</value>
     <comment>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
@@ -96,7 +106,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" and "MSBuild" should not be localized.</comment>
   </data>
   <data name="HelpMessage_1_Syntax" UESanitized="true" Visibility="Public">
-    <value>Syntax:              MSBuild.exe [options] [project file]
+    <value>Syntax:              MSBuild.exe [options] [project file | directory]
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:
@@ -111,7 +121,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <value>Description:         Builds the specified targets in the project file. If
                      a project file is not specified, MSBuild searches the
                      current working directory for a file that has a file
-                     extension that ends in "proj" and uses that file.
+                     extension that ends in "proj" and uses that file.  If
+                     a directory is specified, MSBuild searches that
+                     directory for a project file.
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:
@@ -948,7 +960,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!--
         The command line message bucket is: MSB1001 - MSB1999
 
-        Next error code should be MSB1050.
+        Next error code should be MSB1051.
 
         Don't forget to update this comment after using the new code.
   -->

--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -1560,6 +1560,54 @@ namespace Microsoft.Build.UnitTests
                 return fileNamesToReturn.ToArray();
             }
         }
+
+        /// <summary>
+        /// Verifies that when a directory is specified that a project can be found.
+        /// </summary>
+        [Fact]
+        public void TestProcessProjectSwitchDirectory()
+        {
+            string projectDirectory = Directory.CreateDirectory(Path.Combine(ObjectModelHelpers.TempProjectDir, Guid.NewGuid().ToString("N"))).FullName;
+
+            try
+            {
+                string expectedProject = "project1.proj";
+                string[] extensionsToIgnore = null;
+                IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(new[] { expectedProject });
+                string actualProject = MSBuildApp.ProcessProjectSwitch(new[] { projectDirectory }, extensionsToIgnore, projectHelper.GetFiles);
+
+                Assert.Equal(expectedProject, actualProject);
+            }
+            finally
+            {
+                RobustDelete(projectDirectory);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when a directory is specified and there are multiple projects that the correct error is thrown.
+        /// </summary>
+        [Fact]
+        public void TestProcessProjectSwitchDirectoryMultipleProjects()
+        {
+            string projectDirectory = Directory.CreateDirectory(Path.Combine(ObjectModelHelpers.TempProjectDir, Guid.NewGuid().ToString("N"))).FullName;
+
+            try
+            {
+                InitializationException exception = Assert.Throws<InitializationException>(() =>
+                {
+                    string[] extensionsToIgnore = null;
+                    IgnoreProjectExtensionsHelper projectHelper = new IgnoreProjectExtensionsHelper(new[] { "project1.proj", "project2.proj" });
+                    MSBuildApp.ProcessProjectSwitch(new[] { projectDirectory }, extensionsToIgnore, projectHelper.GetFiles);
+                });
+
+                Assert.Equal(ResourceUtilities.FormatResourceString("AmbiguousProjectDirectoryError", projectDirectory), exception.Message);
+            }
+            finally
+            {
+                RobustDelete(projectDirectory);
+            }
+        }
 #endregion
 
 #region ProcessFileLoggerSwitches


### PR DESCRIPTION
If Directory.Exists then the current code just uses that as the base directory to search.

Needed to add a new error so that the directory path of what was searched is shown instead of it just saying "this directory".  I also updated the help text.

```
Syntax:              MSBuild.exe [options] [project file | directory]

Description:         Builds the specified targets in the project file. If
                     a project file is not specified, MSBuild searches the
                     current working directory for a file that has a file
                     extension that ends in "proj" and uses that file.  If
                     a directory is specified, MSBuild searches that
                     directory for a project file.
```

Closes #1225