### PR TITLE
Catch FormatException coming from Convert.ChangeType.

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -3608,9 +3608,13 @@ namespace Microsoft.Build.Evaluation
                         }
                     }
                 }
+                // The coercion failed therefore we return null
                 catch (InvalidCastException)
                 {
-                    // The coercion failed therefore we return null
+                    return null;
+                }
+                catch (FormatException)
+                {
                     return null;
                 }
 


### PR DESCRIPTION
String.TrimEnd has a new overload for a single char in .NET Core 2.0. However, when MSBuild encounters this new overload first, it throws a FormatException which is not caught - breaking the build.

The fix is to catch the FormatException just like an InvalidCastException and continue searching the rest of the reflection MethodInfos for a match.

Fix #1634

@rainersigwald @AndyGerlicher 

This change isn't necessary for "1.0", but I need to get an MSBuild version with this fix to unblock taking a new corefx in dotnet/cli/master.