### PR TITLE
Fix more warnings, enable /warnaserror

### DIFF
--- a/Samples/Dependency/Dependency.csproj
+++ b/Samples/Dependency/Dependency.csproj
@@ -27,7 +27,7 @@
     <Compile Include="Alpha.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(NetCoreBuild)' != 'true'">
     <Reference Include="System" />
   </ItemGroup>
   <Import Project="..\dir.targets" />

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -140,10 +140,9 @@ if /i "%TARGET%"=="CoreCLR" (
 )
 
 :: The set of warnings to suppress for now
-:: warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "D:\MSBuild\bin\x86\Windows_NT\Debug\Output\MSBuild.exe", "x86".
 :: warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
 :: warning MSB3026: Could not copy "XXX" to "XXX". Beginning retry 1 in 1000ms.
-SET _NOWARN=MSB3270;MSB3277;MSB3026
+SET _NOWARN=MSB3277;MSB3026
 
 echo.
 echo ** Rebuilding MSBuild with locally built binaries

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -142,7 +142,8 @@ if /i "%TARGET%"=="CoreCLR" (
 :: The set of warnings to suppress for now
 :: warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
 :: warning MSB3026: Could not copy "XXX" to "XXX". Beginning retry 1 in 1000ms.
-SET _NOWARN=MSB3277;MSB3026
+:: warning AL1053: The version '1.2.3.4-foo' specified for the 'product version' is not in the normal 'major.minor.build.revision' format
+SET _NOWARN=MSB3277;MSB3026;AL1053
 
 echo.
 echo ** Rebuilding MSBuild with locally built binaries

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -139,10 +139,16 @@ if /i "%TARGET%"=="CoreCLR" (
     set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\15.0\Bin\MSBuild.exe"
 )
 
+:: The set of warnings to suppress for now
+:: warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "D:\MSBuild\bin\x86\Windows_NT\Debug\Output\MSBuild.exe", "x86".
+:: warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+:: warning MSB3026: Could not copy "XXX" to "XXX". Beginning retry 1 in 1000ms.
+SET _NOWARN=MSB3270;MSB3277;MSB3026
+
 echo.
 echo ** Rebuilding MSBuild with locally built binaries
 
-call "%~dp0build.cmd" /t:%TARGET_ARG% /p:Configuration=%BUILD_CONFIGURATION% %LOCALIZED_BUILD_ARGUMENT%
+call "%~dp0build.cmd" /t:%TARGET_ARG% /p:Configuration=%BUILD_CONFIGURATION% %LOCALIZED_BUILD_ARGUMENT% "/nowarn:%_NOWARN%" /warnaserror
 
 if %ERRORLEVEL% NEQ 0 (
     echo.

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -298,6 +298,12 @@ if [[ $BOOTSTRAP_ONLY = true ]]; then
     exit $?
 fi
 
+# The set of warnings to suppress for now
+# warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "D:\MSBuild\bin\x86\Windows_NT\Debug\Output\MSBuild.exe", "x86".
+# warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
+# warning MSB3026: Could not copy "XXX" to "XXX". Beginning retry 1 in 1000ms.
+_NOWARN=MSB3270;MSB3277;MSB3026
+
 echo
 echo "** Rebuilding MSBuild with locally built binaries"
-runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_BOOTSTRAPPED_EXE" "/t:$TARGET_ARG $BUILD_MSBUILD_ARGS" "$LOCAL_BUILD_LOG_PATH"
+runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_BOOTSTRAPPED_EXE" "/t:$TARGET_ARG $BUILD_MSBUILD_ARGS /warnaserror /nowarn:$_NOWARN" "$LOCAL_BUILD_LOG_PATH"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -301,7 +301,7 @@ fi
 # The set of warnings to suppress for now
 # warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
 # warning MSB3026: Could not copy "XXX" to "XXX". Beginning retry 1 in 1000ms.
-_NOWARN="MSB3270;MSB3277;MSB3026"
+_NOWARN="MSB3277;MSB3026"
 
 echo
 echo "** Rebuilding MSBuild with locally built binaries"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -301,7 +301,8 @@ fi
 # The set of warnings to suppress for now
 # warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
 # warning MSB3026: Could not copy "XXX" to "XXX". Beginning retry 1 in 1000ms.
-_NOWARN="MSB3277;MSB3026"
+# warning AL1053: The version '1.2.3.4-foo' specified for the 'product version' is not in the normal 'major.minor.build.revision' format
+_NOWARN="MSB3277;MSB3026;AL1053"
 
 echo
 echo "** Rebuilding MSBuild with locally built binaries"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -299,11 +299,10 @@ if [[ $BOOTSTRAP_ONLY = true ]]; then
 fi
 
 # The set of warnings to suppress for now
-# warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "D:\MSBuild\bin\x86\Windows_NT\Debug\Output\MSBuild.exe", "x86".
 # warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
 # warning MSB3026: Could not copy "XXX" to "XXX". Beginning retry 1 in 1000ms.
-_NOWARN=MSB3270;MSB3277;MSB3026
+_NOWARN="MSB3270;MSB3277;MSB3026"
 
 echo
 echo "** Rebuilding MSBuild with locally built binaries"
-runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_BOOTSTRAPPED_EXE" "/t:$TARGET_ARG $BUILD_MSBUILD_ARGS /warnaserror /nowarn:$_NOWARN" "$LOCAL_BUILD_LOG_PATH"
+runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_BOOTSTRAPPED_EXE" "/t:$TARGET_ARG $BUILD_MSBUILD_ARGS /warnaserror /nowarn:\"$_NOWARN\"" "$LOCAL_BUILD_LOG_PATH"

--- a/src/Shared/Compat/TypeExtensions.cs
+++ b/src/Shared/Compat/TypeExtensions.cs
@@ -577,15 +577,15 @@ namespace System.Reflection
                             {
                                 testForParamArray = true;
                             }
-                            else
-                            {
-                                // From our existing code, our policy here is that if a parameterInfo 
-                                // is optional then all subsequent parameterInfos shall be optional. 
+                            //else
+                            //{
+                            //    // From our existing code, our policy here is that if a parameterInfo 
+                            //    // is optional then all subsequent parameterInfos shall be optional. 
 
-                                // Thus, iff the first parameterInfo is not optional then this MethodInfo is no longer a canidate.
-                                if (!parameterInfos[argumentTypes.Length].IsOptional)
-                                    testForParamArray = true;
-                            }
+                            //    // Thus, iff the first parameterInfo is not optional then this MethodInfo is no longer a canidate.
+                            //    if (!parameterInfos[argumentTypes.Length].IsOptional)
+                            //        testForParamArray = true;
+                            //}
                             #endregion
                         }
 

--- a/src/Shared/Compat/XmlCharType.cs
+++ b/src/Shared/Compat/XmlCharType.cs
@@ -21,7 +21,6 @@ using System.Diagnostics;
 
 namespace System.Xml {
 
-    /// <include file='doc\XmlCharType.uex' path='docs/doc[@for="XmlCharType"]/*' />
     /// <internalonly/>
     /// <devdoc>
     ///  The XmlCharType class is used for quick character type recognition

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -458,7 +458,11 @@ namespace Microsoft.Build.BackEnd
                         }
 #endif
                     }
-                    catch (IOException e)
+                    catch (IOException
+#if FEATURE_NAMED_PIPES_FULL_DUPLEX
+                    e
+#endif
+                    )
                     {
                         // We will get here when:
                         // 1. The host (OOP main node) connects to us, it immediately checks for user privileges

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private Dictionary<string, TaskParameter> _taskParameters;
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Constructor
         /// </summary>
@@ -115,9 +116,7 @@ namespace Microsoft.Build.BackEnd
                 IDictionary<string, string> buildProcessEnvironment,
                 CultureInfo culture,
                 CultureInfo uiCulture,
-#if FEATURE_APPDOMAIN
                 AppDomainSetup appDomainSetup,
-#endif
                 int lineNumberOfTask,
                 int columnNumberOfTask,
                 string projectFileOfTask,
@@ -126,6 +125,38 @@ namespace Microsoft.Build.BackEnd
                 string taskLocation,
                 IDictionary<string, object> taskParameters
             )
+#else
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="nodeId">The ID of the node being configured.</param>
+        /// <param name="startupDirectory">The startup directory for the task being executed.</param>
+        /// <param name="buildProcessEnvironment">The set of environment variables to apply to the task execution process.</param>
+        /// <param name="culture">The culture of the thread that will execute the task.</param>
+        /// <param name="uiCulture">The UI culture of the thread that will execute the task.</param>
+        /// <param name="lineNumberOfTask">The line number of the location from which this task was invoked.</param>
+        /// <param name="columnNumberOfTask">The column number of the location from which this task was invoked.</param>
+        /// <param name="projectFileOfTask">The project file from which this task was invoked.</param>
+        /// <param name="continueOnError">Flag to continue with the build after a the task failed</param>
+        /// <param name="taskName">Name of the task.</param>
+        /// <param name="taskLocation">Location of the assembly the task is to be loaded from.</param>
+        /// <param name="taskParameters">Parameters to apply to the task.</param>
+        public TaskHostConfiguration
+            (
+                int nodeId,
+                string startupDirectory,
+                IDictionary<string, string> buildProcessEnvironment,
+                CultureInfo culture,
+                CultureInfo uiCulture,
+                int lineNumberOfTask,
+                int columnNumberOfTask,
+                string projectFileOfTask,
+                bool continueOnError,
+                string taskName,
+                string taskLocation,
+                IDictionary<string, object> taskParameters
+            )
+#endif
         {
             ErrorUtilities.VerifyThrowInternalLength(taskName, "taskName");
             ErrorUtilities.VerifyThrowInternalLength(taskLocation, "taskLocation");

--- a/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
+++ b/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.UnitTests
                 Assert.NotEqual(processHandle, NativeMethodsShared.NullIntPtr);
 
                 //Actually call the method
-                GetProcessIdDelegate processIdDelegate = (GetProcessIdDelegate)Marshal.GetDelegateForFunctionPointer(processHandle, typeof(GetProcessIdDelegate));
+                GetProcessIdDelegate processIdDelegate = Marshal.GetDelegateForFunctionPointer<GetProcessIdDelegate>(processHandle);
                 uint processId = processIdDelegate();
 
                 //Make sure the return value is the same as retrieved from the .net methods to make sure everything works

--- a/src/Utilities/UnitTests/Microsoft.Build.Utilities.UnitTests.csproj
+++ b/src/Utilities/UnitTests/Microsoft.Build.Utilities.UnitTests.csproj
@@ -63,7 +63,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build.Tasks.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Build.Tasks.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" Condition="'$(NetCoreBuild)' != 'true'">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(CompilerToolsDir)\Microsoft.Build.Tasks.CodeAnalysis.dll</HintPath>
     </Reference>

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -1091,6 +1091,7 @@ namespace Microsoft.Build.UnitTests
 
 #pragma warning restore 618
 
+#if FEATURE_CODETASKFACTORY
         private static string s_verifyToolsetAndToolLocationHelperProjectCommonContent = @"
                                     string currentInstallFolderLocation = null;
 
@@ -1144,7 +1145,6 @@ namespace Microsoft.Build.UnitTests
                                     }
   ";
 
-#if FEATURE_CODETASKFACTORY
         [Fact]
         public void VerifyToolsetAndToolLocationHelperAgree()
         {

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Build.BackEnd
 
         #region Constructors and Factories
 
+#if FEATURE_NAMED_PIPES_FULL_DUPLEX
         /// <summary>
         /// Instantiates an endpoint to act as a client
         /// </summary>
@@ -51,13 +52,19 @@ namespace Microsoft.Build.BackEnd
         /// <param name="host">The component host.</param>
         /// <param name="enableReuse">Whether this node may be reused for a later build.</param>
         internal NodeEndpointOutOfProc(
-#if FEATURE_NAMED_PIPES_FULL_DUPLEX
             string pipeName, 
+            IBuildComponentHost host,
+            bool enableReuse)
 #else
+        /// <summary>
+        /// Instantiates an endpoint to act as a client
+        /// </summary>
+        internal NodeEndpointOutOfProc(
             string clientToServerPipeHandle,
             string serverToClientPipeHandle,
+            IBuildComponentHost host,
+            bool enableReuse)
 #endif
-            IBuildComponentHost host, bool enableReuse)
         {
             ErrorUtilities.VerifyThrowArgumentNull(host, "host");
             _componentHost = host;

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -485,9 +485,6 @@ namespace Microsoft.Build.BackEnd
             processSecurityAttributes.nLength = Marshal.SizeOf<BackendNativeMethods.SECURITY_ATTRIBUTES>();
             threadSecurityAttributes.nLength = Marshal.SizeOf<BackendNativeMethods.SECURITY_ATTRIBUTES>();
 
-            BackendNativeMethods.PROCESS_INFORMATION processInfo = new BackendNativeMethods.PROCESS_INFORMATION();
-
-
             CommunicationsUtilities.Trace("Launching node from {0}", msbuildLocation);
 
 #if RUNTIME_TYPE_NETCORE
@@ -523,6 +520,8 @@ namespace Microsoft.Build.BackEnd
             CommunicationsUtilities.Trace("Successfully launched msbuild.exe node with PID {0}", process.Id);
             return process.Id;
 #else
+            BackendNativeMethods.PROCESS_INFORMATION processInfo = new BackendNativeMethods.PROCESS_INFORMATION();
+
             string exeName = msbuildLocation;
             
             bool result = BackendNativeMethods.CreateProcess

--- a/src/XMakeBuildEngine/BackEnd/Node/NodeConfiguration.cs
+++ b/src/XMakeBuildEngine/BackEnd/Node/NodeConfiguration.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private LoggerDescription[] _forwardingLoggers;
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Constructor
         /// </summary>
@@ -50,19 +51,34 @@ namespace Microsoft.Build.BackEnd
             (
             int nodeId,
             BuildParameters buildParameters,
-            LoggerDescription[] forwardingLoggers
-#if FEATURE_APPDOMAIN
-            , AppDomainSetup appDomainSetup
-#endif
+            LoggerDescription[] forwardingLoggers,
+            AppDomainSetup appDomainSetup
             )
         {
             _nodeId = nodeId;
             _buildParameters = buildParameters;
             _forwardingLoggers = forwardingLoggers;
-#if FEATURE_APPDOMAIN
             _appDomainSetup = appDomainSetup;
-#endif
         }
+#else
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="nodeId">The node id.</param>
+        /// <param name="buildParameters">The build parameters</param>
+        /// <param name="forwardingLoggers">The forwarding loggers.</param>
+        public NodeConfiguration
+            (
+            int nodeId,
+            BuildParameters buildParameters,
+            LoggerDescription[] forwardingLoggers
+            )
+        {
+            _nodeId = nodeId;
+            _buildParameters = buildParameters;
+            _forwardingLoggers = forwardingLoggers;
+        }
+#endif
 
         /// <summary>
         /// Private constructor for deserialization
@@ -117,7 +133,7 @@ namespace Microsoft.Build.BackEnd
         }
 #endif
 
-        #region INodePacket Members
+#region INodePacket Members
 
         /// <summary>
         /// Retrieves the packet type.
@@ -129,9 +145,9 @@ namespace Microsoft.Build.BackEnd
             { return NodePacketType.NodeConfiguration; }
         }
 
-        #endregion
+#endregion
 
-        #region INodePacketTranslatable Members
+#region INodePacketTranslatable Members
 
         /// <summary>
         /// Translates the packet to/from binary form.
@@ -156,7 +172,7 @@ namespace Microsoft.Build.BackEnd
             configuration.Translate(translator);
             return configuration;
         }
-        #endregion
+#endregion
 
         /// <summary>
         /// We need to clone this object since it gets modified for each node which is launched.

--- a/src/XMakeBuildEngine/Collections/ConvertingEnumerable.cs
+++ b/src/XMakeBuildEngine/Collections/ConvertingEnumerable.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 namespace Microsoft.Build.Collections
 {
     /// <summary>
-    /// Enumerable that uses a provided <see cref="Converter&lt;TFrom, TTo&gt;"/> delegate to
+    /// Enumerable that uses a provided Converter delegate to
     /// convert each item from a backing enumerator as it is returned.
     /// </summary>
     /// <typeparam name="TFrom">Type of underlying enumerator</typeparam>
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
-        /// Enumerable that uses a provided <see cref="Converter&lt;TFrom, TTo&gt;"/> delegate to
+        /// Enumerable that uses a provided Converter delegate to
         /// convert each item from a backing enumerator as it is returned.
         /// </summary>
         /// <typeparam name="TFrom2">Type of underlying enumerator</typeparam>

--- a/src/XMakeBuildEngine/Definition/Toolset.cs
+++ b/src/XMakeBuildEngine/Definition/Toolset.cs
@@ -108,11 +108,13 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private const string Dev10LightSwitchInstallKeyRegistryPath = @"Software\Microsoft\DevDiv\vs\Servicing\10.0\vslscore";
 
+#if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Null if it hasn't been figured out yet; true if (some variation of) Visual Studio 2010 is installed on 
         /// the current machine, false otherwise. 
         /// </summary>
         private static bool? s_dev10IsInstalled = null;
+#endif
 
         /// <summary>
         /// Name of the tools version

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -80,12 +80,12 @@ namespace Microsoft.Build.Evaluation
             get;
         }
 
+#if FEATURE_WIN32_REGISTRY || FEATURE_SYSTEM_CONFIGURATION
         /// <summary>
         /// Gathers toolset data from the registry and configuration file, if any:
         /// allows you to specify which of the registry and configuration file to
         /// read from by providing ToolsetInitialization
         /// </summary>
-#if FEATURE_WIN32_REGISTRY || FEATURE_SYSTEM_CONFIGURATION
         internal static string ReadAllToolsets(Dictionary<string, Toolset> toolsets, PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, ToolsetDefinitionLocations locations)
         {
             return ReadAllToolsets(toolsets,

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -412,6 +412,7 @@ namespace Microsoft.Build.Evaluation
 
         #endregion
 
+#if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Following function will parse a keyName and returns the basekey for it.
         /// It will also store the subkey name in the out parameter.
@@ -419,7 +420,6 @@ namespace Microsoft.Build.Evaluation
         /// The return value shouldn't be null.
         /// Taken from: \ndp\clr\src\BCL\Microsoft\Win32\Registry.cs
         /// </summary>
-#if FEATURE_WIN32_REGISTRY
         private static RegistryKey GetBaseKeyFromKeyName(string keyName, RegistryView view, out string subKeyName)
         {
             if (keyName == null)

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
     /// </summary>
     public class TaskBuilder_Tests : ITargetBuilderCallback
     {
+#if FEATURE_CODEDOM
         /// <summary>
         /// Task definition for a task that outputs items containing null metadata.
         /// </summary>
@@ -142,6 +143,7 @@ namespace ItemCreationTask
     }
 }
 ";
+#endif
 
         /// <summary>
         /// The mock component host and logger

--- a/src/XMakeBuildEngine/UnitTests/Construction/XmlReaderWithoutLocation_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/XmlReaderWithoutLocation_Tests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 get { return _wrappedReader.BaseURI; }
             }
 
-            public new void Close()
+            protected override void Dispose(bool disposing)
             {
                 _wrappedReader.Dispose();
             }

--- a/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -210,7 +210,7 @@
       <Project>{16cd7635-7cf4-4c62-a77b-cf87d0f09a58}</Project>
       <Name>Microsoft.Build</Name>
     </ProjectReference>
-    <Reference Include="Microsoft.Build.Tasks.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Build.Tasks.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" Condition="'$(NetCoreBuild)' != 'true'">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(CompilerToolsDir)\Microsoft.Build.Tasks.CodeAnalysis.dll</HintPath>
     </Reference>

--- a/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Microsoft.Build.Engine.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Build.Engine.UnitTests</AssemblyName>
     <IsTestProject>true</IsTestProject>
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -130,7 +130,7 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(NetCoreBuild)' != 'true'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/XMakeCommandLine/UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
+++ b/src/XMakeCommandLine/UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
@@ -12,6 +12,7 @@
     <RootNamespace>Microsoft.Build.CommandLine.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Build.CommandLine.UnitTests</AssemblyName>
     <IsTestProject>true</IsTestProject>
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -536,8 +536,8 @@ namespace Microsoft.Build.CommandLine
                 List<DistributedLoggerRecord> distributedLoggerRecords = null;
 #if FEATURE_XML_SCHEMA_VALIDATION
                 bool needToValidateProject = false;
-#endif
                 string schemaFile = null;
+#endif
                 int cpuCount = 1;
 #if FEATURE_NODE_REUSE
                 bool enableNodeReuse = true;

--- a/src/XMakeTasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/XMakeTasks/AssemblyDependency/AssemblyInformation.cs
@@ -32,12 +32,13 @@ namespace Microsoft.Build.Tasks
         private IMetaDataDispenser _metadataDispenser = null;
         private IMetaDataAssemblyImport _assemblyImport = null;
         private static Guid s_importerGuid = new Guid(((GuidAttribute)Attribute.GetCustomAttribute(typeof(IMetaDataImport), typeof(GuidAttribute), false)).Value);
+        private readonly Assembly _assembly;
 #endif
         private string _sourceFile;
         private FrameworkName _frameworkName;
+#if FEATURE_ASSEMBLY_LOADFROM && !MONO
         private static string s_targetFrameworkAttribute = "System.Runtime.Versioning.TargetFrameworkAttribute";
-        private readonly Assembly _assembly;
-
+#endif
         // Borrowed from genman.
         private const int GENMAN_STRING_BUF_SIZE = 1024;
         private const int GENMAN_LOCALE_BUF_SIZE = 64;

--- a/src/XMakeTasks/GenerateResource.cs
+++ b/src/XMakeTasks/GenerateResource.cs
@@ -146,11 +146,13 @@ namespace Microsoft.Build.Tasks
         // Contains the list of paths from which inputs will not be taken into account during up-to-date check.  
         private ITaskItem[] _excludedInputPaths;
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// The task items that we remoted across the appdomain boundary
         /// we use this list to disconnect the task items once we're done.
         /// </summary>
         private List<ITaskItem> _remotedTaskItems;
+#endif
 
         /// <summary>
         /// Satellite input assemblies.
@@ -880,6 +882,7 @@ namespace Microsoft.Build.Tasks
             return clonedOutput;
         }
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Remember this TaskItem so that we can disconnect it when this Task has finished executing
         /// Only if we're passing TaskItems to another AppDomain is this necessary. This call
@@ -893,6 +896,7 @@ namespace Microsoft.Build.Tasks
                 _remotedTaskItems.AddRange(items);
             }
         }
+#endif
 
         /// <summary>
         /// Computes the path to ResGen.exe for use in logging and for passing to the 
@@ -2195,11 +2199,13 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private ITaskItem[] _assemblyFiles;
 
+#if FEATURE_ASSEMBLY_LOADFROM
         /// <summary>
         /// The AssemblyNameExtensions for each of the referenced assemblies in "assemblyFiles".
         /// This is populated lazily.
         /// </summary>
         private AssemblyNameExtension[] _assemblyNames;
+#endif
 
         /// <summary>
         /// List of input files to process.
@@ -2285,7 +2291,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool _useSourcePath = false;
 
-        #endregion
+#endregion
 
         /// <summary>
         /// Process all files.
@@ -2436,7 +2442,7 @@ namespace Microsoft.Build.Tasks
         }
 #endif
 
-        #region Code from ResGen.EXE
+#region Code from ResGen.EXE
 
         /// <summary>
         /// Read all resources from a file and write to a new file in the chosen format
@@ -3780,7 +3786,7 @@ namespace Microsoft.Build.Tasks
             public string name;
             public object value;
         }
-        #endregion // Code from ResGen.EXE
+#endregion // Code from ResGen.EXE
     }
 
 #if FEATURE_ASSEMBLY_LOADFROM

--- a/src/XMakeTasks/GetReferenceAssemblyPaths.cs
+++ b/src/XMakeTasks/GetReferenceAssemblyPaths.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private const string WARNONNOREFERENCEASSEMBLYDIRECTORY = "MSBUILDWARNONNOREFERENCEASSEMBLYDIRECTORY";
 
+#if FEATURE_GAC
         /// <summary>
         /// This is the sentinel assembly for .NET FX 3.5 SP1
         /// Used to determine if SP1 of 3.5 is installed
@@ -36,6 +37,7 @@ namespace Microsoft.Build.Tasks
         /// Cache in a static whether or not we have found the 35sp1sentinel assembly.
         /// </summary>
         private static bool? s_net35SP1SentinelAssemblyFound;
+#endif
 
         /// <summary>
         /// Hold the reference assembly paths based on the passed in targetframeworkmoniker.


### PR DESCRIPTION
Fixed the 40+ remaining warnings when building for .NET Core.  Most were related to `#if`'s in the wrong place.  

This also enables `/warnaserror` in cibuild but I had to add 3 warnings to the `/nowarn` list:

```
warning AL1053: The version '1.2.3.4-foo' specified for the 'product version' is not in the normal 'major.minor.build.revision' format.
warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.
warning MSB3026: Could not copy "XXX" to "XXX". Beginning retry 1 in 1000ms.
```