### PR TITLE
Ensure BaseIntermediateOutputPath has a trailing slash when set by user

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -323,6 +323,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <AutoUnifyAssemblyReferences Condition="'$(GenerateBindingRedirectsOutputType)' == 'true' and '$(AutoGenerateBindingRedirects)' != 'true'">false</AutoUnifyAssemblyReferences>
   </PropertyGroup>
   <PropertyGroup>
+    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
     <CleanFile Condition="'$(CleanFile)'==''">$(MSBuildProjectFile).FileListAbsolute.txt</CleanFile>
     <!-- During DesignTime Builds, skip project reference build as Design time is only queueing information.-->
     <BuildProjectReferences Condition="'$(BuildProjectReferences)' == '' and '$(DesignTimeBuild)' == 'true'">false</BuildProjectReferences>

--- a/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ProjectExtensionsTargetsImportTest.cs" />
     <Compile Include="PropertyParser_Tests.cs" />
     <Compile Include="ReadLinesFromFile_Tests.cs" />
+    <Compile Include="RegressionTests.cs" />
     <Compile Include="RemoveDir_Tests.cs" />
     <Compile Include="RemoveDuplicates_Tests.cs" />
     <Compile Include="ResolveCodeAnalysisRuleSet_Tests.cs" />

--- a/src/XMakeTasks/UnitTests/RegressionTests.cs
+++ b/src/XMakeTasks/UnitTests/RegressionTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.UnitTests;
+using Xunit;
+
+namespace Microsoft.Build.Tasks.UnitTests
+{
+    public sealed class RegressionTests
+    {
+        /// <summary>
+        /// Verifies that when a user overrides the BaseIntermediateOutputPath that the build still works.
+        /// </summary>
+        /// <remarks>This was written because of regression https://github.com/Microsoft/msbuild/issues/1509. </remarks>
+        [Fact]
+        public void OverrideBaseIntermediateOutputPathSucceeds()
+        {
+            Project project = ObjectModelHelpers.CreateInMemoryProject($@"
+                <Project DefaultTargets=""Build"" xmlns=""msbuildnamespace"" ToolsVersion=""msbuilddefaulttoolsversion"">
+                    <Import Project=""$(MSBuildToolsPath)\Microsoft.Common.props"" />
+
+                    <PropertyGroup>
+                        <BaseIntermediateOutputPath>obj\x86\Debug</BaseIntermediateOutputPath>
+                    </PropertyGroup>
+
+                    <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
+
+                    <Target Name=""Build"" />
+                </Project>
+                ");
+
+            bool result = project.Build();
+
+            Assert.True(result);
+        }
+    }
+}


### PR DESCRIPTION
We used to ensure the trailing slash in common targets but I moved this to common props.  This however broke the scenario when a user sets the property since the trailing slash is not ensured and the _CheckForInvalidConfigurationAndPlatform target would then fail.

I also introduced a unit test to ensure this doesn't regress again.

Closes #1509