### PR TITLE
Consider Implicit status to find insertion loc

### DIFF
--- a/src/BuildValues.props
+++ b/src/BuildValues.props
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!--
@@ -8,6 +8,6 @@
       prerelease version number and without the leading zeroes foo-20 is
       smaller than foo-4.
     -->
-    <RevisionNumber>00077</RevisionNumber>
+    <RevisionNumber>00078</RevisionNumber>
   </PropertyGroup>
 </Project>

--- a/src/XMakeBuildEngine/Construction/ProjectElementContainer.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectElementContainer.cs
@@ -485,9 +485,9 @@ namespace Microsoft.Build.Construction
                 // If none is found, then the node being added is inserted as the only node of its kind
 
                 ProjectElement referenceSibling;
-                Predicate<ProjectElement> siblingIsSameAsChild = _ => _.ExpressedAsAttribute == false;
+                Predicate<ProjectElement> siblingIsExplicitElement = _ => _.ExpressedAsAttribute == false && _.IsImplicit == false;
 
-                if (TrySearchLeftSiblings(child.PreviousSibling, siblingIsSameAsChild, out referenceSibling))
+                if (TrySearchLeftSiblings(child.PreviousSibling, siblingIsExplicitElement, out referenceSibling))
                 {
                     //  Add after previous sibling
                     XmlElement.InsertAfter(child.XmlElement, referenceSibling.XmlElement);
@@ -503,7 +503,7 @@ namespace Microsoft.Build.Construction
                         }
                     }
                 }
-                else if (TrySearchRightSiblings(child.NextSibling, siblingIsSameAsChild, out referenceSibling))
+                else if (TrySearchRightSiblings(child.NextSibling, siblingIsExplicitElement, out referenceSibling))
                 {
                     //  Add as first child
                     XmlElement.InsertBefore(child.XmlElement, referenceSibling.XmlElement);

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectSdkImplicitImport_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectSdkImplicitImport_Tests.cs
@@ -58,6 +58,55 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             }
         }
 
+        [Fact]
+        public void ProjectWithSdkImportsIsCloneable()
+        {
+            var testSdkRoot = Path.Combine(Path.GetTempPath(), "MSBuildUnitTest");
+            var testSdkDirectory = Path.Combine(testSdkRoot, "MSBuildUnitTestSdk", "Sdk");
 
+            try
+            {
+                Directory.CreateDirectory(testSdkDirectory);
+
+                string sdkPropsPath = Path.Combine(testSdkDirectory, "Sdk.props");
+                string sdkTargetsPath = Path.Combine(testSdkDirectory, "Sdk.targets");
+
+                File.WriteAllText(sdkPropsPath, "<Project />");
+                File.WriteAllText(sdkTargetsPath, "<Project />");
+
+                using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", testSdkRoot))
+                {
+                    // Based on the new-console-project CLI template (but not matching exactly
+                    // should not be a deal-breaker).
+                    string content = @"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""**\*.cs"" />
+    <EmbeddedResource Include=""**\*.resx"" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.NETCore.App"" Version=""1.0.1"" />
+  </ItemGroup>
+
+</Project>";
+
+                    ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
+
+                    var clone = project.DeepClone();
+                }
+            }
+            finally
+            {
+                if (Directory.Exists(testSdkRoot))
+                {
+                    FileUtilities.DeleteWithoutTrailingBackslash(testSdkDirectory, true);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1431.

If a project had an Sdk attribute (and thus implicit Import elements), calling DeepClone on it could throw:

```
Unhandled Exception: System.ArgumentException: The reference node is not a child of this node.
   at System.Xml.XmlNode.InsertAfter(XmlNode newChild, XmlNode refChild)
   at Microsoft.Build.Construction.ProjectElementContainer.AddToXml(ProjectElement child)
   at Microsoft.Build.Construction.ProjectElementContainer.InsertAfterChild(ProjectElement child, ProjectElement reference)
   at Microsoft.Build.Construction.ProjectElementContainer.DeepClone(ProjectRootElement factory, ProjectElementContainer parent)
   at Microsoft.Build.Construction.ProjectElementContainer.DeepClone(ProjectRootElement factory, ProjectElementContainer parent)
   at Microsoft.Build.Construction.ProjectRootElement.DeepClone()
```

This was because we traverse the ProjectElement tree to find a sibling XML element to insert next to. If an adjacent ProjectElement's XML element has no physical representation, it is unparented and therefore not a good target for manipulations.

Add an implicitness check to the existing is-valid-for-referencing check to cause the next-XML-tree-sibling search to pass over implicit elements.

+ unit test and version bump so the xplat official build can succeed after merging.