### PR TITLE
Add AssemblyResolve handler for in-memory assemblies in CodeTaskFactory

### DIFF
--- a/src/XMakeTasks/CodeTaskFactory.cs
+++ b/src/XMakeTasks/CodeTaskFactory.cs
@@ -31,6 +31,37 @@ namespace Microsoft.Build.Tasks
     public class CodeTaskFactory : ITaskFactory
     {
         /// <summary>
+        /// This dictionary keeps track of custom references to compiled assemblies.  The in-memory assembly is loaded from a byte
+        /// stream and as such its dependencies cannot be found unless they are in the MSBuild.exe directory or the GAC.  They
+        /// cannot be found even if they are already loaded in the AppDomain.  This dictionary knows the FullName of the assembly
+        /// and a reference to the assembly itself.  In the <see cref="CurrentDomainOnAssemblyResolve"/> handler, the dictionary 
+        /// is used to return the loaded assemblies as a way to allow custom references that are not in the normal assembly Load
+        /// context.
+        /// </summary>
+        private static readonly IDictionary<string, Assembly> s_knownReferenceAssemblies = new ConcurrentDictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+
+        static CodeTaskFactory()
+        {
+            // The handler is not detached because it only returns assemblies for custom references that cannot be found in the normal Load context
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomainOnAssemblyResolve;
+        }
+
+        /// <summary>
+        /// Handles the <see cref="AppDomain.AssemblyResolve"/> event to return assemblies loaded from custom references.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private static Assembly CurrentDomainOnAssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            Assembly assembly = null;
+            // Return the assembly loaded from the custom reference if the FullName matches what is being looked for
+            s_knownReferenceAssemblies.TryGetValue(args.Name, out assembly);
+
+            return assembly;
+        }
+
+        /// <summary>
         /// Default assemblies names to reference during inline code compilation - from the .NET Framework
         /// </summary>
         private static readonly string[] s_defaultReferencedFrameworkAssemblyNames = { @"System.Core" };
@@ -657,6 +688,7 @@ namespace Microsoft.Build.Tasks
                                 if (candidateAssembly != null)
                                 {
                                     candidateAssemblyLocation = candidateAssembly.Location;
+                                    s_knownReferenceAssemblies.Add(candidateAssembly.FullName, candidateAssembly);
                                 }
                             }
                             catch (BadImageFormatException e)

--- a/src/XMakeTasks/CodeTaskFactory.cs
+++ b/src/XMakeTasks/CodeTaskFactory.cs
@@ -688,7 +688,7 @@ namespace Microsoft.Build.Tasks
                                 if (candidateAssembly != null)
                                 {
                                     candidateAssemblyLocation = candidateAssembly.Location;
-                                    s_knownReferenceAssemblies.Add(candidateAssembly.FullName, candidateAssembly);
+                                    s_knownReferenceAssemblies[candidateAssembly.FullName] = candidateAssembly;
                                 }
                             }
                             catch (BadImageFormatException e)


### PR DESCRIPTION
We could that since the assembly is loaded via `Assembly.Load(byte[])`, it is not allowed to use loaded dependencies because they came from a different load context.  This change keeps a static dictionary around with a mapping of assembly strong name and assembly.  If the inline task asks for the dependency at run time, the assembly resolve handler will return the loaded assembly if the strong name is the same.

Users will still experience runtime exceptions if they only list top-level dependencies in their `<Reference />` list.  To get around this, they'll need to list the full closure of dependencies that are not in the GAC or the MSBuild.exe directory.

Closes #594