### PR TITLE
ProjectRootElement can reload itself

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -312,6 +312,9 @@ namespace Microsoft.Build.Construction
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
+        public void Reload(bool throwIfUnsavedChanges=true) { }
+        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true) { }
+        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true) { }
         public void Save() { }
         public void Save(System.IO.TextWriter writer) { }
         public void Save(string path) { }

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Build.Construction
         public Microsoft.Build.Construction.ProjectRootElement DeepClone() { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
-        public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, System.Nullable<bool> preserveFormatting) { throw null; }
         public void Reload(bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
         public void ReloadFrom(string path, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
         public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
@@ -322,7 +322,7 @@ namespace Microsoft.Build.Construction
         public void Save(System.Text.Encoding saveEncoding) { }
         public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
-        public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, System.Nullable<bool> preserveFormatting) { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Name={Name} #Children={Count} Condition={Condition}")]
     public partial class ProjectTargetElement : Microsoft.Build.Construction.ProjectElementContainer

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -312,9 +312,9 @@ namespace Microsoft.Build.Construction
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
-        public void Reload(bool throwIfUnsavedChanges=true) { }
-        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true) { }
-        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true) { }
+        public void Reload(bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
+        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
+        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
         public void Save() { }
         public void Save(System.IO.TextWriter writer) { }
         public void Save(string path) { }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -312,6 +312,9 @@ namespace Microsoft.Build.Construction
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
+        public void Reload(bool throwIfUnsavedChanges=true) { }
+        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true) { }
+        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true) { }
         public void Save() { }
         public void Save(System.IO.TextWriter writer) { }
         public void Save(string path) { }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Build.Construction
         public Microsoft.Build.Construction.ProjectRootElement DeepClone() { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
-        public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, System.Nullable<bool> preserveFormatting) { throw null; }
         public void Reload(bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
         public void ReloadFrom(string path, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
         public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
@@ -322,7 +322,7 @@ namespace Microsoft.Build.Construction
         public void Save(System.Text.Encoding saveEncoding) { }
         public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
-        public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
+        public static Microsoft.Build.Construction.ProjectRootElement TryOpen(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, System.Nullable<bool> preserveFormatting) { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Name={Name} #Children={Count} Condition={Condition}")]
     public partial class ProjectTargetElement : Microsoft.Build.Construction.ProjectElementContainer

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -312,9 +312,9 @@ namespace Microsoft.Build.Construction
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, bool preserveFormatting) { throw null; }
-        public void Reload(bool throwIfUnsavedChanges=true) { }
-        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true) { }
-        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true) { }
+        public void Reload(bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
+        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
+        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
         public void Save() { }
         public void Save(System.IO.TextWriter writer) { }
         public void Save(string path) { }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -535,6 +535,16 @@ namespace Microsoft.Build.UnitTests
             return projectFilePath;
         }
 
+        internal static ProjectRootElement CreateInMemoryProjectRootElement(string projectContents, ProjectCollection collection = null, bool preserveFormatting = true)
+        {
+            var cleanedProject = ObjectModelHelpers.CleanupFileContents(projectContents);
+
+            return ProjectRootElement.Create(
+                XmlReader.Create(new StringReader(cleanedProject)),
+                collection ?? new ProjectCollection(),
+                preserveFormatting);
+        }
+
         /// <summary>
         /// Create a project in memory. Load up the given XML.
         /// </summary>

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1928,7 +1928,13 @@ namespace Microsoft.Build.Construction
             // Reload should only mutate the state if there are no parse errors.
             ThrowIfDocumentHasParsingErrors(document);
 
+            // Do not clear the string cache.
+            // Based on the assumption that Projects are reloaded repeatedly from their file with small increments,
+            // and thus most strings would get reused
+            //this.XmlDocument.ClearAnyCachedStrings();
+
             this.RemoveAllChildren();
+
             ProjectParser.Parse(document, this);
 
             MarkDirty("Project reloaded", null);

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1917,7 +1917,8 @@ namespace Microsoft.Build.Construction
                 (path, cache) => CreateProjectFromPath(path, globalProperties, toolsVersion, loggingService, cache, buildEventContext,
                                     preserveFormatting: false),
                 isExplicitlyLoaded,
-                preserveFormatting: false);
+                // don't care about formatting, reuse whatever is there
+                preserveFormatting: null);
 
             return projectRootElement;
         }

--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1099,7 +1099,7 @@ namespace Microsoft.Build.Construction
         /// Initialize a ProjectRootElement instance by loading from the specified file path.
         /// Uses the specified project collection and preserves the formatting of the document if specified.
         /// </summary>
-        public static ProjectRootElement Open(string path, ProjectCollection projectCollection, bool preserveFormatting)
+        public static ProjectRootElement Open(string path, ProjectCollection projectCollection, bool? preserveFormatting)
         {
             ErrorUtilities.VerifyThrowArgumentLength(path, "path");
             ErrorUtilities.VerifyThrowArgumentNull(projectCollection, "projectCollection");
@@ -1156,7 +1156,7 @@ namespace Microsoft.Build.Construction
         /// It is possible for ProjectRootElements to be brought into memory and discarded due to memory pressure. Therefore
         /// this method returning false does not indicate that it has never been loaded, only that it is not currently in memory.
         /// </remarks>
-        public static ProjectRootElement TryOpen(string path, ProjectCollection projectCollection, bool preserveFormatting)
+        public static ProjectRootElement TryOpen(string path, ProjectCollection projectCollection, bool? preserveFormatting)
         {
             ErrorUtilities.VerifyThrowArgumentLength(path, "path");
             ErrorUtilities.VerifyThrowArgumentNull(projectCollection, "projectCollection");
@@ -1968,12 +1968,12 @@ namespace Microsoft.Build.Construction
         /// May throw InvalidProjectFileException.
         /// </summary>
         internal static ProjectRootElement Open(string path, ProjectRootElementCache projectRootElementCache, bool isExplicitlyLoaded,
-            bool preserveFormatting)
+            bool? preserveFormatting)
         {
             ErrorUtilities.VerifyThrowInternalRooted(path);
 
             ProjectRootElement projectRootElement = projectRootElementCache.Get(path,
-                preserveFormatting ? s_openLoaderPreserveFormattingDelegate : s_openLoaderDelegate,
+                preserveFormatting ?? false ? s_openLoaderPreserveFormattingDelegate : s_openLoaderDelegate,
                 isExplicitlyLoaded, preserveFormatting);
 
             return projectRootElement;

--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -2439,7 +2439,8 @@ namespace Microsoft.Build.Evaluation
                             _buildEventContext,
                             explicitlyLoaded),
                         explicitlyLoaded,
-                        preserveFormatting: false);
+                        // don't care about formatting, reuse whatever is there
+                        preserveFormatting: null);
 
                     if (duplicateImport)
                     {

--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="preserveFormatting"><code>true</code> to the project was loaded with the formated preserved, otherwise <code>false</code>.</param>
         /// <returns>The ProjectRootElement instance if one exists.  Null otherwise.</returns>
         internal ProjectRootElement Get(string projectFile, OpenProjectRootElement openProjectRootElement, bool isExplicitlyLoaded,
-            bool preserveFormatting)
+            bool? preserveFormatting)
         {
             // Should already have been canonicalized
             ErrorUtilities.VerifyThrowInternalRooted(projectFile);
@@ -204,7 +204,7 @@ namespace Microsoft.Build.Evaluation
                 ProjectRootElement projectRootElement;
                 _weakCache.TryGetValue(projectFile, out projectRootElement);
 
-                if (projectRootElement != null && projectRootElement.XmlDocument.PreserveWhitespace != preserveFormatting)
+                if (preserveFormatting != null && projectRootElement != null && projectRootElement.XmlDocument.PreserveWhitespace != preserveFormatting)
                 {
                     //  Cached project doesn't match preserveFormatting setting, so don't use it
                     projectRootElement = null;
@@ -346,14 +346,14 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal ProjectRootElement TryGet(string projectFile)
         {
-            return TryGet(projectFile, preserveFormatting: false);
+            return TryGet(projectFile, preserveFormatting: null);
         }
 
         /// <summary>
         /// Returns any a ProjectRootElement in the cache with the provided full path,
         /// otherwise null.
         /// </summary>
-        internal ProjectRootElement TryGet(string projectFile, bool preserveFormatting)
+        internal ProjectRootElement TryGet(string projectFile, bool? preserveFormatting)
         {
             ProjectRootElement result = Get(
                 projectFile,

--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -206,8 +206,8 @@ namespace Microsoft.Build.Evaluation
 
                 if (preserveFormatting != null && projectRootElement != null && projectRootElement.XmlDocument.PreserveWhitespace != preserveFormatting)
                 {
-                    //  Cached project doesn't match preserveFormatting setting, so don't use it
-                    projectRootElement = null;
+                    //  Cached project doesn't match preserveFormatting setting, so reload it
+                    projectRootElement.Reload(true, preserveFormatting);
                 }
 
                 if (projectRootElement != null && _autoReloadFromDisk)
@@ -218,7 +218,7 @@ namespace Microsoft.Build.Evaluation
                     // It's an in-memory project that hasn't been saved yet.
                     if (fileInfo != null)
                     {
-                        bool forgetEntry = false;
+                        bool reloadEntry = false;
 
                         if (fileInfo.LastWriteTime != projectRootElement.LastWriteTimeWhenRead)
                         {
@@ -228,7 +228,7 @@ namespace Microsoft.Build.Evaluation
                             // to force a load from disk. There might then exist more than one ProjectRootElement with the same path,
                             // but clients ought not get themselves into such a state - and unless they save them to disk,
                             // it may not be a problem.  
-                            forgetEntry = true;
+                            reloadEntry = true;
                         }
                         else if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDCACHECHECKFILECONTENT")))
                         {
@@ -248,16 +248,14 @@ namespace Microsoft.Build.Evaluation
 
                             if (diskContent != cacheContent)
                             {
-                                forgetEntry = true;
+                                reloadEntry = true;
                             }
                         }
 
-                        if (forgetEntry)
+                        if (reloadEntry)
                         {
-                            ForgetEntry(projectRootElement);
-
-                            DebugTraceCache("Out of date dropped from XML cache: ", projectFile);
-                            projectRootElement = null;
+                            DebugTraceCache("Out of date, reloaded: ", projectFile);
+                            projectRootElement.Reload(true, null);
                         }
                     }
                 }

--- a/src/XMakeBuildEngine/Resources/Strings.resx
+++ b/src/XMakeBuildEngine/Resources/Strings.resx
@@ -1560,13 +1560,28 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="InvalidGetPathOfFileAboveParameter">
     <value>The parameter '{0}' can only be a file name and cannot include a directory.</value>
   </data>
+
+  <data name="FileToReloadFromDoesNotExist">
+    <value>MSB4229: File to reload from does not exist: {0}</value>
+    <comment>{StrBegin="MSB4229: "}</comment>
+  </data>
+
+  <data name="ValueNotSet">
+    <value>MSB4230: Value not set: {0}</value>
+    <comment>{StrBegin="MSB4230: "}</comment>
+  </data>
+
+  <data name="NoReloadOnUnsavedChanges">
+    <value>MSB4231: ProjectRootElement can't reload if it contains unsaved changes.</value>
+    <comment>{StrBegin="MSB4231: "}</comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
         
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4229.
+        Next message code should be MSB4232.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
@@ -129,16 +129,21 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
 
                 ProjectRootElement xml0 = ProjectRootElement.Create(path);
                 xml0.Save();
+                var version0 = xml0.Version;
 
                 cache.AddEntry(xml0);
 
                 ProjectRootElement xml1 = cache.TryGet(path);
-                Assert.Equal(true, Object.ReferenceEquals(xml0, xml1));
+                var version1 = xml1.Version;
+                Assert.Same(xml0, xml1);
+                Assert.Equal(version0, version1);
 
                 File.SetLastWriteTime(path, DateTime.Now + new TimeSpan(1, 0, 0));
 
                 ProjectRootElement xml2 = cache.TryGet(path);
-                Assert.Equal(false, Object.ReferenceEquals(xml0, xml2));
+                var version2 = xml2.Version;
+                Assert.Same(xml0, xml2);
+                Assert.NotEqual(version0, version2);
             }
             finally
             {
@@ -163,16 +168,21 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
 
                 ProjectRootElement xml0 = ProjectRootElement.Create(path);
                 xml0.Save();
+                var version0 = xml0.Version;
 
                 cache.AddEntry(xml0);
 
                 ProjectRootElement xml1 = cache.TryGet(path);
-                Assert.Equal(true, Object.ReferenceEquals(xml0, xml1));
+                var version1 = xml1.Version;
+                Assert.Same(xml0, xml1);
+                Assert.Equal(version0, version1);
 
                 File.SetLastWriteTime(path, DateTime.Now + new TimeSpan(1, 0, 0));
 
                 ProjectRootElement xml2 = cache.TryGet(path);
-                Assert.Equal(true, Object.ReferenceEquals(xml0, xml2));
+                var version2 = xml2.Version;
+                Assert.Same(xml0, xml1);
+                Assert.Equal(version0, version2);
             }
             finally
             {

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
@@ -1648,6 +1648,42 @@ true, true, true)]
         }
 
         [Fact]
+        public void ReloadThrowsForInMemoryProjectsWithoutAPath()
+        {
+            Action<ProjectRootElement, string> act = (p, c) =>
+            {
+                var exception =
+                    Assert.Throws<InvalidOperationException>(
+                        () =>
+                            p.Reload(throwIfUnsavedChanges: false));
+
+                Assert.Contains(@"Value not set:", exception.Message);
+            };
+
+            // reload does not mutate the project element
+            AssertReload(SimpleProject, ComplexProject, false, false, false, act);
+        }
+
+        [Fact]
+        public void ReloadFromAPathThrowsOnMissingPath()
+        {
+            Action<ProjectRootElement, string> act = (p, c) =>
+            {
+                var fullPath = Path.GetFullPath("foo");
+
+                var exception =
+                    Assert.Throws<InvalidOperationException>(
+                        () =>
+                            p.ReloadFrom(fullPath, throwIfUnsavedChanges: false));
+
+                Assert.Contains(@"File to reload from does not exist:", exception.Message);
+            };
+
+            // reload does not mutate the project element
+            AssertReload(SimpleProject, ComplexProject, false, false, false, act);
+        }
+
+        [Fact]
         public void ReloadThrowsOnInvalidMsBuildSyntax()
         {
             var unknownAttribute =

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
@@ -1319,6 +1319,42 @@ Project(""{";
         }
 
         [Theory]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, true)]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(true, null, true)]
+        [InlineData(false, null, false)]
+        public void ReloadCanSpecifyPreserveFormatting(bool initialPreserveFormatting, bool? reloadShouldPreserveFormatting, bool expectedFormattingAfterReload)
+        {
+            using (var testFiles = new Helpers.TestProjectWithFiles("", new[] { "build.proj" }))
+            {
+                var projectFile = testFiles.CreatedFiles.First();
+
+                var projectElement = ObjectModelHelpers.CreateInMemoryProjectRootElement(SimpleProject, null, initialPreserveFormatting);
+                projectElement.Save(projectFile);
+                Assert.Equal(initialPreserveFormatting, projectElement.PreserveFormatting);
+
+                projectElement.Reload(false, reloadShouldPreserveFormatting);
+                Assert.Equal(expectedFormattingAfterReload, projectElement.PreserveFormatting);
+
+                // reset project to original preserve formatting
+                projectElement.Reload(false, initialPreserveFormatting);
+                Assert.Equal(initialPreserveFormatting, projectElement.PreserveFormatting);
+
+                projectElement.ReloadFrom(XmlReader.Create(new StringReader(ObjectModelHelpers.CleanupFileContents(SimpleProject))), false, reloadShouldPreserveFormatting);
+                Assert.Equal(expectedFormattingAfterReload, projectElement.PreserveFormatting);
+
+                // reset project to original preserve formatting
+                projectElement.Reload(false, initialPreserveFormatting);
+                Assert.Equal(initialPreserveFormatting, projectElement.PreserveFormatting);
+
+                projectElement.ReloadFrom(projectFile, false, reloadShouldPreserveFormatting);
+                Assert.Equal(expectedFormattingAfterReload, projectElement.PreserveFormatting);
+            }
+        }
+
+        [Theory]
 
         // same content should still dirty the project
         [InlineData(
@@ -1551,7 +1587,7 @@ true, true, true)]
 
 </Project>");
 
-            using (var testFiles = new Helpers.TestProjectWithFiles("null", new []{"build.proj"}))
+            using (var testFiles = new Helpers.TestProjectWithFiles("", new []{"build.proj"}))
             using (var projectCollection1 = new ProjectCollection())
             using (var projectCollection2 = new ProjectCollection())
             {

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
@@ -32,6 +32,61 @@ namespace Microsoft.Build.UnitTests.OM.Construction
     /// </summary>
     public class ProjectRootElement_Tests
     {
+        private const string SimpleProject = 
+@"<Project xmlns=`msbuildnamespace`>
+
+  <PropertyGroup>
+    <P>property value</P>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <i Include=`a`>
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>";
+
+        private const string ComplexProject =
+@"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
+    <PropertyGroup Condition=""false"">
+        <p>p1</p>
+        <q>q1</q>
+    </PropertyGroup>
+    <PropertyGroup/>
+    <PropertyGroup>
+        <r>r1</r>
+    </PropertyGroup>
+    <Choose>
+        <When Condition=""true"">
+            <Choose>
+                <When Condition=""true"">
+                    <PropertyGroup>
+                        <s>s1</s>
+                    </PropertyGroup>
+                </When>
+            </Choose>
+        </When>
+        <When Condition=""false"">
+            <PropertyGroup>
+                <s>s2</s> <!-- both esses -->
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <Choose>
+                <When Condition=""false""/>
+                <Otherwise>
+                    <PropertyGroup>
+                        <t>t1</t>
+                    </PropertyGroup>
+                </Otherwise>
+            </Choose>
+        </Otherwise>
+    </Choose>
+    <Import Project='$(MSBuildToolsPath)\microsoft.csharp.targets'/>
+</Project>";
+
         /// <summary>
         /// Empty project content
         /// </summary>
@@ -1263,6 +1318,420 @@ Project(""{";
             Assert.Null(ProjectRootElement.TryOpen(projectXml.FullPath, collection, preserveFormatting: false));
         }
 
+        [Theory]
+
+        // same content should still dirty the project
+        [InlineData(
+SimpleProject,
+SimpleProject,
+true, false, false)]
+
+        // new comment
+        [InlineData(
+@"<Project xmlns=`msbuildnamespace`>
+
+  <PropertyGroup>
+    <P>property value</P>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <i Include=`a`>
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>",
+@"
+<!-- new comment -->
+<Project xmlns=`msbuildnamespace`>
+  <PropertyGroup>
+    <P><!-- new comment -->property value<!-- new comment --></P>
+  </PropertyGroup>
+  
+  <!-- new comment -->
+  <ItemGroup>
+    <i Include=`a`>
+      <!-- new comment -->
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>",
+true, false, true)]
+
+        // changed comment
+        [InlineData(
+@"
+<!-- new comment -->
+<Project xmlns=`msbuildnamespace`>
+  <PropertyGroup>
+    <P><!-- new comment -->property value<!-- new comment --></P>
+  </PropertyGroup>
+  
+  <!-- new comment -->
+  <ItemGroup>
+    <i Include=`a`>
+      <!-- new comment -->
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>",
+@"
+<!-- changed comment -->
+<Project xmlns=`msbuildnamespace`>
+  <PropertyGroup>
+    <P><!-- changed comment -->property value<!-- changed comment --></P>
+  </PropertyGroup>
+  
+  <!-- changed comment -->
+  <ItemGroup>
+    <i Include=`a`>
+      <!-- changed comment -->
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>",
+true, false, true)]
+
+        // deleted comment
+        [InlineData(
+@"
+<!-- new comment -->
+<Project xmlns=`msbuildnamespace`>
+  <PropertyGroup>
+    <P><!-- new comment -->property value<!-- new comment --></P>
+  </PropertyGroup>
+  
+  <!-- new comment -->
+  <ItemGroup>
+    <i Include=`a`>
+      <!-- new comment -->
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>",
+@"
+<Project xmlns=`msbuildnamespace`>
+  <PropertyGroup>
+    <P>property value</P>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <i Include=`a`>
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>",
+true, false, true)]
+
+        // new comments and changed code
+        [InlineData(
+@"<Project xmlns=`msbuildnamespace`>
+
+  <PropertyGroup>
+    <P>property value</P>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <i Include=`a`>
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>",
+@"
+<!-- new comment -->
+<Project xmlns=`msbuildnamespace`>
+  <PropertyGroup>
+    <P>property value</P>
+    <P2><!-- new comment -->property value<!-- new comment --></P2>
+  </PropertyGroup>
+
+</Project>",
+true, true, true)]
+
+        // commented out code
+        [InlineData(
+@"<Project xmlns=`msbuildnamespace`>
+
+  <PropertyGroup>
+    <P>property value</P>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <i Include=`a`>
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>",
+@"<Project xmlns=`msbuildnamespace`>
+  <PropertyGroup>
+    <P>property value</P>
+  </PropertyGroup>
+
+<!--
+  <ItemGroup>
+    <i Include=`a`>
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+-->
+</Project>",
+true, true, true)]
+        public void ReloadRespectsNewContents(string initialProjectContents, string changedProjectContents, bool versionChanged, bool msbuildChildrenChanged, bool xmlChanged)
+        {
+            Action<ProjectRootElement, string> act = (p, c) =>
+            {
+                p.ReloadFrom(
+                    XmlReader.Create(new StringReader(c)),
+                    throwIfUnsavedChanges: false);
+            };
+
+            AssertReload(initialProjectContents, changedProjectContents, versionChanged, msbuildChildrenChanged, xmlChanged, act);
+        }
+
+        [Fact]
+        public void ReloadedStateIsResilientToChangesAndDiskRoundtrip()
+        {
+            var initialProjectContents = ObjectModelHelpers.CleanupFileContents(
+@"
+<!-- new comment -->
+<Project xmlns=`msbuildnamespace`>
+
+  <!-- new comment -->
+  <ItemGroup>
+    <i Include=`a`>
+      <!-- new comment -->
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>");
+
+            var changedProjectContents1 = ObjectModelHelpers.CleanupFileContents(
+@"
+<!-- changed comment -->
+<Project xmlns=`msbuildnamespace`>
+  
+  <!-- changed comment -->
+  <ItemGroup>
+
+    <i Include=`a`>
+         <!-- changed comment -->
+           <m>metadata value</m>
+    </i>
+
+  </ItemGroup>
+
+</Project>");
+
+            var changedProjectContents2 = ObjectModelHelpers.CleanupFileContents(
+// spurious comment placement issue: https://github.com/Microsoft/msbuild/issues/1503
+@"
+<!-- changed comment -->
+<Project xmlns=`msbuildnamespace`>
+  
+  <!-- changed comment -->
+  <PropertyGroup>
+    <P>v</P>
+  </PropertyGroup>
+  <ItemGroup>
+
+    <i Include=`a`>
+         <!-- changed comment -->
+           <m>metadata value</m>
+    </i>
+
+  </ItemGroup>
+
+</Project>");
+
+            using (var testFiles = new Helpers.TestProjectWithFiles("null", new []{"build.proj"}))
+            using (var projectCollection1 = new ProjectCollection())
+            using (var projectCollection2 = new ProjectCollection())
+            {
+                var projectPath = testFiles.CreatedFiles.First();
+
+                var projectElement = ObjectModelHelpers.CreateInMemoryProjectRootElement(initialProjectContents, projectCollection1, preserveFormatting: true);
+                projectElement.Save(projectPath);
+
+                projectElement.ReloadFrom(XmlReader.Create(new StringReader(changedProjectContents1)));
+
+                VerifyAssertLineByLine(changedProjectContents1, projectElement.RawXml);
+
+                projectElement.AddProperty("P", "v");
+
+                VerifyAssertLineByLine(changedProjectContents2, projectElement.RawXml);
+
+                projectElement.Save();
+
+                var projectElement2 = ProjectRootElement.Open(projectPath, projectCollection2, preserveFormatting: true);
+
+                VerifyAssertLineByLine(changedProjectContents2, projectElement2.RawXml);
+            }
+        }
+
+        [Fact]
+        public void ReloadThrowsOnInvalidXmlSyntax()
+        {
+            var missingClosingTag =
+@"<Project xmlns=`msbuildnamespace`>
+
+  <PropertyGroup>
+    <P>property value</P>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <i Include=`a`>
+      <m>metadata value<m>
+    </i>
+  </ItemGroup>
+
+</Project>";
+
+            Action<ProjectRootElement, string> act = (p, c) =>
+            {
+                var exception =
+                    Assert.Throws<InvalidProjectFileException>(
+                        () =>
+                            p.ReloadFrom(
+                                XmlReader.Create(
+                                    new StringReader(c)),
+                                throwIfUnsavedChanges: false));
+
+                Assert.Contains(@"The project file could not be loaded. The 'm' start tag on line", exception.Message);
+            };
+
+            // reload does not mutate the project element
+            AssertReload(SimpleProject, missingClosingTag, false, false, false, act);
+        }
+
+        [Fact]
+        public void ReloadThrowsOnInvalidMsBuildSyntax()
+        {
+            var unknownAttribute =
+@"<Project xmlns=`msbuildnamespace`>
+
+  <PropertyGroup Foo=`bar`>
+    <P>property value</P>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <i Include=`a`>
+      <m>metadata value</m>
+    </i>
+  </ItemGroup>
+
+</Project>";
+
+            Action<ProjectRootElement, string> act = (p, c) =>
+            {
+                var exception =
+                    Assert.Throws<InvalidProjectFileException>(
+                        () =>
+                            p.ReloadFrom(
+                                XmlReader.Create(
+                                    new StringReader(c)),
+                                throwIfUnsavedChanges: false));
+
+                Assert.Contains(@"The attribute ""Foo"" in element <PropertyGroup> is unrecognized", exception.Message);
+            };
+
+            // reload does not mutate the project element
+            AssertReload(SimpleProject, unknownAttribute, false, false, false, act);
+        }
+
+        [Fact]
+        public void ReloadThrowsByDefaultIfThereAreUnsavedChanges()
+        {
+            Action<ProjectRootElement, string> act = (p, c) =>
+            {
+                var exception =
+                    Assert.Throws<InvalidOperationException>(
+                        () =>
+                            p.ReloadFrom(
+                                XmlReader.Create(
+                                    new StringReader(c))));
+
+                Assert.Contains(@"ProjectRootElement can't reload if it contains unsaved changes.", exception.Message);
+            };
+
+            // reload does not mutate the project element
+            AssertReload(SimpleProject, ComplexProject, false, false, false, act);
+        }
+
+        [Fact]
+        public void ReloadCanOverwriteUnsavedChanges()
+        {
+            Action<ProjectRootElement, string> act = (p, c) =>
+            {
+                p.ReloadFrom(
+                    XmlReader.Create(new StringReader(ObjectModelHelpers.CleanupFileContents(c))),
+                    throwIfUnsavedChanges: false);
+            };
+
+            AssertReload(SimpleProject, ComplexProject, true, true, true, act);
+        }
+
+        private void AssertReload(
+            string initialContents,
+            string changedContents,
+            bool versionChanged,
+            bool msbuildChildrenChanged,
+            bool xmlChanged,
+            Action<ProjectRootElement, string> act)
+        {
+            var projectElement = ObjectModelHelpers.CreateInMemoryProjectRootElement(initialContents);
+
+            var version = projectElement.Version;
+            var childrenCount = projectElement.AllChildren.Count();
+            var xml = projectElement.RawXml;
+
+            Assert.True(projectElement.HasUnsavedChanges);
+            act(projectElement, ObjectModelHelpers.CleanupFileContents(changedContents));
+
+            if (versionChanged)
+            {
+                Assert.NotEqual(version, projectElement.Version);
+            }
+            else
+            {
+                Assert.Equal(version, projectElement.Version);
+            }
+
+            if (msbuildChildrenChanged)
+            {
+                Assert.NotEqual(childrenCount, projectElement.AllChildren.Count());
+            }
+            else
+            {
+                Assert.Equal(childrenCount, projectElement.AllChildren.Count());
+            }
+
+
+            if (xmlChanged)
+            {
+                Assert.NotEqual(xml, projectElement.RawXml);
+            }
+            else
+            {
+                Assert.Equal(xml, projectElement.RawXml);
+            }
+        }
+
+        private static string SaveToString(ProjectRootElement project)
+        {
+            var writer = new EncodingStringWriter();
+            project.Save(writer);
+
+            return writer.ToString();
+        }
+
         /// <summary>
         /// Test helper for validating that DeepClone and CopyFrom work as advertised.
         /// </summary>
@@ -1339,49 +1808,16 @@ Project(""{";
         /// </summary>
         private ProjectRootElement CreatePREWithSubstantialContent()
         {
-            string content = ObjectModelHelpers.CleanupFileContents(
-      @"<?xml version=""1.0"" encoding=""utf-16""?>
-                    <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
-                        <PropertyGroup Condition=""false"">
-                            <p>p1</p>
-                            <q>q1</q>
-                        </PropertyGroup>
-                        <PropertyGroup/>
-                        <PropertyGroup>
-                            <r>r1</r>
-                        </PropertyGroup>
-                        <Choose>
-                            <When Condition=""true"">
-                                <Choose>
-                                    <When Condition=""true"">
-                                        <PropertyGroup>
-                                            <s>s1</s>
-                                        </PropertyGroup>
-                                    </When>
-                                </Choose>
-                            </When>
-                            <When Condition=""false"">
-                                <PropertyGroup>
-                                    <s>s2</s> <!-- both esses -->
-                                </PropertyGroup>
-                            </When>
-                            <Otherwise>
-                                <Choose>
-                                    <When Condition=""false""/>
-                                    <Otherwise>
-                                        <PropertyGroup>
-                                            <t>t1</t>
-                                        </PropertyGroup>
-                                    </Otherwise>
-                                </Choose>
-                            </Otherwise>
-                        </Choose>
-                        <Import Project='$(MSBuildToolsPath)\microsoft.csharp.targets'/>
-                    </Project>");
+            string content = ObjectModelHelpers.CleanupFileContents(ComplexProject);
 
             ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
 
             return project;
+        }
+
+        private void VerifyAssertLineByLine(string expected, string actual)
+        {
+            Helpers.VerifyAssertLineByLine(expected, actual, false);
         }
     }
 }

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -1441,7 +1441,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
         
         /// <summary>
-        /// Adding an import to an existing PRE object and re-valuating should preserve the initial import PRE object
+        /// Adding an import to an existing PRE object and re-evaluating should preserve the initial import PRE object
         /// </summary>
         [Fact]
         public void ImportingExistingPREObjectShouldPreserveTheObject()


### PR DESCRIPTION
This would enable IDEs to keep reloading a ProjectRootElement when the user changes the file instead of doing reference swapping or relying on `DeepCopyFrom` / `DeepClone` which do not preserve XML trivia (whitespace and comments).

This helps address #1442 and #1472.

Unclear points to discuss, probably best left for a future PR:
- Should the ProjectRootElementCache reload instead of forgetting entries when the white space preservation missmatches or `autoReloadFromDisk` is true?
  - pros
    - references stay the same so no weird stale issues (e.g. an evaluated Project gets stale if the Cache decides to forget the ProjectRootElements the Project references, and would stop receiving changed events.). An alternative to this is to forget entries but pipe through new events so evaluated projects swap their references.
  - cons
    - the Cache would throw the exceptions Reload throws, potentially breaking a lot of stuff that relies on `ProjectCollection` :). For example, all in-memory ProjectRootElements with a path would throw on Reload because their paths are not yet materialized. Or if there's syntax error, etc.