### PR TITLE
Avoid .NET Core 1.1 dependencies for Core

### DIFF
--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -14,7 +14,7 @@
         "System.Reflection.TypeExtensions": "4.1.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Runtime.Serialization.Xml": "4.1.1",
-        "System.Security.Cryptography.X509Certificates": "4.3.0",
+        "System.Security.Cryptography.X509Certificates": "4.1.0",
         "System.Threading.Thread": "4.0.0",
         "System.Xml.XmlDocument": "4.0.1"
       }

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/project.json
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/project.json
@@ -5,13 +5,13 @@
     "xunit.extensibility.core": "2.1.0",
     "xunit.assert": "2.1.0",
     "xunit.abstractions": "2.0.0",
-    "microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00629-09",
-    "System.Collections.Immutable": "1.3.1"
+    "microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00629-09"
   },
   "frameworks": {
     "net46": {
       "dependencies": {
-        "xunit.runner.visualstudio": "2.1.0"
+        "xunit.runner.visualstudio": "2.1.0",
+        "System.Collections.Immutable": "1.3.1"
       }
     },
     "netstandard1.3": {
@@ -19,11 +19,12 @@
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "Microsoft.NETCore": "5.0.1",
         "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+        "System.Collections.Immutable": "1.2.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Console": "4.0.0",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TraceSource": "4.0.0",
-        "System.Security.Cryptography.X509Certificates": "4.3.0",
+        "System.Security.Cryptography.X509Certificates": "4.1.0",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",
         "System.Xml.XmlDocument": "4.0.1",

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -1,16 +1,17 @@
 ﻿{
   "dependencies": {
-    "System.Collections.Immutable": "1.3.1"
   },
   "frameworks": {
     "net46": {
       "dependencies": {
-        "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
+        "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
+        "System.Collections.Immutable": "1.3.1"
       }
     },
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "System.Collections.Immutable": "1.2.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Diagnostics.Contracts": "4.0.1",
         "System.Diagnostics.FileVersionInfo": "4.0.0",

--- a/src/XMakeTasks/project.json
+++ b/src/XMakeTasks/project.json
@@ -1,17 +1,16 @@
 ﻿{
-  "dependencies": {
-    "System.Collections.Immutable": "1.3.1"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {
-        "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5",
-        "System.Reflection.Metadata":   "1.3.0"
+        "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
+        "System.Collections.Immutable": "1.3.1",
+        "System.Reflection.Metadata": "1.3.0"
       }
     },
     "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "System.Collections.Immutable": "1.2.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TraceSource": "4.0.0",
@@ -21,7 +20,7 @@
         "System.Resources.Writer": "4.0.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Runtime.Serialization.Xml": "4.1.1",
-        "System.Security.Cryptography.Algorithms" : "4.3.0",
+        "System.Security.Cryptography.Algorithms": "4.2.0",
         "System.Threading.Thread": "4.0.0",
         "System.Xml.XmlDocument": "4.0.1"
       }

--- a/targets/runtimeDependencies/project.json
+++ b/targets/runtimeDependencies/project.json
@@ -10,13 +10,13 @@
     "xunit": "2.1.0",
     "microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00629-09",
     "System.IO.FileSystem": "4.0.1",
-    "System.IO.Compression": "4.1.0",
-    "System.Collections.Immutable": "1.3.1"
+    "System.IO.Compression": "4.1.0"
   },
   "frameworks": {
     "net46": {
       "dependencies": {
         "xunit.runner.visualstudio": "2.1.0",
+        "System.Collections.Immutable": "1.3.1",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Threading.Tasks.Dataflow": "4.6.0",
         "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01"
@@ -24,7 +24,7 @@
     },
     "netcoreapp1.0": {
       "dependencies": {
-        "System.Security.Cryptography.X509Certificates": "4.3.0",
+        "System.Security.Cryptography.X509Certificates": "4.1.0",
         "System.Net.NetworkInformation": "4.1.0",
         "Microsoft.NETCore": "5.0.1",
         "Microsoft.NETCore.Portable.Compatibility": "1.0.1",


### PR DESCRIPTION
Upgrading dependencies across the board as a consequence of taking the
Roslyn + System.Collections.Immutable update in #1522 updated too much,
causing breakage in dotnet CLI. See dotnet/cli#5266 for some discussion.

This commit attempts to keep the dependencies for .NET Core MSBuild
identical to what they were before while still taking the
System.Collections.Immutable update for Full Framework that's required to
avoid a VS perf hit.