### PR TITLE
Add default values for AppDesignerFolder property

### DIFF
--- a/src/XMakeTasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.CSharp.CurrentVersion.targets
@@ -44,6 +44,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <DefineCommonReferenceSchemas Condition=" '$(DefineCommonReferenceSchemas)' == '' ">true</DefineCommonReferenceSchemas>
         <DefineCommonCapabilities Condition=" '$(DefineCommonCapabilities)' == '' ">true</DefineCommonCapabilities>
         <SynthesizeLinkMetadata Condition=" '$(SynthesizeLinkMetadata)' == '' and '$(HasSharedItems)' == 'true' ">true</SynthesizeLinkMetadata>
+        <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/XMakeTasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -44,6 +44,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <DefineCommonReferenceSchemas Condition=" '$(DefineCommonReferenceSchemas)' == '' ">true</DefineCommonReferenceSchemas>
         <DefineCommonCapabilities Condition=" '$(DefineCommonCapabilities)' == '' ">true</DefineCommonCapabilities>
         <SynthesizeLinkMetadata Condition=" '$(SynthesizeLinkMetadata)' == '' and '$(HasSharedItems)' == 'true' ">true</SynthesizeLinkMetadata>
+        <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">My Project</AppDesignerFolder>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The Web SDK uses the `AppDesignerFolder` property to [exclude launchSettings.json files from publish](https://github.com/aspnet/websdk/blob/75184cba7a7a59c580caf60a74fac247a29d807b/src/Web/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.props#L28):

```xml
    <!-- Set CopyToPublishDirectory to Never for items under AppDesignerFolder ("Properties", by default) to avoid publishing launchSettings.json -->
    <Content Update="$(AppDesignerFolder)/**" CopyToPublishDirectory="Never" Condition="'$(AppDesignerFolder)' != ''"/>
```

However, the `AppDesignerFolder` property is currently only set in the [CSharp](https://github.com/dotnet/roslyn-project-system/blob/fae6ac3cda03df01d05ab47d10b95e39134c85c7/src/Targets/Microsoft.CSharp.DesignTime.targets#L14) / [Visual Basic](https://github.com/dotnet/roslyn-project-system/blob/fae6ac3cda03df01d05ab47d10b95e39134c85c7/src/Targets/Microsoft.VisualBasic.DesignTime.targets#L14) designtime targets, which means that during a normal build it's not set.  This means that the publish command will include the launchSettings.json file for ASP.NET Core projects, which is not the correct behavior.

This PR adds default values for the AppDesignerFolder property to MSBuild.

Fixes dotnet/sdk#631.  I was originally going to [add this to the .NET SDK](https://github.com/dotnet/sdk/pull/645), but after discussing with @davkean we decided it should go in MSBuild so that it's consistent everywhere.

@rainersigwald @AndyGerlicher @cdmihai for review.