### PR TITLE
Add DefaultProjectTypeGuid property for C# and Visual Basic

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -44,6 +44,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <DefineCommonReferenceSchemas Condition=" '$(DefineCommonReferenceSchemas)' == '' ">true</DefineCommonReferenceSchemas>
         <DefineCommonCapabilities Condition=" '$(DefineCommonCapabilities)' == '' ">true</DefineCommonCapabilities>
         <SynthesizeLinkMetadata Condition=" '$(SynthesizeLinkMetadata)' == '' and '$(HasSharedItems)' == 'true' ">true</SynthesizeLinkMetadata>
+        <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</DefaultProjectTypeGuid>
         <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
     </PropertyGroup>
 

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -44,6 +44,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <DefineCommonReferenceSchemas Condition=" '$(DefineCommonReferenceSchemas)' == '' ">true</DefineCommonReferenceSchemas>
         <DefineCommonCapabilities Condition=" '$(DefineCommonCapabilities)' == '' ">true</DefineCommonCapabilities>
         <SynthesizeLinkMetadata Condition=" '$(SynthesizeLinkMetadata)' == '' and '$(HasSharedItems)' == 'true' ">true</SynthesizeLinkMetadata>
+        <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</DefaultProjectTypeGuid>
         <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">My Project</AppDesignerFolder>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes dotnet/sdk#522 and dotnet/cli#5131

The .NET CLI has a command to add projects to a solution.  It needs to know what project type Guid to use in the solution for projects where it's not explicitly defined in the project file.  This change adds a `DefaultProjectTypeGuid` property for C# and VB that it can use for this.

@jeffkl @rainersigwald @AndyGerlicher @jgoshi @davkean for review.

@KevinRansom @enricosada the F# targets should also add this property, I believe the F# value is `{F2A71F9B-5D33-465A-A702-920D77279786}`