### PR TITLE
[DO_NOT_MERGE] cibuild.sh: Fix mono build on non-windows platforms

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -316,8 +316,13 @@ fi
 
 # Microsoft.Net.Compilers package is available now, so we can use the latest csc.exe
 if [ "$host" = "Mono" ]; then
-        CSC_EXE="$PACKAGES_DIR/microsoft.net.compilers/2.0.0-rc3-61110-06/tools/csc.exe"
-        CSC_ARGS="/p:CscToolExe=csc.exe /p:CscToolPath=`dirname $CSC_EXE` /p:DebugType=portable"
+    # The compiler includes the net46 version of System.Runtime.InteropServices.RuntimeInformation,
+    # which is compiled for Windows, breaking csc.exe. Deleting the binary will cause Mono's platform
+    # specific assembly to be used
+    rm $PACKAGES_DIR/microsoft.net.compilers/2.0.0-rc3-61110-06/tools/System.Runtime.InteropServices.RuntimeInformation.dll
+
+    CSC_EXE="$PACKAGES_DIR/microsoft.net.compilers/2.0.0-rc3-61110-06/tools/csc.exe"
+    CSC_ARGS="/p:CscToolExe=csc.exe /p:CscToolPath=`dirname $CSC_EXE` /p:DebugType=portable"
 fi
 
 # The set of warnings to suppress for now


### PR DESCRIPTION
The compiler includes the net46 version of System.Runtime.InteropServices.RuntimeInformation,
which is compiled for Windows, breaking csc.exe. Deleting the binary will cause Mono's platform
specific assembly to be used.

The issue manifested as (eg. on CI server):

  Unhandled Exception: (TaskId:33)
  System.NotImplementedException: The method or operation is not implemented. (TaskId:33)
    at Microsoft.CodeAnalysis.CommonCompiler.Run (System.IO.TextWriter consoleOutput, System.Threading.CancellationToken cancellationToken) [0x00012] in <f2694baa22dd413c8e7d818913b0daf9>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Csc+<>c__DisplayClass1_0.<Run>b__0 (System.IO.TextWriter tw) [0x00000] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.ConsoleUtil.RunWithUtf8Output[T] (System.Func`2[T,TResult] func) [0x0001c] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.ConsoleUtil.RunWithUtf8Output[T] (System.Boolean utf8Output, System.IO.TextWriter textWriter, System.Func`2[T,TResult] func) [0x00016] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Csc.Run (System.String[] args, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter, Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader analyzerLoader) [0x00048] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at (wrapper delegate-invoke) <Module>:invoke_int_string[]_BuildPaths_TextWriter_IAnalyzerAssemblyLoader (string[],Microsoft.CodeAnalysis.BuildPaths,System.IO.TextWriter,Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader) (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.DesktopBuildClient.RunLocalCompilation (System.String[] arguments, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter) [0x00000] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.BuildClient.RunCompilation (System.Collections.Generic.IEnumerable`1[T] originalArguments, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter) [0x0009d] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.DesktopBuildClient.Run (System.Collections.Generic.IEnumerable`1[T] arguments, System.Collections.Generic.IEnumerable`1[T] extraArguments, Microsoft.CodeAnalysis.CommandLine.RequestLanguage language, Microsoft.CodeAnalysis.CommandLine.CompileFunc compileFunc, Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader analyzerAssemblyLoader) [0x0003e] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Program.Main (System.String[] args, System.String[] extraArgs) [0x00018] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Program.Main (System.String[] args) [0x00006] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
   (TaskId:33)
  Unhandled Exception: (TaskId:33)
  System.NotImplementedException: The method or operation is not implemented. (TaskId:33)
    at Microsoft.CodeAnalysis.CommonCompiler.Run (System.IO.TextWriter consoleOutput, System.Threading.CancellationToken cancellationToken) [0x0007b] in <f2694baa22dd413c8e7d818913b0daf9>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Csc+<>c__DisplayClass1_0.<Run>b__0 (System.IO.TextWriter tw) [0x00000] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.ConsoleUtil.RunWithUtf8Output[T] (System.Func`2[T,TResult] func) [0x0001c] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.ConsoleUtil.RunWithUtf8Output[T] (System.Boolean utf8Output, System.IO.TextWriter textWriter, System.Func`2[T,TResult] func) [0x00016] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Csc.Run (System.String[] args, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter, Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader analyzerLoader) [0x00048] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at (wrapper delegate-invoke) <Module>:invoke_int_string[]_BuildPaths_TextWriter_IAnalyzerAssemblyLoader (string[],Microsoft.CodeAnalysis.BuildPaths,System.IO.TextWriter,Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader) (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.DesktopBuildClient.RunLocalCompilation (System.String[] arguments, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter) [0x00000] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.BuildClient.RunCompilation (System.Collections.Generic.IEnumerable`1[T] originalArguments, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter) [0x0009d] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.DesktopBuildClient.Run (System.Collections.Generic.IEnumerable`1[T] arguments, System.Collections.Generic.IEnumerable`1[T] extraArguments, Microsoft.CodeAnalysis.CommandLine.RequestLanguage language, Microsoft.CodeAnalysis.CommandLine.CompileFunc compileFunc, Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader analyzerAssemblyLoader) [0x0003e] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Program.Main (System.String[] args, System.String[] extraArgs) [0x00018] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Program.Main (System.String[] args) [0x00006] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
  [ERROR] FATAL UNHANDLED EXCEPTION: System.NotImplementedException: The method or operation is not implemented. (TaskId:33)
    at Microsoft.CodeAnalysis.CommonCompiler.Run (System.IO.TextWriter consoleOutput, System.Threading.CancellationToken cancellationToken) [0x0007b] in <f2694baa22dd413c8e7d818913b0daf9>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Csc+<>c__DisplayClass1_0.<Run>b__0 (System.IO.TextWriter tw) [0x00000] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.ConsoleUtil.RunWithUtf8Output[T] (System.Func`2[T,TResult] func) [0x0001c] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.ConsoleUtil.RunWithUtf8Output[T] (System.Boolean utf8Output, System.IO.TextWriter textWriter, System.Func`2[T,TResult] func) [0x00016] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Csc.Run (System.String[] args, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter, Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader analyzerLoader) [0x00048] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at (wrapper delegate-invoke) <Module>:invoke_int_string[]_BuildPaths_TextWriter_IAnalyzerAssemblyLoader (string[],Microsoft.CodeAnalysis.BuildPaths,System.IO.TextWriter,Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader) (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.DesktopBuildClient.RunLocalCompilation (System.String[] arguments, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter) [0x00000] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.BuildClient.RunCompilation (System.Collections.Generic.IEnumerable`1[T] originalArguments, Microsoft.CodeAnalysis.BuildPaths buildPaths, System.IO.TextWriter textWriter) [0x0009d] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CommandLine.DesktopBuildClient.Run (System.Collections.Generic.IEnumerable`1[T] arguments, System.Collections.Generic.IEnumerable`1[T] extraArguments, Microsoft.CodeAnalysis.CommandLine.RequestLanguage language, Microsoft.CodeAnalysis.CommandLine.CompileFunc compileFunc, Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader analyzerAssemblyLoader) [0x0003e] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Program.Main (System.String[] args, System.String[] extraArgs) [0x00018] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
    at Microsoft.CodeAnalysis.CSharp.CommandLine.Program.Main (System.String[] args) [0x00006] in <32a305024ade4612b642d6299a42cc9d>:0  (TaskId:33)
/Users/dotnet-bot/j/workspace/Microsoft_msbuild/master/_OSX_Mono_prtest/bin/Bootstrap/Roslyn/Microsoft.CSharp.Core.targets(71,5): error MSB6006: "csc.exe" exited with code 1. [/Users/dotnet-bot/j/workspace/Microsoft_msbuild/master/_OSX_Mono_prtest/src/Framework/Microsoft.Build.Framework.csproj]