### PR TITLE
Enable build summary text for more scenarios.

### DIFF
--- a/src/XMakeBuildEngine/Logging/BaseConsoleLogger.cs
+++ b/src/XMakeBuildEngine/Logging/BaseConsoleLogger.cs
@@ -1020,7 +1020,13 @@ namespace Microsoft.Build.BackEnd.Logging
 
             if (showOnlyWarnings || showOnlyErrors)
             {
-                _showSummary = false;
+                if (!_showSummary.HasValue)
+                {
+                    // By default don't show the summary when the showOnlyWarnings / showOnlyErrors is specified.
+                    // However, if the user explicitly specified summary or nosummary, use that.
+                    _showSummary = false;
+                }
+
                 this.showPerfSummary = false;
             }
 


### PR DESCRIPTION
Always show the Time Elapsed and Build Succeeded text whenever the user
specifies the 'summary' console property flag regardless of log verbosity
or presence of the ErrorsOnly / WarningsOnly flags.

Closes #1513