### PR TITLE
Allow ToolTask.GetProcessStartInfo to be overridden

### DIFF
--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -541,7 +541,7 @@ namespace Microsoft.Build.Utilities
         protected virtual string GenerateCommandLineCommands() { throw null; }
         protected abstract string GenerateFullPathToTool();
         protected virtual string GenerateResponseFileCommands() { throw null; }
-        protected System.Diagnostics.ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch) { throw null; }
+        protected virtual System.Diagnostics.ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch) { throw null; }
         protected virtual string GetResponseFileSwitch(string responseFilePath) { throw null; }
         protected virtual string GetWorkingDirectory() { throw null; }
         protected virtual bool HandleTaskExecutionErrors() { throw null; }

--- a/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -381,7 +381,7 @@ namespace Microsoft.Build.Utilities
         protected virtual string GenerateCommandLineCommands() { throw null; }
         protected abstract string GenerateFullPathToTool();
         protected virtual string GenerateResponseFileCommands() { throw null; }
-        protected System.Diagnostics.ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch) { throw null; }
+        protected virtual System.Diagnostics.ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch) { throw null; }
         protected virtual string GetResponseFileSwitch(string responseFilePath) { throw null; }
         protected virtual string GetWorkingDirectory() { throw null; }
         protected virtual bool HandleTaskExecutionErrors() { throw null; }

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -713,7 +713,7 @@ namespace Microsoft.Build.Utilities
         /// <param name="commandLineCommands"></param>
         /// <param name="responseFileSwitch"></param>
         /// <returns>The information required to start the process.</returns>
-        protected ProcessStartInfo GetProcessStartInfo
+        virtual protected ProcessStartInfo GetProcessStartInfo
         (
             string pathToTool,
             string commandLineCommands,


### PR DESCRIPTION
Current ToolTask implementers are able to set values for previously undefined environment variables and to override previously defined variable values via the EnvironmentVariables property. They are not, however, able to remove Environment Variables which should not be passed down to the ToolTask's child process. 

This inability to manage a ToolTask's environment creates issues particularly in the builds of programs whose behavior is affected by the process environment like https://github.com/dotnet/cli. A ToolTask which invokes such a program needs to be able to selectively provide a `clean` process, ensuring deterministic build behavior. Of course, sometimes it makes sense for such variables to flow, but there is not a current option for preventing that flow without re-implementing ToolTask.

@AndyGerlicher @rainersigwald @livarcocc