### PR TITLE
Print process module path when waiting for debugger to attach

### DIFF
--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -492,7 +492,8 @@ namespace Microsoft.Build.CommandLine
 #endif
                 case "2":
                     // Sometimes easier to attach rather than deal with JIT prompt
-                    Console.WriteLine($"Waiting for debugger to attach (PID {Process.GetCurrentProcess().Id}).  Press enter to continue...");
+                    Process currentProcess = Process.GetCurrentProcess();
+                    Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press enter to continue...");
                     Console.ReadLine();
                     break;
             }
@@ -1825,7 +1826,8 @@ namespace Microsoft.Build.CommandLine
 
                 if (!Debugger.IsAttached)
                 {
-                    Console.WriteLine("Waiting for debugger to attach... (PID {0})", Process.GetCurrentProcess().Id);
+                    Process currentProcess = Process.GetCurrentProcess();
+                    Console.WriteLine($"Waiting for debugger to attach... ({currentProcess.MainModule.FileName} PID {currentProcess.Id})");
                     while (!Debugger.IsAttached)
                     {
                         Thread.Sleep(100);


### PR DESCRIPTION
Sometimes MSBuild is running under `MSBuild.exe` but sometimes it's running under `dotnet.exe`.  This change just prints out the path to the "main module" so its easier to determine what to attach the debugger to.