### PR TITLE
Do not reveal implicit elements through RawXml

### DIFF
--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -705,8 +705,10 @@ namespace Microsoft.Build.Construction
                 {
                     using (ProjectWriter projectWriter = new ProjectWriter(stringWriter))
                     {
-                        projectWriter.Initialize(XmlDocument);
-                        XmlDocument.Save(projectWriter);
+                        var xmlWithNoImplicits = RemoveImplicits();
+
+                        projectWriter.Initialize(xmlWithNoImplicits);
+                        xmlWithNoImplicits.Save(projectWriter);
                     }
 
                     return stringWriter.ToString();
@@ -1745,15 +1747,7 @@ namespace Microsoft.Build.Construction
                 {
                     using (ProjectWriter projectWriter = new ProjectWriter(_projectFileLocation.File, saveEncoding))
                     {
-                        var xmlWithNoImplicits = (XmlDocument)XmlDocument.CloneNode(deep: true);
-
-                        var implicitElements =
-                            xmlWithNoImplicits.SelectNodes($"//*[@{XMakeAttributes.@implicit}]");
-
-                        foreach (XmlNode implicitElement in implicitElements)
-                        {
-                            implicitElement.ParentNode.RemoveChild(implicitElement);
-                        }
+                        var xmlWithNoImplicits = RemoveImplicits();
 
                         projectWriter.Initialize(xmlWithNoImplicits);
                         xmlWithNoImplicits.Save(projectWriter);
@@ -1783,6 +1777,20 @@ namespace Microsoft.Build.Construction
                 DataCollection.CommentMarkProfile(8811, endProjectSave);
             }
 #endif
+        }
+
+        private XmlDocument RemoveImplicits()
+        {
+            var xmlWithNoImplicits = (XmlDocument) XmlDocument.CloneNode(deep: true);
+
+            var implicitElements =
+                xmlWithNoImplicits.SelectNodes($"//*[@{XMakeAttributes.@implicit}]");
+
+            foreach (XmlNode implicitElement in implicitElements)
+            {
+                implicitElement.ParentNode.RemoveChild(implicitElement);
+            }
+            return xmlWithNoImplicits;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -158,6 +158,11 @@ namespace Microsoft.Build.Construction
         private BuildEventContext _buildEventContext;
 
         /// <summary>
+        /// Xpath expression that will find any element with the implicit attribute
+        /// </summary>
+        private static readonly string ImplicitAttributeXpath = $"//*[@{XMakeAttributes.@implicit}]";
+
+        /// <summary>
         /// Initialize a ProjectRootElement instance from a XmlReader.
         /// May throw InvalidProjectFileException.
         /// Leaves the project dirty, indicating there are unsaved changes.
@@ -1781,15 +1786,21 @@ namespace Microsoft.Build.Construction
 
         private XmlDocument RemoveImplicits()
         {
+            if (XmlDocument.SelectSingleNode(ImplicitAttributeXpath) == null)
+            {
+                return XmlDocument;
+            }
+
             var xmlWithNoImplicits = (XmlDocument) XmlDocument.CloneNode(deep: true);
 
             var implicitElements =
-                xmlWithNoImplicits.SelectNodes($"//*[@{XMakeAttributes.@implicit}]");
+                xmlWithNoImplicits.SelectNodes(ImplicitAttributeXpath);
 
             foreach (XmlNode implicitElement in implicitElements)
             {
                 implicitElement.ParentNode.RemoveChild(implicitElement);
             }
+
             return xmlWithNoImplicits;
         }
 

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1826,8 +1826,10 @@ namespace Microsoft.Build.Construction
         {
             using (ProjectWriter projectWriter = new ProjectWriter(writer))
             {
-                projectWriter.Initialize(XmlDocument);
-                XmlDocument.Save(projectWriter);
+                var xmlWithNoImplicits = RemoveImplicits();
+
+                projectWriter.Initialize(xmlWithNoImplicits);
+                xmlWithNoImplicits.Save(projectWriter);
             }
 
             _versionOnDisk = Version;


### PR DESCRIPTION
The initial implementation caused errors when editing a project in Visual
Studio. The Roslyn Project System uses Project.Xml.RawXml to decide what
to show to the user, and handles edits by saving that file. When RawXml
had _Implicit elements, that made the first save create an invalid project
with a literal _Implicit attribute in its imports (as well as imports from
both the Sdk attribute and the now-present Import elements).

To fix this, do the same transformation for RawXml that was being done for
Save.