### PR TITLE
Add net46 dependencies to msbuild nuspecs

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -23,6 +23,15 @@
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
       </group>
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
@@ -25,6 +25,7 @@
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Tasks.Core" version="[$version$]" />
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
+        <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.2.304-preview5" />
       </group>
     </dependencies>
     <contentFiles>

--- a/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
@@ -25,7 +25,6 @@
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Tasks.Core" version="[$version$]" />
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
-        <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.2.304-preview5" />
       </group>
     </dependencies>
     <contentFiles>

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -63,7 +63,6 @@
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
-        <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.2.304-preview5" />
         <dependency id="System.Collections.Immutable" version="1.3.1" />
         <dependency id="System.Reflection.Metadata" version="1.3.0" />
       </group>

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -63,8 +63,47 @@
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
-        <dependency id="System.Collections.Immutable" version="1.3.1" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.AppContext" version="4.1.0" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Collections.Concurrent" version="4.0.12" />
+        <dependency id="System.Collections.Immutable" version="1.2.0" />
+        <dependency id="System.Collections.NonGeneric" version="4.0.1" />
+        <dependency id="System.Console" version="4.0.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.IO.FileSystem" version="4.0.1" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Linq.Parallel" version="4.0.1" />
+        <dependency id="System.ObjectModel" version="4.0.12" />
+        <dependency id="System.Reflection" version="4.1.0" />
         <dependency id="System.Reflection.Metadata" version="1.3.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Resources.Writer" version="4.0.0" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Runtime.Handles" version="4.0.1" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Runtime.Serialization.Primitives" version="4.1.1" />
+        <dependency id="System.Runtime.Serialization.Xml" version="4.1.1" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.2.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.0.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.1.0" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.11" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
+        <dependency id="System.Xml.XDocument" version="4.0.11" />
+        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -63,6 +63,9 @@
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
+        <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.2.304-preview5" />
+        <dependency id="System.Collections.Immutable" version="1.3.1" />
+        <dependency id="System.Reflection.Metadata" version="1.3.0" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -53,6 +53,7 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.2.304-preview5" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -53,7 +53,6 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
-        <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.2.304-preview5" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -53,6 +53,39 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.AppContext" version="4.1.0" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Collections.Concurrent" version="4.0.12" />
+        <dependency id="System.Collections.NonGeneric" version="4.0.1" />
+        <dependency id="System.Console" version="4.0.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.IO.FileSystem" version="4.0.1" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.ObjectModel" version="4.0.12" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Runtime.Handles" version="4.0.1" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Runtime.Serialization.Primitives" version="4.1.1" />
+        <dependency id="System.Runtime.Serialization.Xml" version="4.1.1" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Threading.Timer" version="4.0.1" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
+        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -63,7 +63,50 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
-        <dependency id="System.Collections.Immutable" version="1.3.1" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.0.1" />
+        <dependency id="System.AppContext" version="4.1.0" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Collections.Concurrent" version="4.0.12" />
+        <dependency id="System.Collections.Immutable" version="1.2.0" />
+        <dependency id="System.Collections.NonGeneric" version="4.0.1" />
+        <dependency id="System.Console" version="4.0.0" />
+        <dependency id="System.Diagnostics.Contracts" version="4.0.1" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.FileVersionInfo" version="4.0.0" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.IO.Compression" version="4.1.0" />
+        <dependency id="System.IO.FileSystem" version="4.0.1" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />
+        <dependency id="System.IO.Pipes" version="4.0.0" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Linq.Parallel" version="4.0.1" />
+        <dependency id="System.ObjectModel" version="4.0.12" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1" />
+        <dependency id="System.Reflection.Metadata" version="1.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.0.1" />
+        <dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Runtime.Handles" version="4.0.1" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Runtime.Loader" version="4.0.0" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.11" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Tasks.Dataflow" version="4.6.0" />
+        <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Threading.ThreadPool" version="4.0.10" />
+        <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
+        <dependency id="System.Xml.XmlDocument" version="4.0.1" />
+        <dependency id="System.Xml.XPath.XmlDocument" version="4.0.1" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -63,6 +63,8 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.2.304-preview5" />
+        <dependency id="System.Collections.Immutable" version="1.3.1" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -63,7 +63,6 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
-        <dependency id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.2.304-preview5" />
         <dependency id="System.Collections.Immutable" version="1.3.1" />
       </group>
     </dependencies>

--- a/dir.props
+++ b/dir.props
@@ -242,8 +242,8 @@
 
     <DefineConstants>$(DefineConstants);RUNTIME_TYPE_NETCORE</DefineConstants>
     
-    <!-- target framework for msbuild nuget packages. Used by Nuspec.ReferenceGenerator.targets to update corefx dependencies-->
-    <NuSpecTfm>.NETStandard$(TargetFrameworkVersion.TrimStart('v'))</NuSpecTfm>
+    <!-- target framework for msbuild nuget packages. Used by Nuspec.ReferenceGenerator.targets to update dependencies in our nuspecs-->
+    <NuSpecTfm>.NETStandard$(TargetFrameworkVersion.TrimStart('v'));.NETFramework4.6</NuSpecTfm>
 
   </PropertyGroup>
 


### PR DESCRIPTION
This enables users to publish their msbuild depending app for net46 and get the closure of dependencies needed for msbuild.

I just copied over the net46 only dependencies from the project.json files over to the nuspec files.

This change should affect neither VS (which depends on msbuild via the vsix) nor CLI (who only publishes msbuild packages for .net core, not full framework).

Resolves #1681