### PR TITLE
Add preserveFormatting overloads. Expose PreserveFormatting as read-only property

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -246,6 +246,7 @@ namespace Microsoft.Build.Construction
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemGroupElement> ItemGroupsReversed { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemElement> Items { get { throw null; } }
         public System.DateTime LastWriteTimeWhenRead { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public bool PreserveFormatting { get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyElement> Properties { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyGroupElement> PropertyGroups { get { throw null; } }
@@ -317,6 +318,7 @@ namespace Microsoft.Build.Construction
         public void Save(System.Text.Encoding saveEncoding) { }
         public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Name={Name} #Children={Count} Condition={Condition}")]
     public partial class ProjectTargetElement : Microsoft.Build.Construction.ProjectElementContainer

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -246,6 +246,7 @@ namespace Microsoft.Build.Construction
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemGroupElement> ItemGroupsReversed { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectItemElement> Items { get { throw null; } }
         public System.DateTime LastWriteTimeWhenRead { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public bool PreserveFormatting { get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyElement> Properties { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectPropertyGroupElement> PropertyGroups { get { throw null; } }
@@ -317,6 +318,7 @@ namespace Microsoft.Build.Construction
         public void Save(System.Text.Encoding saveEncoding) { }
         public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Name={Name} #Children={Count} Condition={Condition}")]
     public partial class ProjectTargetElement : Microsoft.Build.Construction.ProjectElementContainer

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1125,7 +1125,7 @@ namespace Microsoft.Build.Construction
         /// Uses the specified project collection.
         /// </summary>
         /// <param name="path">The path of the ProjectRootElement, cannot be null.</param>
-        // <param name="projectCollection">The <see cref="ProjectCollection"/> to load the project into.</param>
+        /// <param name="projectCollection">The <see cref="ProjectCollection"/> to load the project into.</param>
         /// <param name="preserveFormatting">
         /// The formatting to open with. Must match the formatting in the collection to succeed.
         /// </param>

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -730,6 +730,17 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
+        /// Whether the XML is preserving formatting or not.
+        /// </summary>
+        public bool PreserveFormatting
+        {
+            get
+            {
+                return XmlDocument?.PreserveWhitespace ?? false;
+            }
+        }
+
+        /// <summary>
         /// Version number of this object.
         /// A host can compare this to a stored version number to determine whether
         /// a project's XML has changed, even if it has also been saved since.
@@ -1105,6 +1116,25 @@ namespace Microsoft.Build.Construction
         /// this method returning false does not indicate that it has never been loaded, only that it is not currently in memory.
         /// </remarks>
         public static ProjectRootElement TryOpen(string path, ProjectCollection projectCollection)
+        {
+            return TryOpen(path, projectCollection, preserveFormatting: false);
+        }
+
+        /// <summary>
+        /// Returns the ProjectRootElement for the given path if it has been loaded, or null if it is not currently in memory.
+        /// Uses the specified project collection.
+        /// </summary>
+        /// <param name="path">The path of the ProjectRootElement, cannot be null.</param>
+        // <param name="projectCollection">The <see cref="ProjectCollection"/> to load the project into.</param>
+        /// <param name="preserveFormatting">
+        /// The formatting to open with. Must match the formatting in the collection to succeed.
+        /// </param>
+        /// <returns>The loaded ProjectRootElement, or null if it is not currently in memory.</returns>
+        /// <remarks>
+        /// It is possible for ProjectRootElements to be brought into memory and discarded due to memory pressure. Therefore
+        /// this method returning false does not indicate that it has never been loaded, only that it is not currently in memory.
+        /// </remarks>
+        public static ProjectRootElement TryOpen(string path, ProjectCollection projectCollection, bool preserveFormatting)
         {
             ErrorUtilities.VerifyThrowArgumentLength(path, "path");
             ErrorUtilities.VerifyThrowArgumentNull(projectCollection, "projectCollection");

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1141,7 +1141,7 @@ namespace Microsoft.Build.Construction
 
             path = FileUtilities.NormalizePath(path);
 
-            ProjectRootElement projectRootElement = projectCollection.ProjectRootElementCache.TryGet(path);
+            ProjectRootElement projectRootElement = projectCollection.ProjectRootElementCache.TryGet(path, preserveFormatting);
 
             return projectRootElement;
         }

--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -350,8 +350,20 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal ProjectRootElement TryGet(string projectFile)
         {
-            ProjectRootElement result = Get(projectFile, null /* no delegate to load it */, false, /*Since we are not creating a PRE this can be true or false*/
-                preserveFormatting: false);
+            return TryGet(projectFile, preserveFormatting: false);
+        }
+
+        /// <summary>
+        /// Returns any a ProjectRootElement in the cache with the provided full path,
+        /// otherwise null.
+        /// </summary>
+        internal ProjectRootElement TryGet(string projectFile, bool preserveFormatting)
+        {
+            ProjectRootElement result = Get(
+                projectFile,
+                openProjectRootElement: null, // no delegate to load it
+                isExplicitlyLoaded: false, // Since we are not creating a PRE this can be true or false
+                preserveFormatting: preserveFormatting);
 
             return result;
         }

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
@@ -1241,6 +1241,29 @@ Project(""{";
         }
 
         /// <summary>
+        /// Tests TryOpen when preserveFormatting is the same and different than the cached project.
+        /// </summary>
+        [Fact]
+        public void TryOpenWithPreserveFormatting()
+        {
+            string project =
+@"<?xml version=`1.0` encoding=`utf-8`?>
+<Project xmlns = 'msbuildnamespace'>
+</Project>";
+
+            var collection = new ProjectCollection();
+            var projectXml = ProjectRootElement.Create(
+                XmlReader.Create(new StringReader(ObjectModelHelpers.CleanupFileContents(project))),
+                collection,
+                preserveFormatting: true);
+
+            projectXml.Save(FileUtilities.GetTemporaryFile());
+
+            Assert.NotNull(ProjectRootElement.TryOpen(projectXml.FullPath, collection, preserveFormatting: true));
+            Assert.Null(ProjectRootElement.TryOpen(projectXml.FullPath, collection, preserveFormatting: false));
+        }
+
+        /// <summary>
         /// Test helper for validating that DeepClone and CopyFrom work as advertised.
         /// </summary>
         private static void ValidateDeepCloneAndCopyFrom(ProjectRootElement pre)


### PR DESCRIPTION
1. Add extra overloads for `ProjectRootElement.TryOpen` with `preserveFormatting` options.
2. Expose `PreserveFormatting` as a read-only property on `ProjectRootElement`. CPS needs this for the live-reload scenario.
