### PR TITLE
Enable P2P's to determine their own compilation RID

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1558,9 +1558,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="%(_MSBuildProjectReferenceExistent.Identity)"
         Targets="GetTargetFrameworkProperties"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences); ReferringRuntimeIdentifier=$(RuntimeIdentifier)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkProperties" />

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1576,6 +1576,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
 
+    <ItemGroup>
+      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.Identity)' == '%(Identity)' and '$(_ProjectReferenceTargetFrameworkProperties)' != ''">
+        <UndefineProperties Condition="$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectIsRidAgnostic=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);RuntimeIdentifier;ProjectIsRidAgnostic</UndefineProperties>
+        <!-- Unconditionally remove the property that was set as a marker to indicate that for this call we should remove RuntimeIdentifier -->
+        <UndefineProperties Condition="!$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectIsRidAgnostic=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);ProjectIsRidAgnostic</UndefineProperties>
+      </_MSBuildProjectReferenceExistent>
+    </ItemGroup>
+
     <PropertyGroup>
       <_ProjectReferenceTargetFrameworkProperties />
     </PropertyGroup>

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1558,7 +1558,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="%(_MSBuildProjectReferenceExistent.Identity)"
         Targets="GetTargetFrameworkProperties"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences); ReferringRuntimeIdentifier=$(RuntimeIdentifier)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)$(AdditionalPropertiesForGetTargetFrameworkProperties)"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1558,7 +1558,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="%(_MSBuildProjectReferenceExistent.Identity)"
         Targets="GetTargetFrameworkProperties"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)$(AdditionalPropertiesForGetTargetFrameworkProperties)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">


### PR DESCRIPTION
Fixes the RID P2P component of dotnet/sdk#696 

This is part of a two-part PR. The second part is dotnet/sdk#828. 

## What
These PRs, together, enable the following class of projects:
* A RID-specific root project [App.csproj]
* A portable dependency project [Library.csproj]

With this fix in place, one can:
* `dotnet restore App.csproj`
* `dotnet build -r osx.10.11-x64 App.csproj`

Without the fix, Library.csproj will not build because the `osx.10.11-x64` runtime identifier will be passed through as a global property, forcing it to build for a target that does not exist in the NuGet assets file.

## How
The MSBuild portion of the fix adds `RuntimeIdentifier` to the list of `RemoveProperties` passed to the P2P in `_GetProjectReferenceTargetFrameworkProperties`. It also passes along the value of `RuntimeIdentifier` as `ReferringRuntimeIdentifier` so that the dependency can decide how it wants to interpret that Runtime Identifier. The model used is identical to that used for TargetFramework.

The SDK portion of the fix expands the `GetTargetFrameworkProperties` target to also account for RuntimeIdentifiers. The logic is as follows:
* If the project has `RuntimeIdentifier` or `RuntimeIdentifiers` set then use the ReferringRuntimeIdentifier
* If the project does not specify a RID through either mechanism then use `''` as the RuntimeIdentifier

The effect is that RID-specific projects will attempt to build with the RID passed to the root project. Portable projects will be built without a RID specified. 

## Testing
The PR includes a thorough test for the scenario in question, building a RID-specific project that references both a RID-specific and Portable library. Both libraries are proven to compile successfuly through runtime invocation. The RID-specific library both invokes a RID-specific native dependency AND inspects its own RID via an overloaded AssemblyInfo Description attribute.

The feature was enabled without impacting any existing SDK tests.

The combination of these changes was tested on my local machine by manually editing `Microsoft.Common.CurrentVersion.targets` in the Stage0 `dotnet` directory.

## Risk
This feature requires augmenting `Microsoft.Common.CurrentVersion.targets`. Despite this being a central target, there are mitigating circumstances:
* The target modified is specific to the new project system
* The modification is a verbatim copy of the identical behavior for TargetFramework

## Merge Strategy
Due to the codeflow for these fixes, the following will need to happen in order:
 - [] MSBuild PR is merged
 - [] New MSBuild is inserted into CLI
 - [] SDK's CLI dependency is rev'd to latest and SDK PR is merged
 - [] New SDK is inserted into CLI

/cc @srivatsn @DustinCampbell @livarcocc @jonsequitur @rainersigwald @AndyGerlicher @nguerrera @dsplaisted 