### PR TITLE
Fix null-ref on project import fallback error message.

### DIFF
--- a/src/XMakeBuildEngine/Definition/ProjectImportPathMatch.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectImportPathMatch.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -19,6 +20,9 @@ namespace Microsoft.Build.Evaluation
 
         internal ProjectImportPathMatch(string propertyName, List<string> searchPaths)
         {
+            ErrorUtilities.VerifyThrowArgumentNull(propertyName, nameof(propertyName));
+            ErrorUtilities.VerifyThrowArgumentNull(searchPaths, nameof(searchPaths));
+
             PropertyName = propertyName;
             SearchPaths = searchPaths;
             MsBuildPropertyFormat = $"$({PropertyName})";

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -240,9 +240,10 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 //FIXME: handle ; in path on Unix
-                var paths =
-                    property.Value.Split(new[] {_separatorForExtensionsPathSearchPaths},
-                        StringSplitOptions.RemoveEmptyEntries).Distinct();
+                var paths = property.Value
+                    .Split(new[] {_separatorForExtensionsPathSearchPaths}, StringSplitOptions.RemoveEmptyEntries)
+                    .Distinct()
+                    .Where(path => !string.IsNullOrEmpty(path));
 
                 pathsTable.Add(property.Name, new ProjectImportPathMatch(property.Name, paths.ToList()));
             }

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -735,6 +735,64 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
+        [Fact]
+        public void FallbackImportWithFileNotFoundWhenPropertyNotDefined()
+        {
+            // Import something from $(UndefinedProperty)
+            string mainTargetsFileContent = @"
+               <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                   <Import Project='$(UndefinedProperty)\filenotfound.props' />
+                   <Target Name='Main' DependsOnTargets='FromExtn' />
+               </Project>";
+
+            string extnDir1 = null;
+            string mainProjectPath = null;
+
+            try
+            {
+                // The path to "extensions1" fallback should exist, but the file doens't need to
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("file.props"), string.Empty);
+
+                // Implement fallback for UndefinedProperty, but don't define the property.
+                var configFileContents = @"
+                <configuration>
+                  <configSections>
+                    <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"" />
+                  </configSections>
+                  <msbuildToolsets default=""14.1"">
+                    <toolset toolsVersion=""14.1"">
+                      <property name=""MSBuildToolsPath"" value="".""/>
+                      <property name=""MSBuildBinPath"" value="".""/>
+                      <projectImportSearchPaths>
+                        <searchPaths os=""" + NativeMethodsShared.GetOSNameForExtensionsPath() + @""">
+                          <property name=""UndefinedProperty"" value=""" + extnDir1 + @""" />
+                        </searchPaths>
+                      </projectImportSearchPaths>
+                     </toolset>
+                  </msbuildToolsets>
+                </configuration>";
+
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
+
+                ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
+                var reader = GetStandardConfigurationReader();
+
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> { ["FallbackExpandDir1"] = extnDir1 });
+
+                projectCollection.ResetToolsetsForTests(reader);
+                var logger = new MockLogger();
+                projectCollection.RegisterLogger(logger);
+
+                Assert.Throws<InvalidProjectFileException>(() => projectCollection.LoadProject(mainProjectPath));
+                logger.AssertLogContains(@"MSB4226: The imported project ""$(UndefinedProperty)\filenotfound.props"" was not found. Also, tried to find");
+            }
+            finally
+            {
+                FileUtilities.DeleteNoThrow(mainProjectPath);
+                FileUtilities.DeleteDirectoryNoThrow(extnDir1, true);
+            }
+        }
+
         void CreateAndBuildProjectForImportFromExtensionsPath(string extnPathPropertyName, Action<Project, MockLogger> action)
         {
             string extnDir1 = null, extnDir2 = null, mainProjectPath = null;


### PR DESCRIPTION
 - Fix scenario where import fallback is specified in the toolset for a
   property that is not defined. This scenario works but will throw a
   null-ref exception trying to error if the imported project is not
   found.
 - Added checks for null and guards against empty strings being considered
   for fallback.
Fixes #1458