### PR TITLE
Make LargeAddressAware incremental

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -131,9 +131,15 @@
     </PropertyGroup>
   </Target>
 
+  <!-- We want this target to be incremental, but editbin affects the file in place, as does
+       OpenSourceSign. So run this target when the assembly has been updated since the last
+       time it was signed. Signing will run immediately after this, flipping another bit and
+       dropping the marker file. -->
   <Target Name="EditBin"
           AfterTargets="CoreCompile"
           BeforeTargets="OpenSourceSign"
+          Inputs="@(IntermediateAssembly)"
+          Outputs="@(IntermediateAssembly->'%(Identity).oss_signed')"
           Condition="'$(FullFrameworkBuild)' == 'true' and '$(PlatformTarget)' == 'x86'">
     <PropertyGroup>
       <!-- Native equivalent is /LARGEADDRESSAWARE on the linker -->


### PR DESCRIPTION
Unfortunately, we have two processes that run in sequence to modify the
output binary in place. This can happen:

* Initial compile
* First editbin
* First OpenSourceSign
* Second compile (skipped, up to date)
* Second editbin (runs, wasn't incremental before this commit)
* Second OpenSourceSign (runs, prior step makes it appear out of date)

The last OpenSourceSign then complains "this assembly is already
signed", breaking the build.

Fixes #1657 by treating editbin + OpenSourceSign as a unit for purposes
of incrementality.