### PR TITLE
Update and Remove should not apply to Project.Items when their condition is false

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -812,6 +812,8 @@ namespace Microsoft.Build.Evaluation
             DataCollection.CommentMarkProfile(8818, endPass2);
 #endif
             LazyItemEvaluator<P, I, M, D> lazyEvaluator = null;
+
+            // comment next line to turn off lazy Evaluation
             lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _buildEventContext, _loggingService);
 
             // Pass3: evaluate project items
@@ -1700,6 +1702,7 @@ namespace Microsoft.Build.Evaluation
                 return;
             }
 
+            // legacy, dead code beyond this point. Runs only if the lazy evaluator is null. Also, the interpretation of Remove is not implemented
             if (!string.IsNullOrEmpty(itemElement.Include))
             {
                 EvaluateItemElementInclude(itemGroupConditionResult, itemConditionResult, itemElement);
@@ -1707,6 +1710,10 @@ namespace Microsoft.Build.Evaluation
             else if (!string.IsNullOrEmpty(itemElement.Update))
             {
                 EvaluateItemElementUpdate(itemElement);
+            }
+            else
+            {
+                ErrorUtilities.ThrowInternalError("Unexpected item operation");
             }
         }
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Build.Evaluation
             readonly int _elementOrder;
             
             readonly string _rootDirectory;
-            
-            readonly bool _conditionResult;
 
             readonly ImmutableList<string> _excludes;
 
@@ -30,8 +28,6 @@ namespace Microsoft.Build.Evaluation
             {
                 _elementOrder = builder.ElementOrder;
                 _rootDirectory = builder.RootDirectory;
-                
-                _conditionResult = builder.ConditionResult;
 
                 _excludes = builder.Excludes.ToImmutable();
                 _metadata = builder.Metadata.ToImmutable();
@@ -164,12 +160,10 @@ namespace Microsoft.Build.Evaluation
         {
             public int ElementOrder { get; set; }
             public string RootDirectory { get; set; }
-            
-            public bool ConditionResult { get; set; }
-            
+
             public ImmutableList<string>.Builder Excludes { get; set; } = ImmutableList.CreateBuilder<string>();
 
-            public IncludeOperationBuilder(ProjectItemElement itemElement) : base(itemElement)
+            public IncludeOperationBuilder(ProjectItemElement itemElement, bool conditionResult) : base(itemElement, conditionResult)
             {
             }
         }

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Build.Evaluation
             protected readonly ItemSpec<P, I> _itemSpec;
             protected readonly EvaluatorData _evaluatorData;
             protected readonly Expander<P, I> _expander;
+            protected readonly bool _conditionResult;
 
             //  This is used only when evaluating an expression, which instantiates
             //  the items and then removes them
@@ -32,6 +33,7 @@ namespace Microsoft.Build.Evaluation
                 _itemType = builder.ItemType;
                 _itemSpec = builder.ItemSpec;
                 _referencedItemLists = builder.ReferencedItemLists.ToImmutable();
+                _conditionResult = builder.ConditionResult;
 
                 _lazyEvaluator = lazyEvaluator;
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -23,13 +23,24 @@ namespace Microsoft.Build.Evaluation
 
             protected override void SaveItems(ICollection<I> items, ImmutableList<ItemData>.Builder listBuilder)
             {
+                if (!_conditionResult)
+                {
+                    return;
+                }
+
                 listBuilder.RemoveAll(itemData => items.Contains(itemData.Item));
             }
 
             public ImmutableHashSet<string>.Builder GetRemovedGlobs()
             {
-                var globs = _itemSpec.Fragments.OfType<GlobFragment>().Select(g => g.ItemSpecFragment);
                 var builder = ImmutableHashSet.CreateBuilder<string>();
+
+                if (!_conditionResult)
+                {
+                    return builder;
+                }
+
+                var globs = _itemSpec.Fragments.OfType<GlobFragment>().Select(g => g.ItemSpecFragment);
 
                 builder.UnionWith(globs);
 

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Build.Evaluation
 
             public override void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
+                if (!_conditionResult)
+                {
+                    return;
+                }
+
                 var matchedItems = ImmutableList.CreateBuilder<I>();
 
                 for (int i = 0; i < listBuilder.Count; i++)

--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
@@ -366,11 +366,13 @@ namespace Microsoft.Build.Evaluation
             public ItemSpec<P,I> ItemSpec { get; set; }
 
             public ImmutableDictionary<string, LazyItemList>.Builder ReferencedItemLists { get; } = ImmutableDictionary.CreateBuilder<string, LazyItemList>();
+            public bool ConditionResult { get; set; }
 
-            public OperationBuilder(ProjectItemElement itemElement)
+            public OperationBuilder(ProjectItemElement itemElement, bool conditionResult)
             {
                 ItemElement = itemElement;
                 ItemType = itemElement.ItemType;
+                ConditionResult = conditionResult;
             }
         }
 
@@ -378,7 +380,7 @@ namespace Microsoft.Build.Evaluation
         {
             public ImmutableList<ProjectMetadataElement>.Builder Metadata = ImmutableList.CreateBuilder<ProjectMetadataElement>();
 
-            public OperationBuilderWithMetadata(ProjectItemElement itemElement) : base(itemElement)
+            public OperationBuilderWithMetadata(ProjectItemElement itemElement, bool conditionResult) : base(itemElement, conditionResult)
             {
             }
         }
@@ -419,11 +421,11 @@ namespace Microsoft.Build.Evaluation
             }
             else if (itemElement.RemoveLocation != null)
             {
-                operation = BuildRemoveOperation(rootDirectory, itemElement);
+                operation = BuildRemoveOperation(rootDirectory, itemElement, conditionResult);
             }
             else if (itemElement.UpdateLocation != null)
             {
-                operation = BuildUpdateOperation(rootDirectory, itemElement);
+                operation = BuildUpdateOperation(rootDirectory, itemElement, conditionResult);
             }
             else
             {
@@ -435,9 +437,9 @@ namespace Microsoft.Build.Evaluation
             _itemLists[itemElement.ItemType] = newList;
         }
 
-        private UpdateOperation BuildUpdateOperation(string rootDirectory, ProjectItemElement itemElement)
+        private UpdateOperation BuildUpdateOperation(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)
         {
-            OperationBuilderWithMetadata operationBuilder = new OperationBuilderWithMetadata(itemElement);
+            OperationBuilderWithMetadata operationBuilder = new OperationBuilderWithMetadata(itemElement, conditionResult);
 
             // Proces Update attribute
             ProcessItemSpec(itemElement.Update, itemElement.UpdateLocation, operationBuilder);
@@ -449,7 +451,7 @@ namespace Microsoft.Build.Evaluation
 
         private IncludeOperation BuildIncludeOperation(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)
         {
-            IncludeOperationBuilder operationBuilder = new IncludeOperationBuilder(itemElement);
+            IncludeOperationBuilder operationBuilder = new IncludeOperationBuilder(itemElement, conditionResult);
             operationBuilder.ElementOrder = _nextElementOrder++;
             operationBuilder.RootDirectory = rootDirectory;
             operationBuilder.ConditionResult = conditionResult;
@@ -485,9 +487,9 @@ namespace Microsoft.Build.Evaluation
             return new IncludeOperation(operationBuilder, this);
         }
 
-        private RemoveOperation BuildRemoveOperation(string rootDirectory, ProjectItemElement itemElement)
+        private RemoveOperation BuildRemoveOperation(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)
         {
-            OperationBuilder operationBuilder = new OperationBuilder(itemElement);
+            OperationBuilder operationBuilder = new OperationBuilder(itemElement, conditionResult);
 
             ProcessItemSpec(itemElement.Remove, itemElement.RemoveLocation, operationBuilder);
 


### PR DESCRIPTION
Partially resolves #1475 by making Removes and Updates whose condition evaluates to false not apply to `Project.Items`

Leaves #1616 unfixed. Fixing that one requires changes that are too risky for RTW. The items from `Project.ItemsIgnoringCondition` are only used by the old project system, meaning their Solution Explorer will show incorrect data when using conditioned Removes and Updates.