### PR TITLE
Unify reference to System.Threading.Tasks.Dataflow

### DIFF
--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -740,9 +740,6 @@
     <!-- Assemblies Files we depend on -->
     <!-- Be conservative when adding references... adding System.Xml.Linq can add .47 sec cold start time to our launch time, or 80 ms to warm start time -->
     <Reference Include="System" />
-    <Reference Include="System.Threading.Tasks.Dataflow">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "System.Threading.Tasks.Dataflow": "4.6.0"
   },
   "frameworks": {
     "net46": {
@@ -25,7 +26,6 @@
         "System.Runtime": "4.1.0",
         "System.Runtime.Loader": "4.0.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
-        "System.Threading.Tasks.Dataflow": "4.6.0",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",
         "System.Xml.XmlDocument": "4.0.1",


### PR DESCRIPTION
For full framework we're pulling this reference from the GAC and on .NET Core its coming from a NuGet package.  This leaves us with references to different versions which is not ideal.