### PR TITLE
Filetracker from global ansi path

### DIFF
--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -614,15 +614,15 @@ namespace Microsoft.Build.Utilities
             // Due to a Detours limitation, the path to FileTracker32.dll must be
             // representable in ANSI characters. If the local copy is not, fall back to
             // the globally-installed version.
-            if (Encoding.UTF8.GetByteCount(path) > path.Length &&
-                s_FileTrackerFilename.Equals(filename, StringComparison.OrdinalIgnoreCase))
+            if (s_FileTrackerFilename.Equals(filename, StringComparison.OrdinalIgnoreCase))
             {
-                string progfilesPath = Path.Combine(FrameworkLocationHelper.GenerateProgramFiles32(), "MSBuild", "15.1",
+                string progfilesPath = Path.Combine(FrameworkLocationHelper.GenerateProgramFiles32(),
+                    "Microsoft Visual Studio", "Shared", "Common", "MSBuild", MSBuildConstants.CurrentProductVersion,
                     "FileTracker", s_FileTrackerFilename);
 
-                if (!File.Exists(progfilesPath))
+                if (File.Exists(progfilesPath))
                 {
-                    return null;
+                    return progfilesPath;
                 }
             }
 

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -612,8 +612,9 @@ namespace Microsoft.Build.Utilities
             var path = ToolLocationHelper.GetPathToBuildToolsFile(filename, ToolLocationHelper.CurrentToolsVersion, bitness);
 
             // Due to a Detours limitation, the path to FileTracker32.dll must be
-            // representable in ANSI characters. If the local copy is not, fall back to
-            // the globally-installed version.
+            // representable in ANSI characters. Look for it first in the global
+            // shared location which is guaranteed to be ANSI. Fall back to
+            // current folder.
             if (s_FileTrackerFilename.Equals(filename, StringComparison.OrdinalIgnoreCase))
             {
                 string progfilesPath = Path.Combine(FrameworkLocationHelper.GenerateProgramFiles32(),

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -609,7 +609,18 @@ namespace Microsoft.Build.Utilities
 
             // Look for FileTracker.dll/Tracker.exe in the MSBuild tools directory. They may exist elsewhere on disk,
             // but other copies aren't guaranteed to be compatible with the latest.
-            return ToolLocationHelper.GetPathToBuildToolsFile(filename, ToolLocationHelper.CurrentToolsVersion, bitness);
+            var path = ToolLocationHelper.GetPathToBuildToolsFile(filename, ToolLocationHelper.CurrentToolsVersion, bitness);
+
+            // Due to a Detours limitation, the path to FileTracker32.dll must be
+            // representable in ANSI characters. If the local copy is not, fall back to
+            // the globally-installed version.
+            if (Encoding.UTF8.GetByteCount(path) > path.Length &&
+                s_FileTrackerFilename.Equals(filename, StringComparison.OrdinalIgnoreCase))
+            {
+                // TODO: get programfiles path
+            }
+
+            return path;
         }
 
         /// <summary>

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -617,7 +617,13 @@ namespace Microsoft.Build.Utilities
             if (Encoding.UTF8.GetByteCount(path) > path.Length &&
                 s_FileTrackerFilename.Equals(filename, StringComparison.OrdinalIgnoreCase))
             {
-                // TODO: get programfiles path
+                string progfilesPath = Path.Combine(FrameworkLocationHelper.GenerateProgramFiles32(), "MSBuild", "15.1",
+                    "FileTracker", s_FileTrackerFilename);
+
+                if (!File.Exists(progfilesPath))
+                {
+                    return null;
+                }
             }
 
             return path;

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -618,8 +618,7 @@ namespace Microsoft.Build.Utilities
             if (s_FileTrackerFilename.Equals(filename, StringComparison.OrdinalIgnoreCase))
             {
                 string progfilesPath = Path.Combine(FrameworkLocationHelper.GenerateProgramFiles32(),
-                    "Microsoft Visual Studio", "Shared", "Common", "MSBuild", MSBuildConstants.CurrentProductVersion,
-                    "FileTracker", s_FileTrackerFilename);
+                    "MSBuild", MSBuildConstants.CurrentProductVersion, "FileTracker", s_FileTrackerFilename);
 
                 if (File.Exists(progfilesPath))
                 {


### PR DESCRIPTION
In conjunction with internal PR https://devdiv.visualstudio.com/DevDiv/MSBuild/_git/VS/pullrequest/55140, fixes internal bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/286164, which prevents processes from running under Tracker.exe when FileTracker32.dll is found in a path with non-ANSI (Unicode) characters on the path.