### PR TITLE
Fix lc.exe compatibility with file arguments

### DIFF
--- a/src/XMakeTasks/LC.cs
+++ b/src/XMakeTasks/LC.cs
@@ -178,15 +178,15 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Generates response file with arguments for lc.exe
-        /// Used when targeting framework version is 4.6.2 or later
+        /// Used when targeting framework version is 4.6 or later
         /// </summary>
         /// <param name="commandLine">command line builder class to add arguments to the response file</param>
         protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
             Version targetFramework = Util.GetTargetFrameworkVersion(TargetFrameworkVersion);
-            // Don't generate response file on versions of the framework < 4.6.2
-            // They will use the 2.x SDK lc.exe which does not understand response files
-            if (targetFramework.CompareTo(new Version("4.6.2")) < 0)
+            // Don't generate response file on versions of the framework < 4.6
+            // They will use an older lc.exe which does not understand response files
+            if (targetFramework.CompareTo(new Version("4.6")) < 0)
             {
                 return;
             }
@@ -196,15 +196,15 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Generates command line arguments for lc.exe
-        /// Used when targeting framework version is less than 4.6.2
+        /// Used when targeting framework version is less than 4.6
         /// </summary>
         /// <param name="commandLine">command line builder class to add arguments to the command line</param>
         protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
         {
             Version targetFramework = Util.GetTargetFrameworkVersion(TargetFrameworkVersion);
-            // If the target framework version is < 4.6.2, we will be using lc.exe from an older SDK
+            // If the target framework version is < 4.6, we will be using lc.exe from an older SDK
             // In this case, we want to use command line parameters instead of a response file
-            if (targetFramework.CompareTo(new Version("4.6.2")) >= 0)
+            if (targetFramework.CompareTo(new Version("4.6")) >= 0)
             {
                 return;
             }

--- a/src/XMakeTasks/LC.cs
+++ b/src/XMakeTasks/LC.cs
@@ -178,15 +178,15 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Generates response file with arguments for lc.exe
-        /// Used when targeting framework version is 4.0 or later
+        /// Used when targeting framework version is 4.6.2 or later
         /// </summary>
         /// <param name="commandLine">command line builder class to add arguments to the response file</param>
         protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
             Version targetFramework = Util.GetTargetFrameworkVersion(TargetFrameworkVersion);
-            // Don't generate response file on versions of the framework < 4.0
+            // Don't generate response file on versions of the framework < 4.6.2
             // They will use the 2.x SDK lc.exe which does not understand response files
-            if (targetFramework.CompareTo(new Version("4.0")) < 0)
+            if (targetFramework.CompareTo(new Version("4.6.2")) < 0)
             {
                 return;
             }
@@ -196,15 +196,15 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Generates command line arguments for lc.exe
-        /// Used when targeting framework version is less than 4.0
+        /// Used when targeting framework version is less than 4.6.2
         /// </summary>
         /// <param name="commandLine">command line builder class to add arguments to the command line</param>
         protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
         {
             Version targetFramework = Util.GetTargetFrameworkVersion(TargetFrameworkVersion);
-            // If the target framework version is < 4.0, we will be using lc.exe from an older SDK
+            // If the target framework version is < 4.6.2, we will be using lc.exe from an older SDK
             // In this case, we want to use command line parameters instead of a response file
-            if (targetFramework.CompareTo(new Version("4.0")) >= 0)
+            if (targetFramework.CompareTo(new Version("4.6.2")) >= 0)
             {
                 return;
             }

--- a/src/XMakeTasks/UnitTests/LC_Tests.cs
+++ b/src/XMakeTasks/UnitTests/LC_Tests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Build.UnitTests
             task.OutputDirectory = "bin\\debug";
             task.ReferencedAssemblies = new TaskItem[] { new TaskItem("LicensedControl.dll"), new TaskItem("OtherControl.dll") };
             task.NoLogo = true;
-            task.TargetFrameworkVersion = "4.0";
+            task.TargetFrameworkVersion = "4.6";
 
             CommandLine.ValidateHasParameter(task, "/complist:complist.licx", true /* use response file */);
             CommandLine.ValidateHasParameter(task, "/complist:othersrc.txt", true /* use response file */);


### PR DESCRIPTION
File arguments are not supported by lc.exe until version 4.6.2 as explained in issue #914 