### PR TITLE
Add 'VB' as a language name for WriteCodeFragment

### DIFF
--- a/src/XMakeTasks/WriteCodeFragment.cs
+++ b/src/XMakeTasks/WriteCodeFragment.cs
@@ -313,6 +313,7 @@ namespace Microsoft.Build.Tasks
                     break;
                 case "visual basic":
                 case "visualbasic":
+                case "vb":
                     if (AssemblyAttributes == null) return string.Empty;
 
                     extension = "vb";


### PR DESCRIPTION
MSBuild currently uses 'VB' as the name of <Language> for a VB project, so WriteCodeFragment should support the same.