### PR TITLE
Add support for fallback search paths for Target frameworks

### DIFF
--- a/src/XMakeTasks/GetReferenceAssemblyPaths.cs
+++ b/src/XMakeTasks/GetReferenceAssemblyPaths.cs
@@ -144,6 +144,18 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
+        /// Target frameworks are looked up in @RootPath. If it cannot be found
+        /// there, then paths in @TargetFrameworkFallbackSearchPaths
+        /// are used for the lookup, in order. This can have multiple paths, separated
+        /// by ';'
+        /// </summary>
+        public string TargetFrameworkFallbackSearchPaths
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// By default GetReferenceAssemblyPaths performs simple checks
         /// to ensure that certain runtime frameworks are installed depending on the
         /// target framework.
@@ -232,7 +244,7 @@ namespace Microsoft.Build.Tasks
 
             try
             {
-                _tfmPaths = GetPaths(_rootPath, moniker);
+                _tfmPaths = GetPaths(_rootPath, TargetFrameworkFallbackSearchPaths, moniker);
 
                 if (_tfmPaths != null && _tfmPaths.Count > 0)
                 {
@@ -243,7 +255,7 @@ namespace Microsoft.Build.Tasks
                 // There is no point in generating the full framework paths if profile path could not be found.
                 if (targetingProfile && _tfmPaths != null)
                 {
-                    _tfmPathsNoProfile = GetPaths(_rootPath, monikerWithNoProfile);
+                    _tfmPathsNoProfile = GetPaths(_rootPath, TargetFrameworkFallbackSearchPaths, monikerWithNoProfile);
                 }
 
                 // The path with out the profile is just the reference assembly paths.
@@ -273,18 +285,16 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Generate the set of chained reference assembly paths
         /// </summary>
-        private IList<String> GetPaths(string rootPath, FrameworkNameVersioning frameworkmoniker)
+        private IList<String> GetPaths(string rootPath, string targetFrameworkFallbackSearchPaths, FrameworkNameVersioning frameworkmoniker)
         {
             IList<String> pathsToReturn = null;
 
-            if (String.IsNullOrEmpty(rootPath))
-            {
-                pathsToReturn = ToolLocationHelper.GetPathToReferenceAssemblies(frameworkmoniker);
-            }
-            else
-            {
-                pathsToReturn = ToolLocationHelper.GetPathToReferenceAssemblies(rootPath, frameworkmoniker);
-            }
+            pathsToReturn = ToolLocationHelper.GetPathToReferenceAssemblies(
+                                                    frameworkmoniker.Identifier,
+                                                    frameworkmoniker.Version.ToString(),
+                                                    frameworkmoniker.Profile,
+                                                    rootPath,
+                                                    targetFrameworkFallbackSearchPaths);
 
             // No reference assembly paths could be found, log an error so an invalid build will not be produced.
             // 1/26/16: Note this was changed from a warning to an error (see GitHub #173).

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -768,6 +768,9 @@
     <Content Include="Microsoft.Common.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Microsoft.Common.Before.Mono.props" Condition="'$(MonoBuild)' == 'true'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Microsoft.Common.tasks">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/XMakeTasks/Microsoft.Common.Before.Mono.props
+++ b/src/XMakeTasks/Microsoft.Common.Before.Mono.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Mono'">
+    <IsOSX Condition="Exists('/usr/lib/libc.dylib')">true</IsOSX>
+    <TargetFrameworkFallbackSearchPaths Condition="$(IsOSX) == 'true' and '$(TargetFrameworkFallbackSearchPaths)' == ''">/Library/Frameworks/Mono.framework/External/xbuild-frameworks</TargetFrameworkFallbackSearchPaths>
+  </PropertyGroup>
+</Project>

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -78,7 +78,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- The FrameworkPathOverride is required for the inproc visual basic compiler to initialize when targeting target frameworks less than 4.0. If .net 2.0 is not installed then the property value above will not provide the location
              of mscorlib. This is also true if the build author overrides this property to some other directory which does not contain mscorlib.dll. In the case we cannot find mscorlib.dll at the correct location
              we need to find a directory which does contain mscorlib to allow the inproc compiler to initialize and give us the chance to show certain dialogs in the IDE (which only happen after initialization).-->
-    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget), $(TargetFrameworkRootPath)))</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget), $(TargetFrameworkRootPath), ''))</FrameworkPathOverride>
     <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>
   </PropertyGroup>
 

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -78,7 +78,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- The FrameworkPathOverride is required for the inproc visual basic compiler to initialize when targeting target frameworks less than 4.0. If .net 2.0 is not installed then the property value above will not provide the location
              of mscorlib. This is also true if the build author overrides this property to some other directory which does not contain mscorlib.dll. In the case we cannot find mscorlib.dll at the correct location
              we need to find a directory which does contain mscorlib to allow the inproc compiler to initialize and give us the chance to show certain dialogs in the IDE (which only happen after initialization).-->
-    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget), $(TargetFrameworkRootPath), ''))</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget), $(TargetFrameworkRootPath), $(TargetFrameworkFallbackSearchPaths)))</FrameworkPathOverride>
     <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>
   </PropertyGroup>
 
@@ -1110,6 +1110,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Condition="'$(TargetFrameworkMoniker)' != '' and ('$(_TargetFrameworkDirectories)' == '' or '$(_FullFrameworkReferenceAssemblyPaths)' == '')"
         TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
         RootPath="$(TargetFrameworkRootPath)"
+        TargetFrameworkFallbackSearchPaths="$(TargetFrameworkFallbackSearchPaths)"
         BypassFrameworkInstallChecks="$(BypassFrameworkInstallChecks)"
         >
       <Output TaskParameter="ReferenceAssemblyPaths" PropertyName="_TargetFrameworkDirectories"/>


### PR DESCRIPTION
When running on Mono, target frameworks are searched for in
`$mono_prefix/lib/mono/xbuild-frameworks`, which becomes
`/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks`.

This works, but has a problem when upgrading the Mono.framework package:
a *new* `/Library/Frameworks/Mono.framework/Versions/@VERSION@` directory
is created, so anything installed into the previous directory will be
"lost" (For example, installed by Xamarin.Android). The file is still there, but xbuild
will no longer find it.

To address this upgrade scenario, Mono's xbuild also checks a fallback path:

    `/Library/Frameworks/Mono.framework/External/xbuild-frameworks`

This location is not within a versioned framework directory, and thus files
installed into it will survive Mono.framework package upgrades.

Mono would like to eventually migrate to MSBuild instead of xbuild, which
requires bringing xbuild's fallback support to MSBuild.

Implementation:

- We add a new `$(TargetFrameworkFallbackSearchPaths)` property which
can have the list of fallback search paths and gets used by the `GetReferenceAssemblyPaths`.

- For Mono/OSX case, we point that to `/Library/Frameworks/Mono.framework/External/xbuild-frameworks`

  So, effectively, target frameworks are looked up, in order:

  1. `$(TargetFrameworkRootPath)` or the default location, if
     `$(TargetFrameworkRootPath)` is ''

  2. If not found in (1), then try to find it in the fallback search
     paths specified in `$(TargetFrameworkFallbackSearchPaths)`