### PR TITLE
Work around #1675 for C++ Code Analysis scenarios

### DIFF
--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -52,6 +52,20 @@
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
         </dependentAssembly>
+
+        <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
+        <dependentAssembly>
+          <assemblyIdentity name="FxCopTask" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\FxCopTask.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
+        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -46,6 +46,20 @@
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
         </dependentAssembly>
+
+        <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
+        <dependentAssembly>
+          <assemblyIdentity name="FxCopTask" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\FxCopTask.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
+        </dependentAssembly>
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->


### PR DESCRIPTION
This addresses the repro case for #1675, but not its root cause. By
providing a `codeBase` for the CA assemblies, we ensure that any running
MSBuild can find them when deserializing a log message.