### PR TITLE
Glob matching is path aware

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1167,14 +1167,9 @@ namespace Microsoft.Build.Shared
                 out matchFileExpression, out needsRecursion, out isLegalFileSpec,
                 getFileSystemEntries);
 
-            if (isLegalFileSpec)
-            {
-                regexFileMatch = new Regex(matchFileExpression, RegexOptions.IgnoreCase);
-            }
-            else
-            {
-                regexFileMatch = null;
-            }
+            regexFileMatch = isLegalFileSpec
+                ? new Regex(matchFileExpression, RegexOptions.IgnoreCase)
+                : null;
         }
 
         /// <summary>
@@ -1188,7 +1183,7 @@ namespace Microsoft.Build.Shared
         /// <param name="needsRecursion">Receives the flag that is true if recursion is required.</param>
         /// <param name="isLegalFileSpec">Receives the flag that is true if the filespec is legal.</param>
         /// <param name="getFileSystemEntries">Delegate.</param>
-        private static void GetFileSpecInfo
+        internal static void GetFileSpecInfo
         (
             string filespec,
             out string fixedDirectoryPart,

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -611,7 +611,7 @@ namespace Microsoft.Build.Shared
             return fullPath;
         }
 
-        private static bool PathIsInvalid(string path)
+        internal static bool PathIsInvalid(string path)
         {
             if (path.IndexOfAny(InvalidPathChars) >= 0)
             {

--- a/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
+++ b/src/XMakeBuildEngine/Evaluation/ItemSpec.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
@@ -195,7 +196,7 @@ namespace Microsoft.Build.Evaluation
         public string ItemSpecFragment { get; }
 
         /// <summary>
-        /// Path of the projet the itemspec is coming from
+        /// Path of the project the itemspec is coming from
         /// </summary>
         protected string ProjectPath { get; }
 
@@ -208,8 +209,19 @@ namespace Microsoft.Build.Evaluation
             : this(
                 itemSpecFragment,
                 projectPath,
-                new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(itemSpecFragment, projectPath)))
+                CreateFileMatcher(itemSpecFragment, projectPath))
         {
+        }
+
+        private static Lazy<Func<string, bool>> CreateFileMatcher(string itemSpecFragment, string projectPath)
+        {
+            var projectDirectory = string.IsNullOrEmpty(projectPath)
+                ? string.Empty
+                : Path.GetDirectoryName(projectPath);
+
+            return
+                new Lazy<Func<string, bool>>(
+                    () => EngineFileUtilities.GetFileSpecMatchTester(itemSpecFragment, projectDirectory));
         }
 
         protected ItemFragment(string itemSpecFragment, string projectPath, Lazy<Func<string, bool>> fileMatcher)

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -958,6 +958,26 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
         }
 
+        [Theory(Skip = "https://github.com/Microsoft/msbuild/issues/1576")]
+        [InlineData(
+            "../**/*.cs", // include string
+            "a.cs", // exclude string
+            new[] {"ProjectDir/a.cs", "b.cs"}, // files to create relative to the test root dir
+            "ProjectDir", // relative path from test root to project
+            new[] {"../b.cs"} // expected items
+            )]
+        public void ExcludingRelativeItemToCurrentDirectoryShouldWorkWithAboveTheConeIncludes(string includeString, string excludeString, string[] files, string relativePathFromRootToProject, string[] expectedInclude)
+        {
+            var projectContents = string.Format(ItemWithIncludeAndExclude, includeString, excludeString);
+
+            using (var testFiles = new Helpers.TestProjectWithFiles(projectContents, files, relativePathFromRootToProject))
+            using (var projectCollection = new ProjectCollection())
+            {
+                ObjectModelHelpers.AssertItems(expectedInclude, new Project(testFiles.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, projectCollection).Items.ToList());
+            }
+
+        }
+
         /// <summary>
         /// Expression like @(x) should clone metadata, but metadata should still point at the original XML objects
         /// </summary>

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -921,6 +921,43 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             runTest(true, true);
         }
 
+        [Theory]
+        // exclude globbing cone at project level;
+        [InlineData(
+            "../a.cs;b.cs", // include string
+            "**/*.cs", // exclude string
+            new[] {"a.cs", "ProjectDir/b.cs"}, // files to create relative to the test root dir
+            "ProjectDir", // relative path from test root to project
+            new[] {"../a.cs"} // expected items
+            )]
+        // exclude globbing cone below project level;
+        [InlineData(
+            "a.cs;a/b.cs",
+            "a/**/*.cs",
+            new[] { "a.cs", "a/b.cs" },
+            "",
+            new[] {"a.cs"}
+            )]
+        // exclude globbing above project level;
+        [InlineData(
+            "a.cs;../b.cs;../../c.cs",
+            "../**/*.cs",
+            new[] { "a/ProjectDir/a.cs", "a/b.cs", "c.cs"},
+            "a/ProjectDir",
+            new[] { "../../c.cs" }
+            )]
+        public void ExcludeWithMissmatchingGlobCones(string includeString, string excludeString, string[] files, string relativePathFromRootToProject, string[] expectedInclude)
+        {
+            var projectContents = string.Format(ItemWithIncludeAndExclude, includeString, excludeString);
+
+            using (var testFiles = new Helpers.TestProjectWithFiles(projectContents, files, relativePathFromRootToProject))
+            using (var projectCollection = new ProjectCollection())
+            {
+                ObjectModelHelpers.AssertItems(expectedInclude, new Project(testFiles.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, projectCollection).Items.ToList());
+            }
+
+        }
+
         /// <summary>
         /// Expression like @(x) should clone metadata, but metadata should still point at the original XML objects
         /// </summary>

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -2776,6 +2776,27 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Fact]
+        public void GetItemProvenanceSimpleGlob()
+        {
+            var project =
+            @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`*`/>
+                  </ItemGroup>
+                </Project>
+            ";
+
+            var expected = new ProvenanceResultTupleList
+            {
+                Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
+            };
+
+            AssertProvenanceResult(expected, project, "a");
+            AssertProvenanceResult(expected, project, "2.foo");
+            AssertProvenanceResult(new ProvenanceResultTupleList(), project, "a/2.foo");
+        }
+
+        [Fact]
         public void GetItemProvenanceOnlyGlob()
         {
             var project =
@@ -3512,6 +3533,232 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             };
 
             AssertProvenanceResult(expected, project, "1.foo");
+        }
+
+        [Theory]
+        // recursive globing cone is at the project directory
+        [InlineData(
+            // item include glob
+            "**/*.cs",
+            // argument to GetItemProvenance
+            "a/a.cs",
+            // subdirectory path the project file should be placed in, relative to the test directory root.
+            // Subdirs are necessary if .. appears in any of the test paths.
+            // This is to ensure that Path.GetFullpath has enough path fragments to eat into, and to keep the glob inside the test directory root
+            "", 
+            true // should GetItemProvenance find a match
+            )]
+        [InlineData(
+            "**/*.cs",
+            "../a/a.cs",
+            "ProjectDirectory",
+            false
+            )]
+        // recursive globing cone is a superset of the project directory via relative path
+        [InlineData(
+            "../**/*.cs",
+            "../a/a.cs",
+            "ProjectDirectory",
+            true
+            )]
+        [InlineData(
+            "../**/*.cs",
+            "a/a.cs",
+            "ProjectDirectory",
+            true
+            )]
+        [InlineData(
+            "../**/*.cs",
+            "../../a/a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        // recursive globing cone is a subset of the project directory via relative path
+        [InlineData(
+            "a/**/*.cs",
+            "b/a.cs",
+            "",
+            false
+            )]
+        [InlineData(
+            "a/**/*.cs",
+            "a/b/a.cs",
+            "",
+            true
+            )]
+        [InlineData(
+            "a/**/*.cs",
+            "../a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        // recursive globing cone is disjoint of the project directory via relative path
+        [InlineData(
+            "../a/**/*.cs",
+            "../a/b/a.cs",
+            "dir/ProjectDirectory",
+            true
+            )]
+        [InlineData(
+            "../a/**/*.cs",
+            "../b/c/a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        [InlineData(
+            "../a/**/*.cs",
+            "a/a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        // directory name glob is at the project directory
+        [InlineData(
+            "a*a/*.cs",
+            "aba/a.cs",
+            "",
+            true
+            )]
+        [InlineData(
+            "a*a/*.cs",
+            "aba/aba/a.cs",
+            "",
+            false
+            )]
+        [InlineData(
+            "a*a/*.cs",
+            "../aba/a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        // directory name glob is inside the project directory
+        [InlineData(
+            "a/a*a/*.cs",
+            "a/aba/a.cs",
+            "",
+            true
+            )]
+        [InlineData(
+            "a/a*a/*.cs",
+            "a/aba/a/a.cs",
+            "",
+            false
+            )]
+        [InlineData(
+            "a/a*a/*.cs",
+            "../a/aba/a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        // directory name glob is disjoing to the project directory
+        [InlineData(
+            "../a/a*a/*.cs",
+            ".././a/aba/a.cs",
+            "dir/ProjectDirectory",
+            true
+            )]
+        [InlineData(
+            "../a/a*a/*.cs",
+            "../a/a/aba/a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        [InlineData(
+            "../a/a*a/*.cs",
+            "../../a/aba/a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        // filename glob is at the project directory
+        [InlineData(
+            "*.cs",
+            "a.cs",
+            "",
+            true
+            )]
+        [InlineData(
+            "*.cs",
+            "a/a.cs",
+            "",
+            false
+            )]
+        [InlineData(
+            "*.cs",
+            "../a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        // filename glob is under the project directory
+        [InlineData(
+            "a/*.cs",
+            "a/a.cs",
+            "",
+            true
+            )]
+        [InlineData(
+            "a/*.cs",
+            "a/b/a.cs",
+            "",
+            false
+            )]
+        [InlineData(
+            "a/*.cs",
+            "b/a.cs",
+            "",
+            false
+            )]
+        [InlineData(
+            "a/*.cs",
+            "../a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        // filename glob is disjoing to the project directory
+        [InlineData(
+            ".././a/*.cs",
+            "../a/a.cs",
+            "dir/ProjectDirectory",
+            true
+            )]
+        [InlineData(
+            "../a/*.cs",
+            "a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        [InlineData(
+            "../a/*.cs",
+            "../a/a/a.cs",
+            "dir/ProjectDirectory",
+            false
+            )]
+        public void GetItemProvenanceShouldBeSensitiveToGlobbingCone(string includeGlob, string getItemProvenanceArgument, string relativePathOfProjectFile, bool provenanceShouldFindAMatch)
+        {
+            var projectContents =
+                @"<Project ToolsVersion='msbuilddefaulttoolsversion' DefaultTargets='Build' xmlns='msbuildnamespace'>
+                  <ItemGroup>
+                    <A Include=`{0}`/>
+                  </ItemGroup>
+                </Project>
+                ";
+
+            projectContents = string.Format(projectContents, includeGlob);
+
+            using (var testFiles = new Helpers.TestProjectWithFiles(projectContents, new string[0], relativePathOfProjectFile))
+            using (var projectCollection = new ProjectCollection())
+            {
+                var project = new Project(testFiles.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, projectCollection);
+
+                ProvenanceResultTupleList expectedProvenance = null;
+
+                expectedProvenance = provenanceShouldFindAMatch
+                    ? new ProvenanceResultTupleList
+                    {
+                        Tuple.Create("A", Operation.Include, Provenance.Glob, 1)
+                    }
+                    : new ProvenanceResultTupleList();
+
+                AssertProvenanceResult(expectedProvenance, project.GetItemProvenance(getItemProvenanceArgument));
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1598. The problem is worse than item provenance alone. `<I Include="..\a.foo" Exclude="**\*.foo"/>` excludes `..\a.foo` in xplat, but didn't in dev14. This PR fixes issues of this type.