### PR TITLE
Change Open and TryOpen to pass preserveFormatting: null

### DIFF
--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1115,7 +1115,7 @@ namespace Microsoft.Build.Construction
         public static ProjectRootElement Open(string path, ProjectCollection projectCollection)
         {
             return Open(path, projectCollection,
-                preserveFormatting: false);
+                preserveFormatting: null);
         }
 
         /// <summary>
@@ -1162,7 +1162,7 @@ namespace Microsoft.Build.Construction
         /// </remarks>
         public static ProjectRootElement TryOpen(string path, ProjectCollection projectCollection)
         {
-            return TryOpen(path, projectCollection, preserveFormatting: false);
+            return TryOpen(path, projectCollection, preserveFormatting: null);
         }
 
         /// <summary>


### PR DESCRIPTION
Change the default behavior of `ProjectRootElement.Open(String, ProjectCollection)` and `ProjectRootElement.TryOpen(String, ProjectCollection)` to pass `preserveFormatting: null`. This way calls using that overload will not trigger project reloads and set preserveFormatting to false.