### PR TITLE
Drop + reload changed projects in worker nodes

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Build.Evaluation
                     // It's an in-memory project that hasn't been saved yet.
                     if (fileInfo != null)
                     {
-                        bool reloadEntry = false;
+                        bool forgetEntry = false;
 
                         if (fileInfo.LastWriteTime != projectRootElement.LastWriteTimeWhenRead)
                         {
@@ -228,7 +228,7 @@ namespace Microsoft.Build.Evaluation
                             // to force a load from disk. There might then exist more than one ProjectRootElement with the same path,
                             // but clients ought not get themselves into such a state - and unless they save them to disk,
                             // it may not be a problem.  
-                            reloadEntry = true;
+                            forgetEntry = true;
                         }
                         else if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDCACHECHECKFILECONTENT")))
                         {
@@ -248,14 +248,16 @@ namespace Microsoft.Build.Evaluation
 
                             if (diskContent != cacheContent)
                             {
-                                reloadEntry = true;
+                                forgetEntry = true;
                             }
                         }
 
-                        if (reloadEntry)
+                        if (forgetEntry)
                         {
-                            DebugTraceCache("Out of date, reloaded: ", projectFile);
-                            projectRootElement.Reload(true, null);
+                            ForgetEntry(projectRootElement);
+
+                            DebugTraceCache("Out of date dropped from XML cache: ", projectFile);
+                            projectRootElement = null;
                         }
                     }
                 }

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
@@ -129,21 +129,16 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
 
                 ProjectRootElement xml0 = ProjectRootElement.Create(path);
                 xml0.Save();
-                var version0 = xml0.Version;
 
                 cache.AddEntry(xml0);
 
                 ProjectRootElement xml1 = cache.TryGet(path);
-                var version1 = xml1.Version;
-                Assert.Same(xml0, xml1);
-                Assert.Equal(version0, version1);
+                Assert.Equal(true, Object.ReferenceEquals(xml0, xml1));
 
                 File.SetLastWriteTime(path, DateTime.Now + new TimeSpan(1, 0, 0));
 
                 ProjectRootElement xml2 = cache.TryGet(path);
-                var version2 = xml2.Version;
-                Assert.Same(xml0, xml2);
-                Assert.NotEqual(version0, version2);
+                Assert.Equal(false, Object.ReferenceEquals(xml0, xml2));
             }
             finally
             {
@@ -168,21 +163,16 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
 
                 ProjectRootElement xml0 = ProjectRootElement.Create(path);
                 xml0.Save();
-                var version0 = xml0.Version;
 
                 cache.AddEntry(xml0);
 
                 ProjectRootElement xml1 = cache.TryGet(path);
-                var version1 = xml1.Version;
-                Assert.Same(xml0, xml1);
-                Assert.Equal(version0, version1);
+                Assert.Equal(true, Object.ReferenceEquals(xml0, xml1));
 
                 File.SetLastWriteTime(path, DateTime.Now + new TimeSpan(1, 0, 0));
 
                 ProjectRootElement xml2 = cache.TryGet(path);
-                var version2 = xml2.Version;
-                Assert.Same(xml0, xml1);
-                Assert.Equal(version0, version2);
+                Assert.Equal(true, Object.ReferenceEquals(xml0, xml2));
             }
             finally
             {


### PR DESCRIPTION
This is related to
https://devdiv.visualstudio.com/DevDiv/_workitems?id=366048 and
https://devdiv.visualstudio.com/DevDiv/_workitems?id=366077, and
possibly #1526.

In those bugs, a worker node is started and given build requests for the
same project while that project changes on disk. The first build works
(fresh load in the worker node). The second build works (content is
reloaded). But the third one fails--it throws because the project "has
unsaved changes" when it's trying to reload it again. That failure isn't
well communicated back to the main node, so this tends to not log
anything and just abruptly fail the build.

To fix this, I'm reverting the part of #1507 that hit in the worker
node--the only place where `_autoReloadFromDisk` is set to true in the
current world. Instead of using the new `Reload`, we just drop the
`ProjectRootElement from` the cache and load it from scratch, as was
done before.