### PR TITLE
Generate targets in metaproj

### DIFF
--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
@@ -911,7 +911,7 @@ namespace Microsoft.Build.Execution
             }
 
             ErrorUtilities.VerifyThrow(FileUtilities.IsSolutionFilename(config.ProjectFullPath), "{0} is not a solution", config.ProjectFullPath);
-            ProjectInstance[] instances = ProjectInstance.LoadSolutionForBuild(config.ProjectFullPath, config.Properties, config.ExplicitToolsVersionSpecified ? config.ToolsVersion : null, _buildParameters, ((IBuildComponentHost)this).LoggingService, buildEventContext, false /* loaded by solution parser*/);
+            ProjectInstance[] instances = ProjectInstance.LoadSolutionForBuild(config.ProjectFullPath, config.Properties, config.ExplicitToolsVersionSpecified ? config.ToolsVersion : null, _buildParameters, ((IBuildComponentHost)this).LoggingService, buildEventContext, false /* loaded by solution parser*/, config.TargetNames);
 
             // The first instance is the traversal project, which goes into this configuration
             config.Project = instances[0];

--- a/src/XMakeBuildEngine/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/XMakeBuildEngine/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -142,6 +142,9 @@ namespace Microsoft.Build.BackEnd
 
         #endregion
 
+        /// <summary>
+        /// The target names that were requested to execute.
+        /// </summary>
         internal IReadOnlyCollection<string> TargetNames { get; }
 
         /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/XMakeBuildEngine/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text;
 using Microsoft.Build.Construction;
@@ -19,7 +18,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Xml;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Evaluation;

--- a/src/XMakeBuildEngine/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/XMakeBuildEngine/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text;
 using Microsoft.Build.Construction;
@@ -18,6 +19,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Evaluation;
@@ -140,6 +142,8 @@ namespace Microsoft.Build.BackEnd
 
         #endregion
 
+        internal IReadOnlyCollection<string> TargetNames { get; }
+
         /// <summary>
         /// Initializes a configuration from a BuildRequestData structure.  Used by the BuildManager.
         /// Figures out the correct tools version to use, falling back to the provided default if necessary.
@@ -172,6 +176,7 @@ namespace Microsoft.Build.BackEnd
             _explicitToolsVersionSpecified = data.ExplicitToolsVersionSpecified;
             _toolsVersion = ResolveToolsVersion(data, defaultToolsVersion, getToolset);
             _globalProperties = data.GlobalPropertiesDictionary;
+            TargetNames = new List<string>(data.TargetNames);
 
             // The following information only exists when the request is populated with an existing project.
             if (data.ProjectInstance != null)
@@ -237,6 +242,7 @@ namespace Microsoft.Build.BackEnd
             _globalProperties = other._globalProperties;
             this.IsCacheable = other.IsCacheable;
             _configId = configId;
+            TargetNames = other.TargetNames;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/XMakeBuildEngine/Construction/Solution/SolutionProjectGenerator.cs
@@ -8,8 +8,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -51,6 +54,11 @@ namespace Microsoft.Build.Construction
         /// The set of properties which identify the configuration and platform to build a project with
         /// </summary>
         private const string SolutionConfigurationAndPlatformProperties = "Configuration=$(Configuration); Platform=$(Platform)";
+
+        /// <summary>
+        /// A known list of target names to create.  This is for backwards compatibility.
+        /// </summary>
+        private readonly ISet<string> _knownTargetNames = ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase, "Build", "Clean", "Rebuild", "Publish");
 
         /// <summary>
         /// Version 2.0
@@ -104,6 +112,11 @@ namespace Microsoft.Build.Construction
         private ILoggingService _loggingService;
 
         /// <summary>
+        /// The list of targets specified to use.
+        /// </summary>
+        private readonly IReadOnlyCollection<string> _targetNames = new Collection<string>();
+
+        /// <summary>
         /// The solution configuration selected for this build.
         /// </summary>
         private string _selectedSolutionConfiguration;
@@ -121,7 +134,8 @@ namespace Microsoft.Build.Construction
             IDictionary<string, string> globalProperties,
             string toolsVersionOverride,
             BuildEventContext projectBuildEventContext,
-            ILoggingService loggingService
+            ILoggingService loggingService,
+            IReadOnlyCollection<string> targetNames
             )
         {
             _solutionFile = solution;
@@ -129,6 +143,17 @@ namespace Microsoft.Build.Construction
             _toolsVersionOverride = toolsVersionOverride;
             _projectBuildEventContext = projectBuildEventContext;
             _loggingService = loggingService;
+
+            if (targetNames != null)
+            {
+                // Special target names are generated for each project like My_Project:Clean.  If the user specified a value like
+                // that then we need to split by the first colon and assume the rest is a real target name.  This works unless the
+                // target has a colon in it and the user is not trying to run it in a specific project.  At the time of writing this
+                // we figured it unlikely that a target name would have a colon in it...
+
+                // The known target names are also removed from the list in case something like /t:Build was specified it is just ignored
+                _targetNames = targetNames.Select(i => i.Split(new[] { ':' }, 2, StringSplitOptions.RemoveEmptyEntries).Last()).Except(_knownTargetNames, StringComparer.OrdinalIgnoreCase).ToList();
+            }
         }
 
         #endregion // Constructors
@@ -144,6 +169,7 @@ namespace Microsoft.Build.Construction
         /// <param name="toolsVersionOverride">Tools Version override (may be null).  This should be any tools version explicitly passed to the command-line or from an MSBuild ToolsVersion parameter.</param>
         /// <param name="projectBuildEventContext">The logging context for this project.</param>
         /// <param name="loggingService">The logging service.</param>
+        /// <param name="targetNames">A collection of target names the user requested to be built.</param>
         /// <returns>An array of ProjectInstances.  The first instance is the traversal project, the remaining are the metaprojects for each project referenced in the solution.</returns>
         internal static ProjectInstance[] Generate
             (
@@ -151,7 +177,8 @@ namespace Microsoft.Build.Construction
             IDictionary<string, string> globalProperties,
             string toolsVersionOverride,
             BuildEventContext projectBuildEventContext,
-            ILoggingService loggingService
+            ILoggingService loggingService,
+            IReadOnlyCollection<string> targetNames = default(IReadOnlyCollection<string>)
             )
         {
             SolutionProjectGenerator projectGenerator = new SolutionProjectGenerator
@@ -160,7 +187,8 @@ namespace Microsoft.Build.Construction
                 globalProperties,
                 toolsVersionOverride,
                 projectBuildEventContext,
-                loggingService
+                loggingService,
+                targetNames
                 );
 
             return projectGenerator.Generate();
@@ -745,6 +773,12 @@ namespace Microsoft.Build.Construction
                 AddTraversalTargetForProject(traversalInstance, project, projectConfiguration, "Rebuild", "BuildOutput", canBuildDirectly);
                 AddTraversalTargetForProject(traversalInstance, project, projectConfiguration, "Publish", null, canBuildDirectly);
 
+                // Add any other targets specified by the user
+                foreach (string targetName in _targetNames)
+                {
+                    AddTraversalTargetForProject(traversalInstance, project, projectConfiguration, targetName, null, canBuildDirectly);
+                }
+
                 // If we cannot build the project directly, then we need to generate a metaproject for it.
                 if (!canBuildDirectly)
                 {
@@ -767,6 +801,10 @@ namespace Microsoft.Build.Construction
             AddTraversalReferencesTarget(traversalInstance, "Clean", null);
             AddTraversalReferencesTarget(traversalInstance, "Rebuild", "CollectedBuildOutput");
             AddTraversalReferencesTarget(traversalInstance, "Publish", null);
+            foreach (string targetName in _targetNames)
+            {
+                AddTraversalReferencesTarget(traversalInstance, targetName, null);
+            }
         }
 
         /// <summary>
@@ -832,10 +870,10 @@ namespace Microsoft.Build.Construction
             // These are just dummies necessary to make the evaluation into a project instance succeed when 
             // any custom imported targets have declarations like BeforeTargets="Build"
             // They'll be replaced momentarily with the real ones.
-            traversalProject.AddTarget("Build");
-            traversalProject.AddTarget("Rebuild");
-            traversalProject.AddTarget("Clean");
-            traversalProject.AddTarget("Publish");
+            foreach (string targetName in _knownTargetNames.Union(_targetNames))
+            {
+                traversalProject.AddTarget(targetName);
+            }
 
             // For debugging purposes: some information is lost when evaluating into a project instance,
             // so make it possible to see what we have at this point.
@@ -857,10 +895,10 @@ namespace Microsoft.Build.Construction
                 );
 
             // Make way for the real ones                
-            traversalInstance.RemoveTarget("Build");
-            traversalInstance.RemoveTarget("Rebuild");
-            traversalInstance.RemoveTarget("Clean");
-            traversalInstance.RemoveTarget("Publish");
+            foreach (string targetName in _knownTargetNames.Union(_targetNames))
+            {
+                traversalInstance.RemoveTarget(targetName);
+            }
 
             AddStandardTraversalTargets(traversalInstance, projectsInOrder);
 
@@ -1050,6 +1088,11 @@ namespace Microsoft.Build.Construction
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Clean");
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Rebuild");
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Publish");
+
+                foreach (string targetName in _targetNames)
+                {
+                    AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, targetName);
+                }
             }
             else if ((project.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat) ||
                      (project.CanBeMSBuildProjectFile(out unknownProjectTypeErrorMessage)))
@@ -1061,6 +1104,11 @@ namespace Microsoft.Build.Construction
                 AddMetaprojectTargetForManagedProject(traversalProject, metaprojectInstance, project, projectConfiguration, null, targetOutputItemName);
                 AddMetaprojectTargetForManagedProject(traversalProject, metaprojectInstance, project, projectConfiguration, "Rebuild", targetOutputItemName);
                 AddMetaprojectTargetForManagedProject(traversalProject, metaprojectInstance, project, projectConfiguration, "Publish", null);
+
+                foreach (string targetName in _targetNames)
+                {
+                    AddMetaprojectTargetForManagedProject(traversalProject, metaprojectInstance, project, projectConfiguration, targetName, null);
+                }
             }
             else
             {
@@ -1068,6 +1116,11 @@ namespace Microsoft.Build.Construction
                 AddMetaprojectTargetForUnknownProjectType(traversalProject, metaprojectInstance, project, "Clean", unknownProjectTypeErrorMessage);
                 AddMetaprojectTargetForUnknownProjectType(traversalProject, metaprojectInstance, project, "Rebuild", unknownProjectTypeErrorMessage);
                 AddMetaprojectTargetForUnknownProjectType(traversalProject, metaprojectInstance, project, "Publish", unknownProjectTypeErrorMessage);
+
+                foreach (string targetName in _targetNames)
+                {
+                    AddMetaprojectTargetForUnknownProjectType(traversalProject, metaprojectInstance, project, targetName, unknownProjectTypeErrorMessage);
+                }
             }
 
             return metaprojectInstance;

--- a/src/XMakeBuildEngine/Instance/ProjectInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectInstance.cs
@@ -1716,7 +1716,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Creates a set of project instances which represent the project dependency graph for a solution build.
         /// </summary>
-        internal static ProjectInstance[] LoadSolutionForBuild(string projectFile, PropertyDictionary<ProjectPropertyInstance> globalPropertiesInstances, string toolsVersion, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext projectBuildEventContext, bool isExplicitlyLoaded)
+        internal static ProjectInstance[] LoadSolutionForBuild(string projectFile, PropertyDictionary<ProjectPropertyInstance> globalPropertiesInstances, string toolsVersion, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext projectBuildEventContext, bool isExplicitlyLoaded, IReadOnlyCollection<string> targetNames)
         {
             ErrorUtilities.VerifyThrowArgumentLength(projectFile, "projectFile");
             ErrorUtilities.VerifyThrowArgumentNull(globalPropertiesInstances, "globalPropertiesInstances");
@@ -1748,7 +1748,7 @@ namespace Microsoft.Build.Execution
                 }
                 else
                 {
-                    projectInstances = GenerateSolutionWrapper(projectFile, globalProperties, toolsVersion, loggingService, projectBuildEventContext);
+                    projectInstances = GenerateSolutionWrapper(projectFile, globalProperties, toolsVersion, loggingService, projectBuildEventContext, targetNames);
                 }
             }
 
@@ -1785,7 +1785,7 @@ namespace Microsoft.Build.Execution
                     }
 
                     string toolsVersionToUse = Utilities.GenerateToolsVersionToUse(explicitToolsVersion: null, toolsVersionFromProject: toolsVersion, getToolset: buildParameters.GetToolset, defaultToolsVersion: Constants.defaultSolutionWrapperProjectToolsVersion);
-                    projectInstances = GenerateSolutionWrapper(projectFile, globalProperties, toolsVersionToUse, loggingService, projectBuildEventContext);
+                    projectInstances = GenerateSolutionWrapper(projectFile, globalProperties, toolsVersionToUse, loggingService, projectBuildEventContext, targetNames);
                 }
             }
 
@@ -2010,6 +2010,7 @@ namespace Microsoft.Build.Execution
         /// <param name="toolsVersion">The ToolsVersion to use when generating the wrapper.</param>
         /// <param name="loggingService">The logging service used to log messages etc. from the solution wrapper generator.</param>
         /// <param name="projectBuildEventContext">The build event context in which this project is being constructed.</param>
+        /// <param name="targetNames">A collection of target names that the user requested be built.</param>
         /// <returns>The ProjectRootElement for the root traversal and each of the metaprojects.</returns>
         private static ProjectInstance[] GenerateSolutionWrapper
             (
@@ -2017,7 +2018,8 @@ namespace Microsoft.Build.Execution
                 IDictionary<string, string> globalProperties,
                 string toolsVersion,
                 ILoggingService loggingService,
-                BuildEventContext projectBuildEventContext
+                BuildEventContext projectBuildEventContext,
+                IReadOnlyCollection<string> targetNames
             )
         {
             SolutionFile sp = SolutionFile.Parse(projectFile);
@@ -2035,7 +2037,7 @@ namespace Microsoft.Build.Execution
             // It's needed to determine which <UsingTask> tags to put in, whether to put a ToolsVersion parameter
             // on the <MSBuild> task tags, and what MSBuildToolsPath to use when scanning child projects
             // for dependency information.
-            ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, globalProperties, toolsVersion, projectBuildEventContext, loggingService);
+            ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, globalProperties, toolsVersion, projectBuildEventContext, loggingService, targetNames);
             return instances;
         }
 

--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
@@ -167,8 +167,8 @@ namespace Microsoft.Build.UnitTests.Construction
                     @"
                     Microsoft Visual Studio Solution File, Format Version 8.00
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
                 SolutionFile solution = ParseSolutionHelper(solutionFileContents);
                 //Project should get added to the solution
@@ -235,12 +235,12 @@ namespace Microsoft.Build.UnitTests.Construction
                     @"
                     Microsoft Visual Studio Solution File, Format Version 8.00
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject
                         Project('{NNNNNNNN-9925-4D57-9DAF-E0A9D936ABDB}') = 'someproja', 'someproja.proj', '{CCCCCCCC-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
 
@@ -308,8 +308,8 @@ namespace Microsoft.Build.UnitTests.Construction
                     @"
                     Microsoft Visual Studio Solution File, Format Version 8.00
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
                 SolutionFile solution = ParseSolutionHelper(solutionFileContents);
 
@@ -334,8 +334,8 @@ namespace Microsoft.Build.UnitTests.Construction
                 @"
                     Microsoft Visual Studio Solution File, Format Version 11.00
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
             SolutionFile solutionPriorToDev12 = ParseSolutionHelper(solutionFileContentsPriorToDev12);
@@ -350,8 +350,8 @@ namespace Microsoft.Build.UnitTests.Construction
                         VisualStudioVersion = 12.0.20311.0 VSPRO_PLATFORM
                         MinimumVisualStudioVersion = 10.0.40219.1
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
             SolutionFile solutionDev12 = ParseSolutionHelper(solutionFileContentsDev12);
@@ -368,8 +368,8 @@ namespace Microsoft.Build.UnitTests.Construction
                         VisualStudioVersion = VSPRO_PLATFORM
                         MinimumVisualStudioVersion = 10.0.40219.1
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
             SolutionFile solutionDev12Corrupted1 = ParseSolutionHelper(solutionFileContentsDev12Corrupted1);
@@ -383,8 +383,8 @@ namespace Microsoft.Build.UnitTests.Construction
                         VisualStudioVersion = 
                         MinimumVisualStudioVersion = 10.0.40219.1
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
             SolutionFile solutionDev12Corrupted2 = ParseSolutionHelper(solutionFileContentsDev12Corrupted2);
@@ -398,8 +398,8 @@ namespace Microsoft.Build.UnitTests.Construction
                         VisualStudioVersion = VSPRO_PLATFORM 12.0.20311.0
                         MinimumVisualStudioVersion = 10.0.40219.1
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
             SolutionFile solutionDev12Corrupted3 = ParseSolutionHelper(solutionFileContentsDev12Corrupted3);
@@ -413,8 +413,8 @@ namespace Microsoft.Build.UnitTests.Construction
                         VisualStudioVersion =                   12.0.20311.0VSPRO_PLATFORM
                         MinimumVisualStudioVersion = 10.0.40219.1
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
             SolutionFile solutionDev12Corrupted4 = ParseSolutionHelper(solutionFileContentsDev12Corrupted4);
@@ -428,8 +428,8 @@ namespace Microsoft.Build.UnitTests.Construction
                         VisualStudioVersion = ...12..0,.20311.0 VSPRO_PLATFORM
                         MinimumVisualStudioVersion = 10.0.40219.1
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
             SolutionFile solutionDev12Corrupted5 = ParseSolutionHelper(solutionFileContentsDev12Corrupted5);
@@ -443,8 +443,8 @@ namespace Microsoft.Build.UnitTests.Construction
                         VisualStudioVersion =                   12.0.20311.0 VSPRO_PLATFORM
                         MinimumVisualStudioVersion = 10.0.40219.1
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
 
             SolutionFile solutionDev12Corrupted6 = ParseSolutionHelper(solutionFileContentsDev12Corrupted6);
@@ -523,8 +523,8 @@ namespace Microsoft.Build.UnitTests.Construction
                     @"
                     Microsoft Visual Studio Solution File, Format Version 8.00
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
                 SolutionFile solution = ParseSolutionHelper(solutionFileContents);
 
@@ -582,8 +582,8 @@ namespace Microsoft.Build.UnitTests.Construction
                     @"
                     Microsoft Visual Studio Solution File, Format Version 8.00
                         Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                        ProjectSection(ProjectDependencies) = postProject
-	                        EndProjectSection
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
                         EndProject";
                 SolutionFile solution = ParseSolutionHelper(solutionFileContents);
                 string errCode, ignoredKeyword;
@@ -615,8 +615,8 @@ namespace Microsoft.Build.UnitTests.Construction
                 @"
                 Microsoft Visual Studio Solution File, Format Version 8.00
                     Project('{FE3BBBB6-72D5-11D2-9ACE-00C04F79A2A4}') = 'someproj', 'someproj.etp', '{AD0F3D02-9925-4D57-9DAF-E0A9D936ABDB}'
-	                    ProjectSection(ProjectDependencies) = postProject
-	                    EndProjectSection
+                        ProjectSection(ProjectDependencies) = postProject
+                        EndProjectSection
                     EndProject";
             // Delete the someproj.etp file if it exists
             File.Delete(proj1Path);
@@ -766,20 +766,20 @@ namespace Microsoft.Build.UnitTests.Construction
                 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'AnyProject', 'AnyProject\AnyProject.csproj', '{2CAB0FBD-15D8-458B-8E63-1B5B840E9798}'
                 EndProject
                 Global
-	                GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		                Debug|Any CPU = Debug|Any CPU
-		                Release|Any CPU = Release|Any CPU
-		                Description = Some description of this solution
-	                EndGlobalSection
-	                GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		                {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		                {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		                {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		                {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Release|Any CPU.Build.0 = Release|Any CPU
-	                EndGlobalSection
-	                GlobalSection(SolutionProperties) = preSolution
-		                HideSolutionNode = FALSE
-	                EndGlobalSection
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Debug|Any CPU = Debug|Any CPU
+                        Release|Any CPU = Release|Any CPU
+                        Description = Some description of this solution
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {2CAB0FBD-15D8-458B-8E63-1B5B840E9798}.Release|Any CPU.Build.0 = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
                 EndGlobal
                 ";
             try
@@ -1100,96 +1100,96 @@ EndProject
 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{A5EE8128-B08E-4533-86C5-E46714981680}'
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|ARM = Debug|ARM
-		Debug|Mixed Platforms = Debug|Mixed Platforms
-		Debug|Win32 = Debug|Win32
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
-		Release|ARM = Release|ARM
-		Release|Mixed Platforms = Release|Mixed Platforms
-		Release|Win32 = Release|Win32
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|ARM.ActiveCfg = Debug|ARM
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|ARM.Build.0 = Debug|ARM
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|ARM.Deploy.0 = Debug|ARM
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Mixed Platforms.Build.0 = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Mixed Platforms.Deploy.0 = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Win32.ActiveCfg = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Win32.Build.0 = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Win32.Deploy.0 = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x64.ActiveCfg = Debug|x64
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x64.Build.0 = Debug|x64
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x64.Deploy.0 = Debug|x64
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x86.ActiveCfg = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x86.Build.0 = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x86.Deploy.0 = Debug|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Any CPU.ActiveCfg = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|ARM.ActiveCfg = Release|ARM
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|ARM.Build.0 = Release|ARM
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|ARM.Deploy.0 = Release|ARM
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Mixed Platforms.ActiveCfg = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Mixed Platforms.Build.0 = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Mixed Platforms.Deploy.0 = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Win32.ActiveCfg = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Win32.Build.0 = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Win32.Deploy.0 = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x64.ActiveCfg = Release|x64
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x64.Build.0 = Release|x64
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x64.Deploy.0 = Release|x64
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x86.ActiveCfg = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x86.Build.0 = Release|Win32
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x86.Deploy.0 = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|ARM.ActiveCfg = Debug|ARM
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|ARM.Build.0 = Debug|ARM
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|ARM.Deploy.0 = Debug|ARM
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Mixed Platforms.Build.0 = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Mixed Platforms.Deploy.0 = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Win32.ActiveCfg = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Win32.Build.0 = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Win32.Deploy.0 = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|x64.ActiveCfg = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|x86.ActiveCfg = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|x86.Build.0 = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Debug|x86.Deploy.0 = Debug|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|Any CPU.ActiveCfg = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|ARM.ActiveCfg = Release|ARM
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|ARM.Build.0 = Release|ARM
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|ARM.Deploy.0 = Release|ARM
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|Mixed Platforms.ActiveCfg = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|Mixed Platforms.Build.0 = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|Mixed Platforms.Deploy.0 = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|Win32.ActiveCfg = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|Win32.Build.0 = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|Win32.Deploy.0 = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|x64.ActiveCfg = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|x86.ActiveCfg = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|x86.Build.0 = Release|Win32
-		{024E8607-06B0-440D-8741-5A888DC4B176}.Release|x86.Deploy.0 = Release|Win32
-		{A5EE8128-B08E-4533-86C5-E46714981680}.Debug|x86.ActiveCfg = Debug|Win32
-		{A5EE8128-B08E-4533-86C5-E46714981680}.Debug|x86.Build.0 = Debug|Win32
-		{A5EE8128-B08E-4533-86C5-E46714981680}.Debug|x86.Deploy.0 = Debug|Win32
-		{A5EE8128-B08E-4533-86C5-E46714981680}.Release|x86.ActiveCfg = Release|Win32
-		{A5EE8128-B08E-4533-86C5-E46714981680}.Release|x86.Build.0 = Release|Win32
-		{A5EE8128-B08E-4533-86C5-E46714981680}.Release|x86.Deploy.0 = Release|Win32
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{A5526AEA-E0A2-496D-94B7-2BBE835C83F8} = {892B5932-9AA8-46F9-A857-8967DCDBE4F5}
-		{FF6AEDF3-950A-46DD-910B-52BC69B9C99A} = {892B5932-9AA8-46F9-A857-8967DCDBE4F5}
-		{024E8607-06B0-440D-8741-5A888DC4B176} = {892B5932-9AA8-46F9-A857-8967DCDBE4F5}
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Debug|ARM = Debug|ARM
+        Debug|Mixed Platforms = Debug|Mixed Platforms
+        Debug|Win32 = Debug|Win32
+        Debug|x64 = Debug|x64
+        Debug|x86 = Debug|x86
+        Release|Any CPU = Release|Any CPU
+        Release|ARM = Release|ARM
+        Release|Mixed Platforms = Release|Mixed Platforms
+        Release|Win32 = Release|Win32
+        Release|x64 = Release|x64
+        Release|x86 = Release|x86
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Any CPU.ActiveCfg = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|ARM.ActiveCfg = Debug|ARM
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|ARM.Build.0 = Debug|ARM
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|ARM.Deploy.0 = Debug|ARM
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Mixed Platforms.Deploy.0 = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Win32.ActiveCfg = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Win32.Build.0 = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|Win32.Deploy.0 = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x64.ActiveCfg = Debug|x64
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x64.Build.0 = Debug|x64
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x64.Deploy.0 = Debug|x64
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x86.ActiveCfg = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x86.Build.0 = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Debug|x86.Deploy.0 = Debug|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Any CPU.ActiveCfg = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|ARM.ActiveCfg = Release|ARM
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|ARM.Build.0 = Release|ARM
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|ARM.Deploy.0 = Release|ARM
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Mixed Platforms.Build.0 = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Mixed Platforms.Deploy.0 = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Win32.ActiveCfg = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Win32.Build.0 = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|Win32.Deploy.0 = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x64.ActiveCfg = Release|x64
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x64.Build.0 = Release|x64
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x64.Deploy.0 = Release|x64
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x86.ActiveCfg = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x86.Build.0 = Release|Win32
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8}.Release|x86.Deploy.0 = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Any CPU.ActiveCfg = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|ARM.ActiveCfg = Debug|ARM
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|ARM.Build.0 = Debug|ARM
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|ARM.Deploy.0 = Debug|ARM
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Mixed Platforms.Deploy.0 = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Win32.ActiveCfg = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Win32.Build.0 = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|Win32.Deploy.0 = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|x64.ActiveCfg = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|x86.ActiveCfg = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|x86.Build.0 = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Debug|x86.Deploy.0 = Debug|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|Any CPU.ActiveCfg = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|ARM.ActiveCfg = Release|ARM
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|ARM.Build.0 = Release|ARM
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|ARM.Deploy.0 = Release|ARM
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|Mixed Platforms.Build.0 = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|Mixed Platforms.Deploy.0 = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|Win32.ActiveCfg = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|Win32.Build.0 = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|Win32.Deploy.0 = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|x64.ActiveCfg = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|x86.ActiveCfg = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|x86.Build.0 = Release|Win32
+        {024E8607-06B0-440D-8741-5A888DC4B176}.Release|x86.Deploy.0 = Release|Win32
+        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|x86.ActiveCfg = Debug|Win32
+        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|x86.Build.0 = Debug|Win32
+        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|x86.Deploy.0 = Debug|Win32
+        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|x86.ActiveCfg = Release|Win32
+        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|x86.Build.0 = Release|Win32
+        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|x86.Deploy.0 = Release|Win32
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+    GlobalSection(NestedProjects) = preSolution
+        {A5526AEA-E0A2-496D-94B7-2BBE835C83F8} = {892B5932-9AA8-46F9-A857-8967DCDBE4F5}
+        {FF6AEDF3-950A-46DD-910B-52BC69B9C99A} = {892B5932-9AA8-46F9-A857-8967DCDBE4F5}
+        {024E8607-06B0-440D-8741-5A888DC4B176} = {892B5932-9AA8-46F9-A857-8967DCDBE4F5}
+    EndGlobalSection
 EndGlobal
                 ";
 

--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -352,23 +352,23 @@ namespace Microsoft.Build.UnitTests.Construction
                     Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""ClassLibrary2"", ""ClassLibrary2.csproj"", ""{84AA5584-4B0F-41DE-95AA-589E1447EDA0}""
                     EndProject
                     Global
-	                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		                    Debug|Any CPU = Debug|Any CPU
-		                    Release|Any CPU = Release|Any CPU
-	                    EndGlobalSection
-	                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		                    {A437DBE9-DCAA-46D8-9D80-A50EDB2244FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		                    {A437DBE9-DCAA-46D8-9D80-A50EDB2244FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		                    {A437DBE9-DCAA-46D8-9D80-A50EDB2244FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		                    {A437DBE9-DCAA-46D8-9D80-A50EDB2244FD}.Release|Any CPU.Build.0 = Release|Any CPU
-		                    {84AA5584-4B0F-41DE-95AA-589E1447EDA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		                    {84AA5584-4B0F-41DE-95AA-589E1447EDA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		                    {84AA5584-4B0F-41DE-95AA-589E1447EDA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		                    {84AA5584-4B0F-41DE-95AA-589E1447EDA0}.Release|Any CPU.Build.0 = Release|Any CPU
-	                    EndGlobalSection
-	                    GlobalSection(SolutionProperties) = preSolution
-		                    HideSolutionNode = FALSE
-	                    EndGlobalSection
+                        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                            Debug|Any CPU = Debug|Any CPU
+                            Release|Any CPU = Release|Any CPU
+                        EndGlobalSection
+                        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                            {A437DBE9-DCAA-46D8-9D80-A50EDB2244FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                            {A437DBE9-DCAA-46D8-9D80-A50EDB2244FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                            {A437DBE9-DCAA-46D8-9D80-A50EDB2244FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                            {A437DBE9-DCAA-46D8-9D80-A50EDB2244FD}.Release|Any CPU.Build.0 = Release|Any CPU
+                            {84AA5584-4B0F-41DE-95AA-589E1447EDA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                            {84AA5584-4B0F-41DE-95AA-589E1447EDA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                            {84AA5584-4B0F-41DE-95AA-589E1447EDA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                            {84AA5584-4B0F-41DE-95AA-589E1447EDA0}.Release|Any CPU.Build.0 = Release|Any CPU
+                        EndGlobalSection
+                        GlobalSection(SolutionProperties) = preSolution
+                            HideSolutionNode = FALSE
+                        EndGlobalSection
                     EndGlobal
                 ";
 
@@ -516,30 +516,30 @@ namespace Microsoft.Build.UnitTests.Construction
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 11
 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `B`, `Project2\B.csproj`, `{881C1674-4ECA-451D-85B6-D7C59B7F16FA}`
-	ProjectSection(ProjectDependencies) = postProject
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
-	EndProjectSection
+    ProjectSection(ProjectDependencies) = postProject
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
+    EndProjectSection
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = preSolution
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.Build.0 = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.ActiveCfg = Release|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Debug|x64 = Debug|x64
+        Release|Any CPU = Release|Any CPU
+        Release|x64 = Release|x64
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = preSolution
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.Build.0 = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.ActiveCfg = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
 EndGlobal
 ".Replace("`", "\"");
 
@@ -562,48 +562,48 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `A`, `Project1\A.csproj`, `{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}`
 EndProject
 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `B`, `Project2\B.csproj`, `{881C1674-4ECA-451D-85B6-D7C59B7F16FA}`
-	ProjectSection(ProjectDependencies) = postProject
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
-	EndProjectSection
+    ProjectSection(ProjectDependencies) = postProject
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
+    EndProjectSection
 EndProject
 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `C`, `Project3\C.csproj`, `{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}`
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = preSolution
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|x64.Build.0 = Debug|Any CPU
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|x64.ActiveCfg = Release|Any CPU
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|x64.Build.0 = Release|Any CPU
-		{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|x64.Build.0 = Debug|Any CPU
-		{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|x64.ActiveCfg = Release|Any CPU
-		{786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|x64.Build.0 = Release|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.Build.0 = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.ActiveCfg = Release|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Debug|x64 = Debug|x64
+        Release|Any CPU = Release|Any CPU
+        Release|x64 = Release|x64
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = preSolution
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|x64.Build.0 = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|Any CPU.Build.0 = Release|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|x64.ActiveCfg = Release|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Release|x64.Build.0 = Release|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Debug|x64.Build.0 = Debug|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|Any CPU.Build.0 = Release|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|x64.ActiveCfg = Release|Any CPU
+        {786E302A-96CE-43DC-B640-D6B6CC9BF6C0}.Release|x64.Build.0 = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|x64.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|Any CPU.Build.0 = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.ActiveCfg = Release|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Release|x64.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
 EndGlobal
 ".Replace("`", "\"");
 
@@ -651,29 +651,29 @@ EndGlobal
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 11
 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `B`, `B.csproj`, `{881C1674-4ECA-451D-85B6-D7C59B7F16FA}`
-	ProjectSection(ProjectDependencies) = postProject
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
-	EndProjectSection
+    ProjectSection(ProjectDependencies) = postProject
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167} = {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}
+    EndProjectSection
 EndProject
 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `C`, `C.csproj`, `{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}`
 EndProject
 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `D`, `D.csproj`, `{B6E7E06F-FC0B-48F1-911A-55E0E1566F00}`
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = preSolution
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B6E7E06F-FC0B-48F1-911A-55E0E1566F00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B6E7E06F-FC0B-48F1-911A-55E0E1566F00}.Debug|Any CPU.Build.0 = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = preSolution
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4A727FF8-65F2-401E-95AD-7C8BBFBE3167}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {881C1674-4ECA-451D-85B6-D7C59B7F16FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B6E7E06F-FC0B-48F1-911A-55E0E1566F00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B6E7E06F-FC0B-48F1-911A-55E0E1566F00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
 EndGlobal
 ";
             const string projectBravoFileContents =
@@ -1109,30 +1109,30 @@ EndGlobal
                 @"
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ConsoleApplication2', 'ConsoleApplication2\ConsoleApplication2.csproj', '{5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}'
-	ProjectSection(ProjectDependencies) = postProject
-		{E0D295A1-CAFA-4E68-9929-468657DAAC6C} = {E0D295A1-CAFA-4E68-9929-468657DAAC6C}
-	EndProjectSection
+    ProjectSection(ProjectDependencies) = postProject
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C} = {E0D295A1-CAFA-4E68-9929-468657DAAC6C}
+    EndProjectSection
 EndProject
 Project('{F184B08F-C81C-45F6-A57F-5ABD9991F28F}') = 'ConsoleApplication1', 'ConsoleApplication1\ConsoleApplication1.vbproj', '{E0D295A1-CAFA-4E68-9929-468657DAAC6C}'
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {5B97A3C7-3DEE-47A4-870F-5CB6384FE6A4}.Release|Any CPU.Build.0 = Release|Any CPU
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {E0D295A1-CAFA-4E68-9929-468657DAAC6C}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
 EndGlobal
                 ";
 
@@ -1788,37 +1788,37 @@ EndGlobal
                             @"Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'WebSite1', '..\WebSite1\', '{6B8F98F2-C976-4029-9321-5CCD73A174DA}'
-	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = 'SuperCoolReallyAwesomeFramework,Version=v1.0'
-		Debug.AspNetCompiler.VirtualPath = '/WebSite1'
-		Debug.AspNetCompiler.PhysicalPath = '..\WebSite1\'
-		Debug.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
-		Debug.AspNetCompiler.Updateable = 'true'
-		Debug.AspNetCompiler.ForceOverwrite = 'true'
-		Debug.AspNetCompiler.FixedNames = 'false'
-		Debug.AspNetCompiler.Debug = 'True'
-		Release.AspNetCompiler.VirtualPath = '/WebSite1'
-		Release.AspNetCompiler.PhysicalPath = '..\WebSite1\'
-		Release.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
-		Release.AspNetCompiler.Updateable = 'true'
-		Release.AspNetCompiler.ForceOverwrite = 'true'
-		Release.AspNetCompiler.FixedNames = 'false'
-		Release.AspNetCompiler.Debug = 'False'
-		VWDPort = '45602'
-		DefaultWebSiteLanguage = 'Visual Basic'
-	EndProjectSection
+    ProjectSection(WebsiteProperties) = preProject
+        TargetFrameworkMoniker = 'SuperCoolReallyAwesomeFramework,Version=v1.0'
+        Debug.AspNetCompiler.VirtualPath = '/WebSite1'
+        Debug.AspNetCompiler.PhysicalPath = '..\WebSite1\'
+        Debug.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
+        Debug.AspNetCompiler.Updateable = 'true'
+        Debug.AspNetCompiler.ForceOverwrite = 'true'
+        Debug.AspNetCompiler.FixedNames = 'false'
+        Debug.AspNetCompiler.Debug = 'True'
+        Release.AspNetCompiler.VirtualPath = '/WebSite1'
+        Release.AspNetCompiler.PhysicalPath = '..\WebSite1\'
+        Release.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
+        Release.AspNetCompiler.Updateable = 'true'
+        Release.AspNetCompiler.ForceOverwrite = 'true'
+        Release.AspNetCompiler.FixedNames = 'false'
+        Release.AspNetCompiler.Debug = 'False'
+        VWDPort = '45602'
+        DefaultWebSiteLanguage = 'Visual Basic'
+    EndProjectSection
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
 EndGlobal
                 ";
 
@@ -1880,37 +1880,37 @@ EndGlobal
                             @"Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'WebSite1', '..\WebSite1\', '{6B8F98F2-C976-4029-9321-5CCD73A174DA}'
-	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = 'Oscar the grouch'
-		Debug.AspNetCompiler.VirtualPath = '/WebSite1'
-		Debug.AspNetCompiler.PhysicalPath = '..\WebSite1\'
-		Debug.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
-		Debug.AspNetCompiler.Updateable = 'true'
-		Debug.AspNetCompiler.ForceOverwrite = 'true'
-		Debug.AspNetCompiler.FixedNames = 'false'
-		Debug.AspNetCompiler.Debug = 'True'
-		Release.AspNetCompiler.VirtualPath = '/WebSite1'
-		Release.AspNetCompiler.PhysicalPath = '..\WebSite1\'
-		Release.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
-		Release.AspNetCompiler.Updateable = 'true'
-		Release.AspNetCompiler.ForceOverwrite = 'true'
-		Release.AspNetCompiler.FixedNames = 'false'
-		Release.AspNetCompiler.Debug = 'False'
-		VWDPort = '45602'
-		DefaultWebSiteLanguage = 'Visual Basic'
-	EndProjectSection
+    ProjectSection(WebsiteProperties) = preProject
+        TargetFrameworkMoniker = 'Oscar the grouch'
+        Debug.AspNetCompiler.VirtualPath = '/WebSite1'
+        Debug.AspNetCompiler.PhysicalPath = '..\WebSite1\'
+        Debug.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
+        Debug.AspNetCompiler.Updateable = 'true'
+        Debug.AspNetCompiler.ForceOverwrite = 'true'
+        Debug.AspNetCompiler.FixedNames = 'false'
+        Debug.AspNetCompiler.Debug = 'True'
+        Release.AspNetCompiler.VirtualPath = '/WebSite1'
+        Release.AspNetCompiler.PhysicalPath = '..\WebSite1\'
+        Release.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
+        Release.AspNetCompiler.Updateable = 'true'
+        Release.AspNetCompiler.ForceOverwrite = 'true'
+        Release.AspNetCompiler.FixedNames = 'false'
+        Release.AspNetCompiler.Debug = 'False'
+        VWDPort = '45602'
+        DefaultWebSiteLanguage = 'Visual Basic'
+    EndProjectSection
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
 EndGlobal
                 ";
 
@@ -1973,37 +1973,37 @@ EndGlobal
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project('{E24C65DC-7377-472B-9ABA-BC803B73C61A}') = 'WebSite1', '..\WebSite1\', '{6B8F98F2-C976-4029-9321-5CCD73A174DA}'
-	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = '.NETFramework,Version=v4.34'
-		Debug.AspNetCompiler.VirtualPath = '/WebSite1'
-		Debug.AspNetCompiler.PhysicalPath = '..\WebSite1\'
-		Debug.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
-		Debug.AspNetCompiler.Updateable = 'true'
-		Debug.AspNetCompiler.ForceOverwrite = 'true'
-		Debug.AspNetCompiler.FixedNames = 'false'
-		Debug.AspNetCompiler.Debug = 'True'
-		Release.AspNetCompiler.VirtualPath = '/WebSite1'
-		Release.AspNetCompiler.PhysicalPath = '..\WebSite1\'
-		Release.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
-		Release.AspNetCompiler.Updateable = 'true'
-		Release.AspNetCompiler.ForceOverwrite = 'true'
-		Release.AspNetCompiler.FixedNames = 'false'
-		Release.AspNetCompiler.Debug = 'False'
-		VWDPort = '45602'
-		DefaultWebSiteLanguage = 'Visual Basic'
-	EndProjectSection
+    ProjectSection(WebsiteProperties) = preProject
+        TargetFrameworkMoniker = '.NETFramework,Version=v4.34'
+        Debug.AspNetCompiler.VirtualPath = '/WebSite1'
+        Debug.AspNetCompiler.PhysicalPath = '..\WebSite1\'
+        Debug.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
+        Debug.AspNetCompiler.Updateable = 'true'
+        Debug.AspNetCompiler.ForceOverwrite = 'true'
+        Debug.AspNetCompiler.FixedNames = 'false'
+        Debug.AspNetCompiler.Debug = 'True'
+        Release.AspNetCompiler.VirtualPath = '/WebSite1'
+        Release.AspNetCompiler.PhysicalPath = '..\WebSite1\'
+        Release.AspNetCompiler.TargetPath = 'PrecompiledWeb\WebSite1\'
+        Release.AspNetCompiler.Updateable = 'true'
+        Release.AspNetCompiler.ForceOverwrite = 'true'
+        Release.AspNetCompiler.FixedNames = 'false'
+        Release.AspNetCompiler.Debug = 'False'
+        VWDPort = '45602'
+        DefaultWebSiteLanguage = 'Visual Basic'
+    EndProjectSection
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {6B8F98F2-C976-4029-9321-5CCD73A174DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
 EndGlobal
                 ";
 
@@ -2029,6 +2029,54 @@ EndGlobal
             {
                 File.Delete(projectFilePath);
             }
+        }
+
+        /// <summary>
+        /// Verifies that when target names are specified they end up in the metaproj.
+        /// </summary>
+        [Fact]
+        public void CustomTargetNamesAreInInMetaproj()
+        {
+            SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper
+            (@"
+                Microsoft Visual Studio Solution File, Format Version 14.00
+                # Visual Studio 2015
+                Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""ClassLibrary1"", ""ClassLibrary1.csproj"", ""{6185CC21-BE89-448A-B3C0-D1C27112E595}""
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                        Release|Any CPU = Release|Any CPU
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.ActiveCfg = CSConfig1|Any CPU
+                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.Build.0 = CSConfig1|Any CPU
+                        {6185CC21-BE89-448A-B3C0-D1C27112E595}.Release|Any CPU.ActiveCfg = CSConfig2|Any CPU
+                    EndGlobalSection
+                EndGlobal
+            ");
+
+            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, null, new List<string> { "One" });
+
+            Assert.Equal(1, instances[0].Targets.Count(target => String.Compare(target.Value.Name, "One", StringComparison.OrdinalIgnoreCase) == 0));
+
+            instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, null, new List<string> { "Two", "Three", "Four" });
+
+            Assert.Equal(1, instances[0].Targets.Count(target => String.Compare(target.Value.Name, "Two", StringComparison.OrdinalIgnoreCase) == 0));
+            Assert.Equal(1, instances[0].Targets.Count(target => String.Compare(target.Value.Name, "Three", StringComparison.OrdinalIgnoreCase) == 0));
+            Assert.Equal(1, instances[0].Targets.Count(target => String.Compare(target.Value.Name, "Four", StringComparison.OrdinalIgnoreCase) == 0));
+
+            instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, null, new List<string> { "Build" });
+
+            Assert.Equal(1, instances[0].Targets.Count(target => String.Compare(target.Value.Name, "Build", StringComparison.OrdinalIgnoreCase) == 0));
+
+            instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, null, new List<string> { "Five", "Rebuild" });
+
+            Assert.Equal(1, instances[0].Targets.Count(target => String.Compare(target.Value.Name, "Five", StringComparison.OrdinalIgnoreCase) == 0));
+            Assert.Equal(1, instances[0].Targets.Count(target => String.Compare(target.Value.Name, "Rebuild", StringComparison.OrdinalIgnoreCase) == 0));
+
+            instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, null, new List<string> { "My_Project:Six" });
+
+            Assert.Equal(1, instances[0].Targets.Count(target => String.Compare(target.Value.Name, "Six", StringComparison.OrdinalIgnoreCase) == 0));
         }
 
         #region Helper Functions


### PR DESCRIPTION
This allows users to access any target when building a solution.  The target may or may not exist but this will create the corresponding targets in the `.metaproj`.

I had to pass along the target names from the build request all the way down to the solution generator via ReadOnlyCollections.

Closes #1275