### PR TITLE
Preserve Culture metadata on satellite assemblies

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -5323,6 +5323,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <SatelliteDllsProjectOutputGroupOutputIntermediate Include="$(IntermediateOutputPath)%(EmbeddedResource.Culture)\$(TargetName).resources.dll"
                                                          Condition="'%(WithCulture)' == 'true'">
         <TargetPath>%(EmbeddedResource.Culture)\$(TargetName).resources.dll</TargetPath>
+        <Culture>%(EmbeddedResource.Culture)</Culture>
       </SatelliteDllsProjectOutputGroupOutputIntermediate>
     </ItemGroup>
 


### PR DESCRIPTION
Satellite assemblies are produced only with TargetPath metadata, which makes rediscovering their culture later in the build very difficult. Simply preserving it as a distinct metadatum makes scenarios such as NuGet packaging of Roslyn analyzers that are localized much easier.

BTW, I'm not sure about the target branch for this. I think it should ship xplat as well as in Dev15 RC.3. Is this the right branch for that?