### PR TITLE
Undo consume Roslyn from new location.

### DIFF
--- a/src/Shared/UnitTests/App.config
+++ b/src/Shared/UnitTests/App.config
@@ -46,7 +46,7 @@
       <property name="SDK35ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86@InstallationFolder))" />
       <property name="SDK40ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools-x86@InstallationFolder)" />
       <property name="WindowsSDK80Path" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
-      <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
+      <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())" />
     </toolset>
   </msbuildToolsets>
 </configuration>

--- a/src/XMakeBuildEngine/Definition/ToolsetLocalReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetLocalReader.cs
@@ -57,9 +57,7 @@ namespace Microsoft.Build.Evaluation
         protected override IEnumerable<ToolsetPropertyDefinition> GetPropertyDefinitions(string toolsVersion)
         {
             yield return new ToolsetPropertyDefinition(MSBuildConstants.ToolsPath, BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, _sourceLocation);
-            yield return new ToolsetPropertyDefinition("RoslynTargetsPath",
-                System.IO.Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, "Roslyn"),
-                _sourceLocation);
+            yield return new ToolsetPropertyDefinition("RoslynTargetsPath", BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, _sourceLocation);
         }
 
         protected override IEnumerable<ToolsetPropertyDefinition> GetSubToolsetPropertyDefinitions(string toolsVersion, string subToolsetVersion)

--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -74,7 +74,7 @@
         <property name="MSBuildExtensionsPath" value="$(VsInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath32" value="$(VsInstallRoot)\MSBuild" />
 
-        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
+        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())" />
 
         <!-- VC Specific Paths -->
         <property name="VCTargetsPath" value="$(VsInstallRoot)\Common7\IDE\VC\VCTargets\" />

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -68,7 +68,7 @@
         <property name="MSBuildExtensionsPath" value="$(VsInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath32" value="$(VsInstallRoot)\MSBuild" />
 
-        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
+        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())" />
 
         <!-- VC Specific Paths -->
         <property name="VCTargetsPath" value="$(VsInstallRoot)\Common7\IDE\VC\VCTargets\" />

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -13,11 +13,11 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(CompilerToolsFiles)"
-          DestinationFolder="$(DeploymentDir)\Roslyn"
+          DestinationFolder="$(DeploymentDir)\"
           SkipUnchangedFiles="true" />
 
     <Copy SourceFiles="@(CompilerToolsFiles)"
-          DestinationFolder="$(TestDeploymentDir)\Roslyn"
+          DestinationFolder="$(TestDeploymentDir)\"
           SkipUnchangedFiles="true" />
   </Target>
 
@@ -81,10 +81,6 @@
     <!--At build time, we target netstandard to be runnable on many runtimes.
         To get a set of runnable bits, we need to deploy a specific one. On the xplat branch we are testing the .net core runtime platform, so we target netcoreapp -->
     <NuGetTargetMoniker Condition="'$(NetCoreBuild)' == 'true'">.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
-
-    <RuntimeProjectJson>$(MSBuildThisFileDirectory)runtimeDependencies\project.json</RuntimeProjectJson>
-    <RuntimeProjectLockJson>$(MSBuildThisFileDirectory)runtimeDependencies\project.lock.json</RuntimeProjectLockJson>
-
     <NuGetRuntimeIdentifier>$(RuntimeSystem)-$(RuntimeArchitecture)</NuGetRuntimeIdentifier>
   </PropertyGroup>
 
@@ -96,13 +92,13 @@
     </RuntimeProjectJson>
     <RuntimeProjectJson Include="$(MSBuildThisFileDirectory)roslyn\project.json">
       <LockFile>$(MSBuildThisFileDirectory)roslyn\project.lock.json</LockFile>
-      <DestinationFolder>$(DeploymentDir)\Roslyn</DestinationFolder>
-      <TestDeploymentDir>$(TestDeploymentDir)\Roslyn</TestDeploymentDir>
+      <DestinationFolder>$(DeploymentDir)</DestinationFolder>
+      <TestDeploymentDir>$(TestDeploymentDir)</TestDeploymentDir>
     </RuntimeProjectJson>
   </ItemGroup>
 
   <Target Name="RestoreRuntimePackages"
-          Inputs="$(DnuToolPath);$(RuntimeProjectJson)"
+          Inputs="$(DnuToolPath);@(RuntimeProjectJson)"
           Outputs="@(RuntimeProjectJson->'%(LockFile)')">
     <Exec Command="$(DnuRestoreCommand) &quot;%(RuntimeProjectJson.FullPath)&quot;" StandardOutputImportance="Low" />
 
@@ -113,7 +109,7 @@
 
   <Target Name="DeployRuntime"
           DependsOnTargets="RestoreRuntimePackages"
-          Outputs="%(RuntimeProjectJson.DestinationFolder)\dummy">
+          Outputs="%(RuntimeProjectJson.LockFile).IntentionallyDoesNotExistSoThisAlwaysRuns">
     <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="false"
                                          IncludeFrameworkReferences="false"
                                          NuGetPackagesDirectory="$(PackagesDir)"


### PR DESCRIPTION
This change was postponed to another release. Keeping the functionality of
consuming Roslyn from a single location, just adjusting the path. Compared
to previous release, we will now *always* consume Roslyn from the 32-bit
MSBuild folder. This should be fine as the bits are identical.

Related to #1339