### PR TITLE
Log a message when nothing is specified to Error and Warning tasks

### DIFF
--- a/src/XMakeTasks/Error.cs
+++ b/src/XMakeTasks/Error.cs
@@ -94,10 +94,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public override bool Execute()
         {
-            if (Text != null || Code != null)
-            {
-                Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, (Text == null) ? String.Empty : Text);
-            }
+            Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("Error.EmptyMessage"));
 
             // careful to return false. Otherwise the build would continue.
             return false;

--- a/src/XMakeTasks/Error.cs
+++ b/src/XMakeTasks/Error.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public override bool Execute()
         {
-            Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("Error.EmptyMessage"));
+            Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("ErrorAndWarning.EmptyMessage"));
 
             // careful to return false. Otherwise the build would continue.
             return false;

--- a/src/XMakeTasks/Resources/Strings.resx
+++ b/src/XMakeTasks/Resources/Strings.resx
@@ -2624,6 +2624,10 @@
   </data>
 
 
+  <data name="Error.EmptyMessage">
+    <!-- When a user did not specify a message to an <Error /> or <Warning /> task -->
+    <value>(No message specified)</value>
+  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 

--- a/src/XMakeTasks/Resources/Strings.resx
+++ b/src/XMakeTasks/Resources/Strings.resx
@@ -2624,7 +2624,7 @@
   </data>
 
 
-  <data name="Error.EmptyMessage">
+  <data name="ErrorAndWarning.EmptyMessage">
     <!-- When a user did not specify a message to an <Error /> or <Warning /> task -->
     <value>(No message specified)</value>
   </data>

--- a/src/XMakeTasks/UnitTests/ErrorWarningMessage_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ErrorWarningMessage_Tests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.True(retval);
             Assert.Equal(1, e.Warnings);
-            Assert.Contains(AssemblyResources.GetString("Error.EmptyMessage"), e.Log);
+            Assert.Contains(AssemblyResources.GetString("ErrorAndWarning.EmptyMessage"), e.Log);
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.True(retval);
             Assert.Equal(1, e.Warnings);
-            Assert.Contains(AssemblyResources.GetString("Error.EmptyMessage"), e.Log);
+            Assert.Contains(AssemblyResources.GetString("ErrorAndWarning.EmptyMessage"), e.Log);
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.False(retval);
             Assert.Equal(1, e.Errors);
-            Assert.Contains(AssemblyResources.GetString("Error.EmptyMessage"), e.Log);
+            Assert.Contains(AssemblyResources.GetString("ErrorAndWarning.EmptyMessage"), e.Log);
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.False(retval);
             Assert.Equal(1, e.Errors);
-            Assert.Contains(AssemblyResources.GetString("Error.EmptyMessage"), e.Log);
+            Assert.Contains(AssemblyResources.GetString("ErrorAndWarning.EmptyMessage"), e.Log);
         }
 
         /// <summary>

--- a/src/XMakeTasks/UnitTests/ErrorWarningMessage_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ErrorWarningMessage_Tests.cs
@@ -106,39 +106,17 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Empty warning should not log an event
+        /// Empty warning SHOULD log an event
         /// </summary>
         [Fact]
         public void EmptyWarning()
         {
             MockEngine e = new MockEngine();
-            Warning w = new Warning();
-            w.BuildEngine = e;
-
-            // don't set text
-
-            bool retval = w.Execute();
-
-            Console.WriteLine("===");
-            Console.WriteLine(e.Log);
-            Console.WriteLine("===");
-
-            Assert.True(retval);
-            Assert.Equal(0, e.Warnings);
-        }
-
-        /// <summary>
-        /// Empty warning message but a code specified should still be logged
-        /// </summary>
-        [Fact]
-        public void EmptyWarningMessageButCodeSpecified()
-        {
-            MockEngine e = new MockEngine();
-            Warning w = new Warning();
-            w.BuildEngine = e;
-
-            // don't set text
-            w.Code = "123";
+            Warning w = new Warning
+            {
+                BuildEngine = e
+                // don't set text
+            };
 
             bool retval = w.Execute();
 
@@ -148,19 +126,48 @@ namespace Microsoft.Build.UnitTests
 
             Assert.True(retval);
             Assert.Equal(1, e.Warnings);
+            Assert.Contains(AssemblyResources.GetString("Error.EmptyMessage"), e.Log);
         }
 
         /// <summary>
-        /// Empty error should not log an event
+        /// Empty warning message but a code specified should still be logged
+        /// </summary>
+        [Fact]
+        public void EmptyWarningMessageButCodeSpecified()
+        {
+            MockEngine e = new MockEngine();
+            Warning w = new Warning
+            {
+                BuildEngine = e,
+                Code = "123"
+                // don't set text
+            };
+
+            bool retval = w.Execute();
+
+            Console.WriteLine("===");
+            Console.WriteLine(e.Log);
+            Console.WriteLine("===");
+
+            Assert.True(retval);
+            Assert.Equal(1, e.Warnings);
+            Assert.Contains(AssemblyResources.GetString("Error.EmptyMessage"), e.Log);
+        }
+
+        /// <summary>
+        /// Empty error SHOULD log an event
         /// </summary>
         [Fact]
         public void EmptyError()
         {
             MockEngine e = new MockEngine();
-            Error err = new Error();
-            err.BuildEngine = e;
+            Error err = new Error
+            {
+                BuildEngine = e
+                // don't set text
+            };
 
-            // don't set text
+            
 
             bool retval = err.Execute();
 
@@ -169,7 +176,8 @@ namespace Microsoft.Build.UnitTests
             Console.WriteLine("===");
 
             Assert.False(retval);
-            Assert.Equal(0, e.Errors);
+            Assert.Equal(1, e.Errors);
+            Assert.Contains(AssemblyResources.GetString("Error.EmptyMessage"), e.Log);
         }
 
         /// <summary>
@@ -179,11 +187,14 @@ namespace Microsoft.Build.UnitTests
         public void EmptyErrorMessageButCodeSpecified()
         {
             MockEngine e = new MockEngine();
-            Error err = new Error();
-            err.BuildEngine = e;
+            Error err = new Error
+            {
+                BuildEngine = e,
+                Code = "999"
+                // don't set text
+            };
 
-            // don't set text
-            err.Code = "999";
+
             bool retval = err.Execute();
 
             Console.WriteLine("===");
@@ -192,6 +203,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.False(retval);
             Assert.Equal(1, e.Errors);
+            Assert.Contains(AssemblyResources.GetString("Error.EmptyMessage"), e.Log);
         }
 
         /// <summary>

--- a/src/XMakeTasks/Warning.cs
+++ b/src/XMakeTasks/Warning.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public override bool Execute()
         {
-            Log.LogWarning(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("Error.EmptyMessage"));
+            Log.LogWarning(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("ErrorAndWarning.EmptyMessage"));
 
             return true;
         }

--- a/src/XMakeTasks/Warning.cs
+++ b/src/XMakeTasks/Warning.cs
@@ -86,10 +86,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public override bool Execute()
         {
-            if (Text != null || Code != null)
-            {
-                Log.LogWarning(null, Code, HelpKeyword, File, 0, 0, 0, 0, (Text == null) ? String.Empty : Text);
-            }
+            Log.LogWarning(null, Code, HelpKeyword, File, 0, 0, 0, 0, Text ?? TaskResources.GetString("Error.EmptyMessage"));
 
             return true;
         }


### PR DESCRIPTION
Logs (No message specified)

Closes #1350 

Sample output
```
Build started 12/5/2016 2:41:07 PM.
Project "C:\Users\jeffkl\Desktop\Stuff\1350.proj" on node 1 (default targets).
C:\Users\jeffkl\Desktop\Stuff\1350.proj(8,5): error : (No message specified)
Done Building Project "C:\Users\jeffkl\Desktop\Stuff\1350.proj" (default targets) -- FAILED.


Build FAILED.

"C:\Users\jeffkl\Desktop\Stuff\1350.proj" (default target) (1) ->
(Build target) ->
  C:\Users\jeffkl\Desktop\Stuff\1350.proj(8,5): error : (No message specified)

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:00.35
```