### PR TITLE
Binplace System.Collections.Immutable to Output

### DIFF
--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -772,6 +772,9 @@
          but it won't be placed there by default because NuGet references come in as CopyLocal false.
 
          Work around this by munging the reference after NuGet emits it but before RAR.
+
+         TODO: this shouldn't be here. After moving to a better binplacing model (like "publish
+         msbuild.exe to a folder") it should be removed.
     -->
     <ItemGroup>
       <Reference Condition="'%(Reference.NuGetPackageId)' == 'System.Collections.Immutable'">

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -766,4 +766,17 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="!$(Configuration.EndsWith('MONO'))"/>
   -->
   <Import Project="..\dir.targets" />
+  <Target Name="CopyImmutableLocal"
+          BeforeTargets="ResolveAssemblyReferences">
+    <!-- The VSIX installer manifest references System.Collections.Immutable from the Output folder,
+         but it won't be placed there by default because NuGet references come in as CopyLocal false.
+
+         Work around this by munging the reference after NuGet emits it but before RAR.
+    -->
+    <ItemGroup>
+      <Reference Condition="'%(Reference.NuGetPackageId)' == 'System.Collections.Immutable'">
+        <Private>true</Private>
+      </Reference>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
This file is required by the VSIX builder, and was placed in Output as
part of the transitive dependencies of
Microsoft.Build.Tasks.CodeAnalysis, but more recent versions don't have
that dependency, so it wasn't getting placed.

Added a workaround to ensure that Immutable appears in the folder.