### PR TITLE
Set LARGEADDRESSAWARE for x86 .exes (#1594)

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -130,6 +130,29 @@
       <VSDesignTimeBuild Condition="'$(BuildingInsideVisualStudio)'=='true' and '$(BuildingOutOfProcess)'=='false'">true</VSDesignTimeBuild>
     </PropertyGroup>
   </Target>
-  
+
+  <Target Name="EditBin"
+          AfterTargets="CoreCompile"
+          BeforeTargets="OpenSourceSign"
+          Condition="'$(FullFrameworkBuild)' == 'true' and '$(PlatformTarget)' == 'x86'">
+    <PropertyGroup>
+      <!-- Native equivalent is /LARGEADDRESSAWARE on the linker -->
+      <EditBinFlags Condition="'$(LargeAddressAware)'=='true'">$(EditBinFlags) /LARGEADDRESSAWARE</EditBinFlags>
+
+      <!-- Don't require all developers to install C++ tools just to
+           get editbin.exe -->
+      <EditBinContinueOnError>WarnAndContinue</EditBinContinueOnError>
+      <!-- But DO fail the build on CI and official builds if we can't
+           produce the right outputs. Continuing on error to allow
+           test results even on a misconfigured build machine. -->
+      <EditBinContinueOnError Condition="'$(TF_BUILD)' == 'True' or '$(JENKINS_URL)' != ''">ErrorAndContinue</EditBinContinueOnError>
+    </PropertyGroup>
+
+    <Exec Condition="'$(EditBinFlags)'!=''"
+          Command="call &quot;$(VS140COMNTOOLS)..\tools\vsvars32.bat&quot; &amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)"
+          ContinueOnError="$(EditBinContinueOnError)" />
+
+  </Target>
+
   <Import Project="$(NuGetConfigDir)\packageLoad.targets" />
 </Project>

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -25,6 +25,7 @@
          two files should be generated from a single source. -->
     <AppConfig Condition="'$(Platform)' == 'x64'">app.amd64.config</AppConfig>
     <ApplicationIcon>MSBuild.ico</ApplicationIcon>
+    <LargeAddressAware>true</LargeAddressAware>
   </PropertyGroup>
   <PropertyGroup Condition="'$(MonoBuild)' == 'true'">
     <TargetExt>.dll</TargetExt>


### PR DESCRIPTION
Add logic to respect the `LargeAddressAware` property as was done in the VS repo.

Add that property to the `MSBuild.exe` project, which lost it in the GitHub migration.

Fixes #1580 by restoring behavior from v14 and prior builds.