### PR TITLE
Add NormalizePath() to IntrinsicFunctions

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -323,7 +323,7 @@ namespace Microsoft.Build.Shared
                         // we reluctantly have to restrict things here.
                         if (length >= MaxPath)
                         {
-                            throw new PathTooLongException(path);
+                            throw new PathTooLongException();
                         }
 
                         // Avoid creating new strings unnecessarily

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -381,14 +381,9 @@ namespace Microsoft.Build.Evaluation
         /// while ensuring it has a trailing slash.
         /// </summary>
         /// <param name="path">One or more directory paths to combine and normalize.</param>
-        /// <returns>A canonicalized full directory path with the correct directory separators and a trailing slash.  If no path is specified, the return value is <see cref="String.Empty"/>.</returns>
+        /// <returns>A canonicalized full directory path with the correct directory separators and a trailing slash.</returns>
         internal static string NormalizeDirectory(params string[] path)
         {
-            if (path.Length == 0 || path.All(String.IsNullOrWhiteSpace))
-            {
-                return String.Empty;
-            }
-
             return EnsureTrailingSlash(NormalizePath(path));
         }
 

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -378,11 +378,11 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Gets the canonicalized full path of the provided path and ensures it contains the correct directory separator characters for the current operating system.
         /// </summary>
-        /// <param name="path">The path to normalize.</param>
+        /// <param name="path">One or more paths to combine and normalize.</param>
         /// <returns>A canonicalized full path with the correct directory separators.</returns>
-        internal static string NormalizePath(string path)
+        internal static string NormalizePath(params string[] path)
         {
-            return FileUtilities.NormalizePath(path);
+            return FileUtilities.NormalizePath(Path.Combine(path));
         }
 
         public static string GetCurrentToolsDirectory()

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 using Microsoft.Build.Internal;
@@ -373,6 +374,22 @@ namespace Microsoft.Build.Evaluation
         internal static string EnsureTrailingSlash(string path)
         {
             return FileUtilities.EnsureTrailingSlash(path);
+        }
+
+        /// <summary>
+        /// Gets the canonicalized full path of the provided directory and ensures it contains the correct directory separator characters for the current operating system
+        /// while ensuring it has a trailing slash.
+        /// </summary>
+        /// <param name="path">One or more directory paths to combine and normalize.</param>
+        /// <returns>A canonicalized full directory path with the correct directory separators and a trailing slash.  If no path is specified, the return value is <see cref="String.Empty"/>.</returns>
+        internal static string NormalizeDirectory(params string[] path)
+        {
+            if (path.Length == 0 || path.All(String.IsNullOrWhiteSpace))
+            {
+                return String.Empty;
+            }
+
+            return EnsureTrailingSlash(NormalizePath(path));
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -375,6 +375,16 @@ namespace Microsoft.Build.Evaluation
             return FileUtilities.EnsureTrailingSlash(path);
         }
 
+        /// <summary>
+        /// Gets the canonicalized full path of the provided path and ensures it contains the correct directory separator characters for the current operating system.
+        /// </summary>
+        /// <param name="path">The path to normalize.</param>
+        /// <returns>A canonicalized full path with the correct directory separators.</returns>
+        internal static string NormalizePath(string path)
+        {
+            return FileUtilities.NormalizePath(path);
+        }
+
         public static string GetCurrentToolsDirectory()
         {
             return BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -2777,6 +2777,28 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 #endif
 
+        [Fact]
+        public void PropertyFunctionNormalizeDirectory()
+        {
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(new[]
+            {
+                ProjectPropertyInstance.Create("EmptyPath", ""),
+                ProjectPropertyInstance.Create("MyPath", "one"),
+                ProjectPropertyInstance.Create("MySecondPath", "two"),
+            }));
+
+            Assert.Equal(String.Empty, expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::NormalizeDirectory(''))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
+            Assert.Equal(String.Empty, expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::NormalizeDirectory($(EmptyPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
+
+            Assert.Equal(
+                $"{Path.GetFullPath("one")}{Path.DirectorySeparatorChar}",
+                expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::NormalizeDirectory($(MyPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
+
+            Assert.Equal(
+                $"{Path.GetFullPath(Path.Combine("one", "two"))}{Path.DirectorySeparatorChar}",
+                expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::NormalizeDirectory($(MyPath), $(MySecondPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
+        }
+
         /// <summary>
         /// Expand property function that tests for existence of the task host
         /// </summary>

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -2782,13 +2782,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(new[]
             {
-                ProjectPropertyInstance.Create("EmptyPath", ""),
                 ProjectPropertyInstance.Create("MyPath", "one"),
                 ProjectPropertyInstance.Create("MySecondPath", "two"),
             }));
-
-            Assert.Equal(String.Empty, expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::NormalizeDirectory(''))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
-            Assert.Equal(String.Empty, expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::NormalizeDirectory($(EmptyPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
 
             Assert.Equal(
                 $"{Path.GetFullPath("one")}{Path.DirectorySeparatorChar}",


### PR DESCRIPTION
Rather than just "fix" the file path, this normalizes it and fixes the directory separators.  I did not make a unit test because `FileUtilities.NormalizePath()` is well tested.

Closes #55

