### PR TITLE
updated some doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Microsoft.Build (MSBuild)
 The Microsoft Build Engine is a platform for building applications. This engine, which is also known as MSBuild, provides an XML schema for a project file that controls how the build platform processes and builds software. Visual Studio uses MSBuild, but MSBuild *does not* depend on Visual Studio. By invoking msbuild.exe on your project or solution file, you can orchestrate and build products in environments where Visual Studio isn't installed.
 
-For more information on MSBuild, see the [MSDN documentation](https://msdn.microsoft.com/en-us/library/dd393574%28v=vs.140%29.aspx).
+For more information on MSBuild, see the [MSBuild documentation](https://docs.microsoft.com/visualstudio/msbuild/msbuild) on docs.microsoft.com.
 
 ### Build Status
 
@@ -58,15 +58,15 @@ You are also encouraged to start a discussion by filing an issue or creating a g
 
 ### MSBuild Components
 
-* **MSBuild**. [Microsoft.Build.CommandLine](https://msdn.microsoft.com/en-us/library/dd393574(v=vs.120).aspx)  is the entrypoint for the Microsoft Build Engine (MSBuild.exe).
+* **MSBuild**. [Microsoft.Build.CommandLine](https://docs.microsoft.com/visualstudio/msbuild/msbuild)  is the entrypoint for the Microsoft Build Engine (MSBuild.exe).
 
-* **Microsoft.Build**. The [Microsoft.Build](https://msdn.microsoft.com/en-us/library/gg145008(v=vs.120).aspx) namespaces contain types that provide programmatic access to, and control of, the MSBuild engine.
+* **Microsoft.Build**. The [Microsoft.Build](https://msdn.microsoft.com/library/gg145008.aspx) namespaces contain types that provide programmatic access to, and control of, the MSBuild engine.
 
-* **Microsoft.Build.Framework**. The [Microsoft.Build.Framework](https://msdn.microsoft.com/en-us/library/microsoft.build.framework(v=vs.120).aspx) namespace contains the types that define how tasks and loggers interact with the MSBuild engine. For additional information on this component, see our [Microsoft.Build.Framework wiki page](https://github.com/Microsoft/msbuild/wiki/Microsoft.Build.Framework).
+* **Microsoft.Build.Framework**. The [Microsoft.Build.Framework](https://msdn.microsoft.com/library/microsoft.build.framework.aspx) namespace contains the types that define how tasks and loggers interact with the MSBuild engine. For additional information on this component, see our [Microsoft.Build.Framework wiki page](https://github.com/Microsoft/msbuild/wiki/Microsoft.Build.Framework).
 
-* **Microsoft.Build.Tasks**. The [Microsoft.Build.Tasks](https://msdn.microsoft.com/en-us/library/microsoft.build.tasks(v=vs.120).aspx) namespace contains the implementation of all tasks shipping with MSBuild.
+* **Microsoft.Build.Tasks**. The [Microsoft.Build.Tasks](https://msdn.microsoft.com/library/microsoft.build.tasks.aspx) namespace contains the implementation of all tasks shipping with MSBuild.
 
-* **Microsoft.Build.Utilities**. The [Microsoft.Build.Utilities](https://msdn.microsoft.com/en-us/library/microsoft.build.utilities(v=vs.120).aspx) namespace provides helper classes that you can use to create your own MSBuild loggers and tasks.
+* **Microsoft.Build.Utilities**. The [Microsoft.Build.Utilities](https://msdn.microsoft.com/library/microsoft.build.utilities.aspx) namespace provides helper classes that you can use to create your own MSBuild loggers and tasks.
 
 ### License
 


### PR DESCRIPTION
I thought we might want to point people to the latest reference of MSBuild on docs. Also, removed locale and product family version from the msdn links so they go to the latest and to the locale specified by the user in their machine.