### PR TITLE
Implementation of GetPathOfFileAbove

### DIFF
--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -701,6 +701,8 @@ namespace Microsoft.Build.UnitTests
                 if (s_tempProjectDir == null)
                 {
                     s_tempProjectDir = Path.Combine(Path.GetTempPath(), "TempDirForMSBuildUnitTests");
+
+                    Directory.CreateDirectory(s_tempProjectDir);
                 }
 
                 return s_tempProjectDir;

--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -3085,14 +3085,18 @@ namespace Microsoft.Build.Evaluation
                         // Special case a few methods that take extra parameters that can't be passed in by the user
                         //
 
-                        if (_methodMethodName.Equals("GetPathOfFileAbove"))
+                        if (_methodMethodName.Equals("GetPathOfFileAbove") && args.Length == 1)
                         {
-                            // Append the IElementLocation as a parameter to GetPathOfFileAbove
+                            // Append the IElementLocation as a parameter to GetPathOfFileAbove if the user only
+                            // specified the file name.  This is syntactic sugar so they don't have to always
+                            // include $(MSBuildThisFileDirectory) as a parameter.
                             //
+                            string startingDirectory = String.IsNullOrWhiteSpace(elementLocation.File) ? String.Empty : Path.GetDirectoryName(elementLocation.File);
+
                             args = new []
                             {
                                 args[0],
-                                elementLocation,
+                                startingDirectory,
                             };
                         }
                     }

--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -3080,6 +3080,23 @@ namespace Microsoft.Build.Evaluation
                         args[0] = Convert.ChangeType(args[0], objectInstance.GetType(), CultureInfo.InvariantCulture);
                     }
 
+                    if (_receiverType == typeof(IntrinsicFunctions))
+                    {
+                        // Special case a few methods that take extra parameters that can't be passed in by the user
+                        //
+
+                        if (_methodMethodName.Equals("GetPathOfFileAbove"))
+                        {
+                            // Append the IElementLocation as a parameter to GetPathOfFileAbove
+                            //
+                            args = new []
+                            {
+                                args[0],
+                                elementLocation,
+                            };
+                        }
+                    }
+
                     // If we've been asked to construct an instance, then we
                     // need to locate an appropriate constructor and invoke it
                     if (String.Equals("new", _methodMethodName, StringComparison.OrdinalIgnoreCase))

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -309,27 +309,19 @@ namespace Microsoft.Build.Evaluation
         /// Searches for a file based on the specified <see cref="IElementLocation"/>.
         /// </summary>
         /// <param name="file">The file to search for.</param>
-        /// <param name="elementLocation">An <see cref="IElementLocation"/>.  The directory of the <see cref="IElementLocation.File"/> is used as the starting
-        /// location of the file search.</param>
-        /// <returns>The full path of the file if it is found in a path above the <see cref="IElementLocation.File"/>.</returns>
-        internal static string GetPathOfFileAbove(string file, IElementLocation elementLocation)
+        /// <param name="startingDirectory">An optional directory to start the search in.  The default location is the directory
+        /// of the file containing the property funciton.</param>
+        /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
+        internal static string GetPathOfFileAbove(string file, string startingDirectory)
         {
-            if (String.IsNullOrWhiteSpace(elementLocation?.File))
-            {
-                ErrorUtilities.ThrowInternalError($"{nameof(elementLocation)} should not be null and it should have a file path associated with it.");
-            }
-
             // This method does not accept a path, only a file name
             if(file.Any(i => i.Equals(Path.DirectorySeparatorChar) || i.Equals(Path.AltDirectorySeparatorChar)))
             {
                 ErrorUtilities.ThrowArgument("InvalidGetPathOfFileAboveParameter", file);
             }
 
-            // Get the full path to the file and then the directory
-            string lookInDirectory = Path.GetDirectoryName(elementLocation.File);
-
             // Search for a directory that contains that file
-            string directoryName = GetDirectoryNameOfFileAbove(lookInDirectory, file);
+            string directoryName = GetDirectoryNameOfFileAbove(startingDirectory, file);
 
             return String.IsNullOrWhiteSpace(directoryName) ? String.Empty : NormalizePath(directoryName, file);
         }

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -306,6 +306,35 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Searches for a file based on the specified <see cref="IElementLocation"/>.
+        /// </summary>
+        /// <param name="file">The file to search for.</param>
+        /// <param name="elementLocation">An <see cref="IElementLocation"/>.  The directory of the <see cref="IElementLocation.File"/> is used as the starting
+        /// location of the file search.</param>
+        /// <returns>The full path of the file if it is found in a path above the <see cref="IElementLocation.File"/>.</returns>
+        internal static string GetPathOfFileAbove(string file, IElementLocation elementLocation)
+        {
+            if (String.IsNullOrWhiteSpace(elementLocation?.File))
+            {
+                ErrorUtilities.ThrowInternalError($"{nameof(elementLocation)} should not be null and it should have a file path associated with it.");
+            }
+
+            // This method does not accept a path, only a file name
+            if(file.Any(i => i.Equals(Path.DirectorySeparatorChar) || i.Equals(Path.AltDirectorySeparatorChar)))
+            {
+                ErrorUtilities.ThrowArgument("InvalidGetPathOfFileAboveParameter", file);
+            }
+
+            // Get the full path to the file and then the directory
+            string lookInDirectory = Path.GetDirectoryName(elementLocation.File);
+
+            // Search for a directory that contains that file
+            string directoryName = GetDirectoryNameOfFileAbove(lookInDirectory, file);
+
+            return String.IsNullOrWhiteSpace(directoryName) ? String.Empty : NormalizePath(directoryName, file);
+        }
+
+        /// <summary>
         /// Return the string in parameter 'defaultValue' only if parameter 'conditionValue' is empty
         /// else, return the value conditionValue
         /// </summary>

--- a/src/XMakeBuildEngine/Resources/Strings.resx
+++ b/src/XMakeBuildEngine/Resources/Strings.resx
@@ -1557,6 +1557,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <comment>{StrBegin="MSB4802: "}</comment>
   </data>
   
+  <data name="InvalidGetPathOfFileAboveParameter">
+    <value>The parameter '{0}' can only be a file name and cannot include a directory.</value>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
         

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -2685,6 +2685,20 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         /// <summary>
+        /// Verifies that the usage of GetPathOfFileAbove() within an in-memory project throws an exception.
+        /// </summary>
+        [Fact]
+        public void PropertyFunctionStaticMethodGetPathOfFileAboveInMemoryProject()
+        {
+            InvalidProjectFileException exception = Assert.Throws<InvalidProjectFileException>(() =>
+            {
+                ObjectModelHelpers.CreateInMemoryProject("<Project><PropertyGroup><foo>$([MSBuild]::GetPathOfFileAbove('foo'))</foo></PropertyGroup></Project>");
+            });
+
+            Assert.Equal("The expression \"[MSBuild]::GetPathOfFileAbove(foo, \'\')\" cannot be evaluated. The path is not of a legal form.", exception.Message);
+        }
+
+        /// <summary>
         /// Verifies that <see cref="IntrinsicFunctions.GetPathOfFileAbove"/> only accepts a file name.
         /// </summary>
         [Fact]

--- a/src/XMakeBuildEngine/UnitTests/MockElementLocation.cs
+++ b/src/XMakeBuildEngine/UnitTests/MockElementLocation.cs
@@ -23,6 +23,18 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         private static MockElementLocation s_instance = new MockElementLocation();
 
+        private string _file = "mock.targets";
+
+
+        /// <summary>
+        /// Initializes a new instance of the MockElementLocation class.
+        /// </summary>
+        /// <param name="file">The path of the file to use.</param>
+        public MockElementLocation(string file)
+        {
+            _file = file;
+        }
+
         /// <summary>
         /// Private constructor
         /// </summary>
@@ -35,7 +47,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         public override string File
         {
-            get { return "mock.targets"; }
+            get { return _file; }
         }
 
         /// <summary>


### PR DESCRIPTION
Only accepts a file name
Expander magically passes the directory containing IElementLocation.File before the method is called so users don't have to specify both arguments.

Closes #1277