### PR TITLE
Do not use NTM if it has more than one value

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1546,10 +1546,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!--
       Select the moniker to send to each project reference  if not already set. NugetTargetMoniker (NTM) is preferred by default over 
       TargetFrameworkMoniker (TFM) because it is required to disambiguate the UWP case where TFM is fixed at .NETCore,Version=v5.0 and 
-      has floating NTM=UAP,Version=vX.Y.Z
+      has floating NTM=UAP,Version=vX.Y.Z. However, in other cases (classic PCLs), NTM contains multiple values and that will cause the MSBuild
+      invocation below to fail by passing invalid properties. Therefore we do not use the NTM if it contains a semicolon.
     -->
     <PropertyGroup Condition="'$(ReferringTargetFrameworkForProjectReferences)' == ''">
-      <ReferringTargetFrameworkForProjectReferences Condition="'$(NugetTargetMoniker)' != ''">$(NugetTargetMoniker)</ReferringTargetFrameworkForProjectReferences>
+      <ReferringTargetFrameworkForProjectReferences Condition="'$(NugetTargetMoniker)' != '' and !$(NuGetTargetMoniker.Contains(';'))">$(NugetTargetMoniker)</ReferringTargetFrameworkForProjectReferences>
       <ReferringTargetFrameworkForProjectReferences Condition="'$(NugetTargetMoniker)' == ''">$(TargetFrameworkMoniker)</ReferringTargetFrameworkForProjectReferences>
     </PropertyGroup>
 


### PR DESCRIPTION
**Customer scenario**
Building a classic portable class library with any project references fails

**Bugs this fixes:**
[VSO 377419](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=377419&_a=edit)

**Workarounds, if any**
Set ReferringTargetFrameworkForProjectReferences=$(TargetFrameworkMoniker) in your project file.

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
Yes, introduced very recently.

**Root cause analysis:**
We missed that $(NugetTargetMoniker) can contain multiple values and validation did not run through classic PCL scenarios.

**How was the bug found?**
Dogfooding. (The dogfooders affected have tested with this fix applied and confirmed it eliminates the problem.)

@AndyGerlicher @rainersigwald @cdmihai 
