### PR TITLE
DONOTMERGE Enable task factories for .NET Core

### DIFF
--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1551,11 +1551,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   
   <!-- Engine errors for features not supported on .NET Core have the arbitrarily-chosen 48 prefix -->
-  <data name="TaskFactoryNotSupportedFailure" xml:space="preserve">
-    <value>MSB4801: The task factory "{0}" could not be loaded because this version of MSBuild does not support it.</value>
-    <comment>{StrBegin="MSB4801: "}</comment>
-  </data>
-
   <data name="TaskInstantiationFailureNotSupported" xml:space="preserve">
     <value>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</value>
     <comment>{StrBegin="MSB4802: "}</comment>
@@ -1618,6 +1613,7 @@ MSB4169
 MSB4170
 MSB4171
 MSB4172
+MSB4801
 
 
         Don't forget to update this comment after using a new code.

--- a/src/Shared/TaskEngineAssemblyResolver.cs
+++ b/src/Shared/TaskEngineAssemblyResolver.cs
@@ -7,16 +7,21 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 
+#if !FEATURE_ASSEMBLY_LOADFROM
+using System.Runtime.Loader;
+#endif
 using Microsoft.Build.Shared;
 
-#if FEATURE_APPDOMAIN
+
 namespace Microsoft.Build.BackEnd.Logging
 {
     /// <summary>
     /// This is a helper class to install an AssemblyResolver event handler in whatever AppDomain this class is created in.
     /// </summary>
     internal class TaskEngineAssemblyResolver
+#if FEATURE_APPDOMAIN
         : MarshalByRefObject
+#endif
     {
         /// <summary>
         /// This public default constructor is needed so that instances of this class can be created by NDP.
@@ -44,12 +49,20 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal void InstallHandler()
         {
+#if FEATURE_APPDOMAIN
             Debug.Assert(_eventHandler == null, "The TaskEngineAssemblyResolver.InstallHandler method should only be called once!");
 
             _eventHandler = new ResolveEventHandler(ResolveAssembly);
 
             AppDomain.CurrentDomain.AssemblyResolve += _eventHandler;
+#else
+            _eventHandler = new Func<AssemblyLoadContext, AssemblyName, Assembly>(ResolveAssembly);
+
+            AssemblyLoadContext.Default.Resolving += _eventHandler;
+#endif
         }
+
+        
 
         /// <summary>
         /// Removes the event handler.
@@ -58,7 +71,11 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             if (_eventHandler != null)
             {
+#if FEATURE_APPDOMAIN
                 AppDomain.CurrentDomain.AssemblyResolve -= _eventHandler;
+#else
+                AssemblyLoadContext.Default.Resolving -= _eventHandler;
+#endif
                 _eventHandler = null;
             }
             else
@@ -68,6 +85,7 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// This is an assembly resolution handler necessary for fixing up types instantiated in different
         /// AppDomains and loaded with a Assembly.LoadFrom equivalent call. See comments in TaskEngine.ExecuteTask
@@ -77,6 +95,9 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="args"></param>
         /// <returns></returns>
         internal Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+#else
+        private Assembly ResolveAssembly(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName)
+#endif
         {
             // Is this our task assembly?
             if (_taskAssemblyFile != null)
@@ -85,6 +106,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 {
                     try
                     {
+#if FEATURE_APPDOMAIN
                         AssemblyNameExtension taskAssemblyName = new AssemblyNameExtension(AssemblyName.GetAssemblyName(_taskAssemblyFile));
                         AssemblyNameExtension argAssemblyName = new AssemblyNameExtension(args.Name);
 
@@ -95,7 +117,16 @@ namespace Microsoft.Build.BackEnd.Logging
 #else
                             return Assembly.LoadFrom(_taskAssemblyFile);
 #endif
+
                         }
+#else
+                        AssemblyNameExtension taskAssemblyName = new AssemblyNameExtension(AssemblyLoadContext.GetAssemblyName(_taskAssemblyFile));
+                        AssemblyNameExtension argAssemblyName = new AssemblyNameExtension(assemblyName);
+                        if (taskAssemblyName.Equals(argAssemblyName))
+                        {
+                            return AssemblyLoadContext.Default.LoadFromAssemblyPath(_taskAssemblyFile);
+                        }
+#endif
                     }
                     // any problems with the task assembly? return null.
                     catch (FileNotFoundException)
@@ -113,6 +144,7 @@ namespace Microsoft.Build.BackEnd.Logging
             return null;
         }
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Overridden to give this class infinite lease time. Otherwise we end up with a limited
         /// lease (5 minutes I think) and instances can expire if they take long time processing.
@@ -124,11 +156,13 @@ namespace Microsoft.Build.BackEnd.Logging
             return null;
         }
 
-        // path to the task assembly, but only if it's loaded using LoadFrom. If it's loaded with Load, this is null.
-        private string _taskAssemblyFile = null;
 
         // we have to store the event handler instance in case we have to remove it
         private ResolveEventHandler _eventHandler = null;
+#else
+        private Func<AssemblyLoadContext, AssemblyName, Assembly> _eventHandler = null;
+#endif
+        // path to the task assembly, but only if it's loaded using LoadFrom. If it's loaded with Load, this is null.
+        private string _taskAssemblyFile = null;
     }
 }
-#endif


### PR DESCRIPTION
Getting this out for code review and to see how it does in CI.

This enables task factories on .NET Core which will allows my new Roslyn-based CodeTaskFactory to be loaded.