### PR TITLE
Fix invalid Xml comment being generated in preprocessor if "--" is in the path to a resolved Sdk

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Preprocessor.cs
+++ b/src/XMakeBuildEngine/Evaluation/Preprocessor.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Evaluation
                         if (((XmlElement)child).GetAttribute(XMakeAttributes.@implicit).Length > 0)
                         {
                             importTag =
-                                $"  Import of \"{importProject}\" from Sdk \"{importSdk}\" was implied by the {XMakeElements.project} element's {XMakeAttributes.sdk} attribute.";
+                                $"  Import of \"{importProject.Replace("--", "__")}\" from Sdk \"{importSdk}\" was implied by the {XMakeElements.project} element's {XMakeAttributes.sdk} attribute.";
                         }
 
                         destination.AppendChild(destinationDocument.CreateComment(


### PR DESCRIPTION
Looks like there was one place in the preprocessor where it wasn't replacing "--" with "--" in Xml comments.

@rainersigwald