### PR TITLE
Improve P2P handling for cross-targeting

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1512,17 +1512,55 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   -->
   <Target Name="_GetProjectReferenceTargetFrameworkProperties"
           Outputs="%(_MSBuildProjectReferenceExistent.Identity)">
-    <!-- As a mitigation for https://github.com/Microsoft/msbuild/issues/1276
-       .vcxproj is treated specially to avoid the cost of double-evaluating
-       for easily-identifiable-as-not-cross-targeting C++ projects. -->
+    <!--
+      Honor SkipGetTargetFrameworkProperties=true metadata on project references
+      to mean that the project reference is known not to target multiple frameworks
+      and the mechanism here for selecting the best one can be skipped as an optimization.
+
+      We give this treatment to .vcxproj by default since no .vcxproj can target more
+      than one framework.
+   -->
+   <ItemGroup>
+      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and '%(Extension)' == '.vcxproj'">
+        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      </_MSBuildProjectReferenceExistent>
+   </ItemGroup>
+
+    <!--
+       Allow project references to specify which target framework properties to set and their values
+       without consulting the referenced project. This has two use cases:
+
+       1. A caller may wish to pick a compatible but sub-optimal target framework. For example,
+          to unit test the .NETStandard implementation using a .NETFramework caller even though
+          there is also a .NETFramework implementation.
+
+       2. As an escape hatch for cases where the compatibility check performed by 
+          GetTargetFrameworkProperties is faulty.
+    -->
+    <ItemGroup>
+      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SetTargetFramework)' != ''">
+        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      </_MSBuildProjectReferenceExistent>
+    </ItemGroup>
+
+    <!--
+      Select the moniker to send to each project reference  if not already set. NugetTargetMoniker (NTM) is preferred by default over 
+      TargetFrameworkMoniker (TFM) because it is required to disambiguate the UWP case where TFM is fixed at .NETCore,Version=v5.0 and 
+      has floating NTM=UAP,Version=vX.Y.Z
+    -->
+    <PropertyGroup Condition="'$(ReferringTargetFrameworkForProjectReferences)' == ''">
+      <ReferringTargetFrameworkForProjectReferences Condition="'$(NugetTargetMoniker)' != ''">$(NugetTargetMoniker)</ReferringTargetFrameworkForProjectReferences>
+      <ReferringTargetFrameworkForProjectReferences Condition="'$(NugetTargetMoniker)' == ''">$(TargetFrameworkMoniker)</ReferringTargetFrameworkForProjectReferences>
+    </PropertyGroup>
+
     <MSBuild
         Projects="%(_MSBuildProjectReferenceExistent.Identity)"
         Targets="GetTargetFrameworkProperties"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(TargetFrameworkMoniker)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework"
-        Condition="'%(_MSBuildProjectReferenceExistent.Extension)' != '.vcxproj'">
+        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>


### PR DESCRIPTION
1. Deal with UWP case where NugetTargetMoniker is needed instead of TargetFrameworkMoniker
2. Provide mechanism to override the moniker that is passed to reference
3. Provide mechanism to pick any target framework of reference
4. Provide mechanism to skip the best TFM computation for known single-targeting case

@AndyGerlicher @rainersigwald

**Customer scenario**

*Primary:* 
Referencing an SDK/CPS-based project from UWP project would behave incorrectly (pick wrong TFM of reference) or fail with incorrect incompatibility error.

Also:
* There was no supported way to override the moniker sent to refs.
* There was no supported way to pick a different TFM than the one selected by the SDK for a cross-targeted ref, but sometimes you want to test a different one than the one deemed best for the caller.
* There was no supported way to turn off the cross-targeting protocol if you know ref is single targeted (which can now be used to improve performance if needed).


**Bugs this fixes:**
#1474 
#1390
dotnet/sdk#707
dotnet/roslyn-project-system#477


**Risk**

Low.

**Performance impact**

Negligible. 

**Is this a regression from a previous update?**

No.


**Root cause analysis:**

We missed the special cases around monikers for UWP.


**How was the bug found?**

Customer reported