### PR TITLE
Enable clean + build of crosstargeting projects

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
@@ -19,6 +19,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(CustomBeforeMicrosoftCommonCrossTargetingTargets)" Condition="'$(CustomBeforeMicrosoftCommonCrossTargetingTargets)' != '' and Exists('$(CustomBeforeMicrosoftCommonCrossTargetingTargets)')"/>
 
+  <Target Name="_ComputeTargetFrameworkItems" Returns="@(InnerOutput)">
+    <ItemGroup>
+      <_TargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+  </Target>
+
   <!--
   ============================================================
                                        DispatchToInnerBuilds
@@ -35,10 +41,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                       all target frameworks..
   ============================================================
   -->
-  <Target Name="DispatchToInnerBuilds" Returns="@(InnerOutput)">
-    <ItemGroup>
-      <_TargetFramework Include="$(TargetFrameworks)" />
-    </ItemGroup>
+  <Target Name="DispatchToInnerBuilds"
+          DependsOnTargets="_ComputeTargetFrameworkItems"
+          Returns="@(InnerOutput)">
+    <!-- If this logic is changed, also update Clean -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Condition="'$(TargetFrameworks)' != '' "
              Targets="$(InnerTargets)"
@@ -80,13 +86,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                                        Clean
 
    Cross-targeting version of clean.
+
+   Inner-build dispatch is a clone of DispatchToInnerBuilds;
+   the only reason it's replicated is that it must be a different
+   target to be run in the same build (e.g. by Rebuild or by
+   a /t:Clean;Build invocation.
   ============================================================
   -->
-  <Target Name="Clean" DependsOnTargets="_SetCleanInnerTarget;DispatchToInnerBuilds" />
-  <Target Name="_SetCleanInnerTarget">
-    <PropertyGroup>
-      <InnerTargets>Clean</InnerTargets>
-    </PropertyGroup>
+  <Target Name="Clean"
+          DependsOnTargets="_ComputeTargetFrameworkItems">
+    <!-- If this logic is changed, also update DispatchToInnerBuilds -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Condition="'$(TargetFrameworks)' != '' "
+             Targets="Clean"
+             Properties="TargetFramework=%(_TargetFramework.Identity)" />
   </Target>
 
   <!--
@@ -96,12 +109,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    Cross-targeting version of rebuild.
   ============================================================
   -->
-  <Target Name="Rebuild" DependsOnTargets="_SetRebuildInnerTarget;DispatchToInnerBuilds" />
-  <Target Name="_SetRebuildInnerTarget">
-    <PropertyGroup>
-      <InnerTargets>Rebuild</InnerTargets>
-    </PropertyGroup>
-  </Target>
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
   <!--
     This will import NuGet restore targets, which is a special case separate from the package -> project extension 


### PR DESCRIPTION
Fixes #1065 by duplicating `DispatchToInnerBuilds` to the crosstargeting
version of `Clean`. This enables Clean to run before Build (or the
arbitrary user target set via the `InnerTargets` property), reducing the
surprise of command line builds that use `/t:Clean;Build` rather than
`/t:Rebuild`.

This change also changes the cross-targeting definition of `Rebuild` to
match the standard `Clean;Build` rather than invoking `Rebuild` on each
inner build. That makes it easier to author outer-build extension logic,
fixing NuGet/Home#4475.