### PR TITLE
Fix invalid indexer in HybridDictionary

### DIFF
--- a/src/Shared/HybridDictionary.cs
+++ b/src/Shared/HybridDictionary.cs
@@ -349,8 +349,8 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public object this[object key]
         {
-            get { return (Object)this[key]; }
-            set { this[key] = value; }
+            get { return ((IDictionary<TKey, TValue>)this)[(TKey)key]; }
+            set { ((IDictionary<TKey, TValue>)this)[(TKey)key] = (TValue)value; }
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/HybridDictionary_Tests.cs
+++ b/src/Shared/UnitTests/HybridDictionary_Tests.cs
@@ -193,6 +193,17 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             }
         }
 
+        [Fact]
+        private void VerifyHybridDictionaryBaseIndexer()
+        {
+            var dict = new HybridDictionary<string, string>();
+            dict[(object) "key"] = "value";
+
+            Assert.Equal("value", dict["key"]);
+            Assert.Equal("value", dict[(object)"key"]);
+            Assert.Equal("key", dict.Keys.First());
+        }
+
         /// <summary>
         /// Performs both actions supplied and asserts either both or neither threw
         /// </summary>


### PR DESCRIPTION
Indexer (defined in IDictionary) implemented in a way that recursively
calls itself. Nothing called this code, but if it did it would be wrong
(stack overflow).

Closes #77