### PR TITLE
Update casing for Sdks

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Path to the Sdks folder for this MSBuild instance.
         /// </summary>
-        internal string MSBuildSDKsPath
+        internal string MSBuildSdksPath
         {
             get
             {
@@ -463,7 +463,7 @@ namespace Microsoft.Build.Shared
                 }
 
                 // Allow an environment-variable override of the default SDK location
-                return Environment.GetEnvironmentVariable("MSBuildSDKsPath") ?? defaultSdkPath;
+                return Environment.GetEnvironmentVariable(MSBuildConstants.SdksPath) ?? defaultSdkPath;
             }
         }
 

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Name of the property that indicates the root of the SDKs folder
         /// </summary>
-        internal const string SdksPath = "MSBuildSDKsPath";
+        internal const string SdksPath = "MSBuildSdksPath";
 
         /// <summary>
         /// The most current Visual Studio Version known to this version of MSBuild. 

--- a/src/XMakeBuildEngine/Definition/ToolsetLocalReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetLocalReader.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Evaluation
         protected override IEnumerable<ToolsetPropertyDefinition> GetPropertyDefinitions(string toolsVersion)
         {
             yield return new ToolsetPropertyDefinition(MSBuildConstants.ToolsPath, BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, _sourceLocation);
-            yield return new ToolsetPropertyDefinition(MSBuildConstants.SdksPath, BuildEnvironmentHelper.Instance.MSBuildSDKsPath, _sourceLocation);
+            yield return new ToolsetPropertyDefinition(MSBuildConstants.SdksPath, BuildEnvironmentHelper.Instance.MSBuildSdksPath, _sourceLocation);
             yield return new ToolsetPropertyDefinition("RoslynTargetsPath", BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory, _sourceLocation);
         }
 

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -390,9 +390,9 @@ namespace Microsoft.Build.Evaluation
             return BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64;
         }
 
-        public static string GetMSBuildSDKsPath()
+        public static string GetMSBuildSdksPath()
         {
-            return BuildEnvironmentHelper.Instance.MSBuildSDKsPath;
+            return BuildEnvironmentHelper.Instance.MSBuildSdksPath;
         }
 
         public static string GetVsInstallRoot()

--- a/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
@@ -210,9 +210,9 @@ namespace Microsoft.Build.Construction
                     // TODO: paths should just be Sdk.props/targets; Sdk-aware imports should do the rest of the path.
                     //  Use lower case version of Sdk name when constructing the path so that it can be case-insensitive even on case-sensitive file systems
                     var initialImportPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSdksPath,
-                        sdkName.ToLowerInvariant(), "Sdk", "Sdk.props");
+                        sdkName.ToLowerInvariant(), "sdk", "Sdk.props");
                     var finalImportPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSdksPath,
-                        sdkName.ToLowerInvariant(), "Sdk", "Sdk.targets");
+                        sdkName.ToLowerInvariant(), "sdk", "Sdk.targets");
 
                     // TODO: don't require all SDKs to have both props and targets
                     // if (File.Exists(initialImportPath))

--- a/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
@@ -208,10 +208,11 @@ namespace Microsoft.Build.Construction
                     }
 
                     // TODO: paths should just be Sdk.props/targets; Sdk-aware imports should do the rest of the path.
+                    //  Use lower case version of Sdk name when constructing the path so that it can be case-insensitive even on case-sensitive file systems
                     var initialImportPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSdksPath,
-                        sdkName, "Sdk", "Sdk.props");
+                        sdkName.ToLowerInvariant(), "Sdk", "Sdk.props");
                     var finalImportPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSdksPath,
-                        sdkName, "Sdk", "Sdk.targets");
+                        sdkName.ToLowerInvariant(), "Sdk", "Sdk.targets");
 
                     // TODO: don't require all SDKs to have both props and targets
                     // if (File.Exists(initialImportPath))

--- a/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectParser.cs
@@ -208,9 +208,9 @@ namespace Microsoft.Build.Construction
                     }
 
                     // TODO: paths should just be Sdk.props/targets; Sdk-aware imports should do the rest of the path.
-                    var initialImportPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSDKsPath,
+                    var initialImportPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSdksPath,
                         sdkName, "Sdk", "Sdk.props");
-                    var finalImportPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSDKsPath,
+                    var finalImportPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildSdksPath,
                         sdkName, "Sdk", "Sdk.targets");
 
                     // TODO: don't require all SDKs to have both props and targets

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -869,7 +869,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     </PropertyGroup>
 </Project>");
 
-                using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", testSdkRoot))
+                using (new Helpers.TemporaryEnvironment(MSBuildConstants.SdksPath, testSdkRoot))
                 {
                     string content = @"<Project Sdk='MSBuildUnitTestSdk'>
   <PropertyGroup>

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ConstructionEditing_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ConstructionEditing_Tests.cs
@@ -3219,7 +3219,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 File.WriteAllText(sdkPropsPath, "<Project />");
                 File.WriteAllText(sdkTargetsPath, "<Project />");
 
-                using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", testSdkRoot))
+                using (new Helpers.TemporaryEnvironment(MSBuildConstants.SdksPath, testSdkRoot))
                 {
                     using (var testProject = new Helpers.TestProjectWithFiles(@"
                     <Project Sdk='MSBuildUnitTestSdk' >

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectSdkImplicitImport_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectSdkImplicitImport_Tests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 File.WriteAllText(sdkPropsPath, "<Project />");
                 File.WriteAllText(sdkTargetsPath, "<Project />");
 
-                using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", testSdkRoot))
+                using (new Helpers.TemporaryEnvironment(MSBuildConstants.SdksPath, testSdkRoot))
                 {
                     string content = @"
                     <Project Sdk='MSBuildUnitTestSdk' >

--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -60,7 +60,7 @@
         <property name="MSBuildToolsPath" value="$([MSBuild]::GetCurrentToolsDirectory())" />
         <property name="MSBuildToolsPath32" value="$([MSBuild]::GetToolsDirectory32())" />
         <property name="MSBuildToolsPath64" value="$([MSBuild]::GetToolsDirectory64())" />
-        <property name="MSBuildSDKsPath" value="$([MSBuild]::GetMSBuildSDKsPath())" />
+        <property name="MSBuildSdksPath" value="$([MSBuild]::GetMSBuildSdksPath())" />
         <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1@InstallationFolder)" />
         <property name="MSBuildRuntimeVersion" value="4.0.30319" />
         <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -54,7 +54,7 @@
         <property name="MSBuildToolsPath" value="$([MSBuild]::GetCurrentToolsDirectory())" />
         <property name="MSBuildToolsPath32" value="$([MSBuild]::GetToolsDirectory32())" />
         <property name="MSBuildToolsPath64" value="$([MSBuild]::GetToolsDirectory64())" />
-        <property name="MSBuildSDKsPath" value="$([MSBuild]::GetMSBuildSDKsPath())" />
+        <property name="MSBuildSdksPath" value="$([MSBuild]::GetMSBuildSdksPath())" />
         <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1@InstallationFolder)" />
         <property name="MSBuildRuntimeVersion" value="4.0.30319" />
         <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />


### PR DESCRIPTION
This change makes the casing of `Sdk` more consistent.

More importantly, it uses the lowercase version of the Sdk name when constructing the Sdk path.  This will enable Sdk names to be case-insensitive even when the file system is case sensitive.  For this to work we'll also need to make sure that we use lowercase versions of the Sdk names when we are deploying them to the Sdk folder.  This is the same way NuGet handles package IDs today.

@rainersigwald @AndyGerlicher