### PR TITLE
Cache IsMono call

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -454,13 +454,6 @@ namespace Microsoft.Build.Shared
 
         #region Member data
 
-        static NativeMethodsShared()
-        {
-            // There could be potentially expensive TypeResolve events, so cache IsMono.
-            // Also, VS does not host Mono runtimes, so turn IsMono off when msbuild is running under VS
-            IsMono = !BuildEnvironmentHelper.Instance.RunningInVisualStudio && Type.GetType("Mono.Runtime") != null;
-        }
-
         /// <summary>
         /// Default buffer size to use when dealing with the Windows API.
         /// </summary>
@@ -501,10 +494,19 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        private static readonly Lazy<bool> _isMonoLazy = new Lazy<bool>(
+            () =>
+            {
+                // There could be potentially expensive TypeResolve events, so cache IsMono.
+                // Also, VS does not host Mono runtimes, so turn IsMono off when msbuild is running under VS
+                return !BuildEnvironmentHelper.Instance.RunningInVisualStudio && Type.GetType("Mono.Runtime") != null;
+            },
+            true);
+
         /// <summary>
         /// Gets a flag indicating if we are running under MONO
         /// </summary>
-        internal static bool IsMono { get; private set; }
+        internal static bool IsMono => _isMonoLazy.Value;
 
         /// <summary>
         /// Gets a flag indicating if we are running under some version of Windows

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -456,8 +456,9 @@ namespace Microsoft.Build.Shared
 
         static NativeMethodsShared()
         {
-            // VS has potentially expensive TypeResolve events, so cache IsMono
-            IsMono = Type.GetType("Mono.Runtime") != null;
+            // There could be potentially expensive TypeResolve events, so cache IsMono.
+            // Also, VS does not host Mono runtimes, so turn IsMono off when msbuild is running under VS
+            IsMono = !BuildEnvironmentHelper.Instance.RunningInVisualStudio && Type.GetType("Mono.Runtime") != null;
         }
 
         /// <summary>

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -454,6 +454,12 @@ namespace Microsoft.Build.Shared
 
         #region Member data
 
+        static NativeMethodsShared()
+        {
+            // VS has potentially expensive TypeResolve events, so cache IsMono
+            IsMono = Type.GetType("Mono.Runtime") != null;
+        }
+
         /// <summary>
         /// Default buffer size to use when dealing with the Windows API.
         /// </summary>
@@ -497,13 +503,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Gets a flag indicating if we are running under MONO
         /// </summary>
-        internal static bool IsMono
-        {
-            get
-            {
-                return Type.GetType("Mono.Runtime") != null;
-            }
-        }
+        internal static bool IsMono { get; private set; }
 
         /// <summary>
         /// Gets a flag indicating if we are running under some version of Windows

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -52,8 +52,14 @@
     <Compile Include="..\..\Shared\ResourceUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\..\Shared\VisualStudioLocationHelper.cs">
+      <Link>VisualStudioLocationHelper.cs</Link>
+    </Compile>
     <Compile Include="AssemblyResources.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="..\..\Shared\BuildEnvironmentHelper.cs">
+      <Link>BuildEnvironmentHelper.cs</Link>
     </Compile>
     <Compile Include="..\..\Shared\InternalErrorException.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/project.json
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/project.json
@@ -11,7 +11,8 @@
   "frameworks": {
     "net46": {
       "dependencies": {
-        "xunit.runner.visualstudio": "2.1.0"
+        "xunit.runner.visualstudio": "2.1.0",
+        "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
       }
     },
     "netstandard1.3": {


### PR DESCRIPTION
VS has potentially expensive TypeResolve events, so cache IsMono. Apparently the c++ side of things even triggers a design time build during some TypeResolve calls.