### PR TITLE
Fix AssemblyInformation.GetRuntimeVersion on Nano Server

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -346,6 +346,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_WORKINGSET</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_MSCOREE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/XMakeTasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/XMakeTasks/AssemblyDependency/AssemblyInformation.cs
@@ -457,6 +457,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>The CLR runtime version or empty if the path does not exist.</returns>
         internal static string GetRuntimeVersion(string path)
         {
+#if FEATURE_MSCOREE
             if (NativeMethodsShared.IsWindows)
             {
                 StringBuilder runtimeVersion = null;
@@ -489,6 +490,9 @@ namespace Microsoft.Build.Tasks
             {
                 return ManagedRuntimeVersionReader.GetRuntimeVersion(path);
             }
+#else
+                return ManagedRuntimeVersionReader.GetRuntimeVersion(path);
+#endif
         }
 
 

--- a/src/XMakeTasks/NativeMethods.cs
+++ b/src/XMakeTasks/NativeMethods.cs
@@ -1304,6 +1304,7 @@ typedef enum _tagAssemblyComparisonResult
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool CertFreeCertificateContext(IntPtr CertContext);
 
+#if FEATURE_MSCOREE
         /// <summary>
         /// Get the runtime version for a given file
         /// </summary>
@@ -1314,6 +1315,7 @@ typedef enum _tagAssemblyComparisonResult
         /// <returns>HResult</returns>
         [DllImport(MscoreeDLL, SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern uint GetFileVersion(String szFullPath, StringBuilder szBuffer, int cchBuffer, out uint dwLength);
+#endif
         #endregion
 
         #region Methods


### PR DESCRIPTION
`AssemblyInformation.GetRuntimeVersion` calls into `mscoree.dll`, which is part of NetFX and not available on .NET Core.

Because .NET Core is the only flavour of .NET available on Nano Server, this task would fail on Nano Server.

In this PR, the call to `mscoree.dll` is put behind a `FEATURE_MSCOREE` feature flag which is set for NetFX only. If this feature flag is not set, `ManagedRuntimeVersionReader.GetRuntimeVersion(path);` is used instead.

Related issues:
Closes #1233
dotnet/cli#4469
dotnet/cli#5081

/cc @rainersigwald, @jeffkl 