### PR TITLE
Mark System.Threading.Task.Dataflow as Private=true

### DIFF
--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -764,18 +764,19 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="!$(Configuration.EndsWith('MONO'))"/>
   -->
   <Import Project="..\dir.targets" />
-  <Target Name="CopyImmutableLocal"
-          BeforeTargets="ResolveAssemblyReferences">
-    <!-- The VSIX installer manifest references System.Collections.Immutable from the Output folder,
-         but it won't be placed there by default because NuGet references come in as CopyLocal false.
+  <Target Name="CopyImmutableAndDataflowLocal"
+          BeforeTargets="ResolveAssemblyReferences"
+          AfterTargets="ResolveNuGetPackages">
+    <!-- The VSIX installer manifest references System.Collections.Immutable and System.Threading.Tasks.Dataflow
+         from the Output folder, but they won't be placed there by default because NuGet references come in as CopyLocal false.
 
-         Work around this by munging the reference after NuGet emits it but before RAR.
+         Work around this by munging the references after NuGet emits them but before RAR.
 
          TODO: this shouldn't be here. After moving to a better binplacing model (like "publish
          msbuild.exe to a folder") it should be removed.
     -->
     <ItemGroup>
-      <Reference Condition="'%(Reference.NuGetPackageId)' == 'System.Collections.Immutable'">
+      <Reference Condition="'%(Reference.NuGetPackageId)' == 'System.Collections.Immutable' or '%(Reference.NuGetPackageId)' == 'System.Threading.Tasks.Dataflow'">
         <Private>true</Private>
       </Reference>
     </ItemGroup>


### PR DESCRIPTION
To make our microbuild definition pass again for xplat.