### PR TITLE
Add support for .net SDK 4.7 - VersionLatestOnMachine

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -579,6 +579,8 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public string FrameworkVersion46Path { get { throw null; } }
         [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion47Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
         public string Path { get { throw null; } }
         public override bool Execute() { throw null; }
     }

--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Build.Utilities
         Version461 = 8,
         Version462 = 10,
         Version47 = 11,
-        VersionLatest = 11,
+        VersionLatest = 10,
         VersionLatestOnMachine = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>

--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -303,6 +303,7 @@ namespace Microsoft.Build.Utilities
     }
     public enum TargetDotNetFrameworkVersion
     {
+        Latest = 9999,
         Version11 = 0,
         Version20 = 1,
         Version30 = 2,
@@ -316,7 +317,6 @@ namespace Microsoft.Build.Utilities
         Version462 = 10,
         Version47 = 11,
         VersionLatest = 10,
-        VersionLatestOnMachine = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
     {

--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -316,6 +316,7 @@ namespace Microsoft.Build.Utilities
         Version462 = 10,
         Version47 = 11,
         VersionLatest = 11,
+        VersionLatestOnMachine = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
     {

--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -314,7 +314,8 @@ namespace Microsoft.Build.Utilities
         Version46 = 7,
         Version461 = 8,
         Version462 = 10,
-        VersionLatest = 10,
+        Version47 = 11,
+        VersionLatest = 11,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
     {

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -353,6 +353,8 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public string FrameworkVersion46Path { get { throw null; } }
         [Microsoft.Build.Framework.OutputAttribute]
+        public string FrameworkVersion47Path { get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
         public string Path { get { throw null; } }
         public override bool Execute() { throw null; }
     }

--- a/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -161,6 +161,7 @@ namespace Microsoft.Build.Utilities
         Version462 = 10,
         Version47 = 11,
         VersionLatest = 11,
+        VersionLatestOnMachine = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
     {

--- a/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -159,7 +159,8 @@ namespace Microsoft.Build.Utilities
         Version46 = 7,
         Version461 = 8,
         Version462 = 10,
-        VersionLatest = 10,
+        Version47 = 11,
+        VersionLatest = 11,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
     {

--- a/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Build.Utilities
         Version461 = 8,
         Version462 = 10,
         Version47 = 11,
-        VersionLatest = 11,
+        VersionLatest = 10,
         VersionLatestOnMachine = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>

--- a/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -148,6 +148,7 @@ namespace Microsoft.Build.Utilities
     }
     public enum TargetDotNetFrameworkVersion
     {
+        Latest = 9999,
         Version11 = 0,
         Version20 = 1,
         Version30 = 2,
@@ -161,7 +162,6 @@ namespace Microsoft.Build.Utilities
         Version462 = 10,
         Version47 = 11,
         VersionLatest = 10,
-        VersionLatestOnMachine = 9999,
     }
     public partial class TargetPlatformSDK : System.IEquatable<Microsoft.Build.Utilities.TargetPlatformSDK>
     {

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Build.Shared
         internal static readonly Version dotNetFrameworkVersion46 = new Version(4, 6);
         internal static readonly Version dotNetFrameworkVersion461 = new Version(4, 6, 1);
         internal static readonly Version dotNetFrameworkVersion462 = new Version(4, 6, 2);
+        internal static readonly Version dotNetFrameworkVersion47 = new Version(4, 7);
 
         // visual studio versions.
         internal static readonly Version visualStudioVersion100 = new Version(10, 0);
@@ -205,6 +206,9 @@ namespace Microsoft.Build.Shared
 
             // v4.6.2
             CreateDotNetFrameworkSpecForV4(dotNetFrameworkVersion462, visualStudioVersion150),
+
+            // v4.7
+            CreateDotNetFrameworkSpecForV4(dotNetFrameworkVersion47, visualStudioVersion150),
         };
 
         /// <summary>
@@ -272,7 +276,8 @@ namespace Microsoft.Build.Shared
                 dotNetFrameworkVersion452,
                 dotNetFrameworkVersion46,
                 dotNetFrameworkVersion461,
-                dotNetFrameworkVersion462
+                dotNetFrameworkVersion462,
+                dotNetFrameworkVersion47
             }),
         };
 
@@ -303,6 +308,7 @@ namespace Microsoft.Build.Shared
             { Tuple.Create(dotNetFrameworkVersion46, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion150) },
             { Tuple.Create(dotNetFrameworkVersion461, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion46, visualStudioVersion150) },
             { Tuple.Create(dotNetFrameworkVersion462, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion461, visualStudioVersion150) },
+            { Tuple.Create(dotNetFrameworkVersion47, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion47, visualStudioVersion150) },
        };
 
         private static readonly IReadOnlyDictionary<Version, DotNetFrameworkSpec> s_dotNetFrameworkSpecDict;
@@ -1159,8 +1165,11 @@ namespace Microsoft.Build.Shared
             {
                 string sdkVersionFolder = "4.6"; // Default for back-compat
 
-                // Framework 4.6.1 
-                if (dotNetSdkVersion == dotNetFrameworkVersion461)
+                if (dotNetSdkVersion == dotNetFrameworkVersion47)
+                {
+                    sdkVersionFolder = "4.7";
+                }
+                else if (dotNetSdkVersion == dotNetFrameworkVersion461)
                 {
                     sdkVersionFolder = "4.6.1";
                 }

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Build.Shared
             { Tuple.Create(dotNetFrameworkVersion46, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion150) },
             { Tuple.Create(dotNetFrameworkVersion461, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion46, visualStudioVersion150) },
             { Tuple.Create(dotNetFrameworkVersion462, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion461, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion47, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion47, visualStudioVersion150) },
+            { Tuple.Create(dotNetFrameworkVersion47, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion462, visualStudioVersion150) },
        };
 
         private static readonly IReadOnlyDictionary<Version, DotNetFrameworkSpec> s_dotNetFrameworkSpecDict;

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1970,6 +1970,10 @@ namespace Microsoft.Build.Utilities
                 case TargetDotNetFrameworkVersion.Version47:
                     return FrameworkLocationHelper.dotNetFrameworkVersion47;
 
+                case TargetDotNetFrameworkVersion.VersionLatestOnMachine:
+                    // VersionLatestOnMachine is a special value to indicate the highest version we know about.
+                    return FrameworkLocationHelper.dotNetFrameworkVersion47;
+
                 default:
                     ErrorUtilities.ThrowArgument("ToolLocationHelper.UnsupportedFrameworkVersion", version);
                     return null;

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -83,11 +83,16 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         Version462 = 10,
 
+        /// <summary>
+        /// version 4.7
+        /// </summary>
+        Version47 = 11,
+
         // keep this up to date, this should always point to the last entry
         /// <summary>
         /// the latest version available at the time of release
         /// </summary>
-        VersionLatest = Version462
+        VersionLatest = Version47
     }
 
     /// <summary>
@@ -1952,6 +1957,9 @@ namespace Microsoft.Build.Utilities
 
                 case TargetDotNetFrameworkVersion.Version462:
                     return FrameworkLocationHelper.dotNetFrameworkVersion462;
+
+                case TargetDotNetFrameworkVersion.Version47:
+                    return FrameworkLocationHelper.dotNetFrameworkVersion47;
 
                 default:
                     ErrorUtilities.ThrowArgument("ToolLocationHelper.UnsupportedFrameworkVersion", version);

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -88,11 +88,20 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         Version47 = 11,
 
-        // keep this up to date, this should always point to the last entry
+        // Keep this up to date, this should always point to the last entry
         /// <summary>
-        /// the latest version available at the time of release
+        /// The latest version available at the time of major release. This
+        /// value should not be updated in minor releases as it could be a
+        /// breaking change.
         /// </summary>
-        VersionLatest = Version47
+        VersionLatest = Version462,
+
+        /// <summary>
+        /// Sentinel value for the latest version that we currently know about. Similar to
+        /// VersionLatest except the compiled value in the calling application will not need
+        /// to change for the update in MSBuild to used.
+        /// </summary>
+        VersionLatestOnMachine = 9999
     }
 
     /// <summary>

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -88,20 +88,24 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         Version47 = 11,
 
-        // Keep this up to date, this should always point to the last entry
         /// <summary>
         /// The latest version available at the time of major release. This
         /// value should not be updated in minor releases as it could be a
-        /// breaking change.
+        /// breaking change. Use 'Latest' if possible, but note the
+        /// compatibility implications.
         /// </summary>
         VersionLatest = Version462,
 
         /// <summary>
-        /// Sentinel value for the latest version that we currently know about. Similar to
-        /// VersionLatest except the compiled value in the calling application will not need
-        /// to change for the update in MSBuild to used.
+        /// Sentinel value for the latest version that this version of MSBuild is aware of. Similar
+        /// to VersionLatest except the compiled value in the calling application will not need to
+        /// change for the update in MSBuild to be used.
         /// </summary>
-        VersionLatestOnMachine = 9999
+        /// <remarks>
+        /// This value was introduced in Visual Studio 15.1. It is incompatible with previous
+        /// versions of MSBuild.
+        /// </remarks>
+        Latest = 9999
     }
 
     /// <summary>
@@ -1644,7 +1648,7 @@ namespace Microsoft.Build.Utilities
         /// <returns>Path string.</returns>
         public static string GetPathToDotNetFrameworkSdk()
         {
-            return GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.VersionLatest);
+            return GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Latest);
         }
 
         /// <summary>
@@ -1970,8 +1974,8 @@ namespace Microsoft.Build.Utilities
                 case TargetDotNetFrameworkVersion.Version47:
                     return FrameworkLocationHelper.dotNetFrameworkVersion47;
 
-                case TargetDotNetFrameworkVersion.VersionLatestOnMachine:
-                    // VersionLatestOnMachine is a special value to indicate the highest version we know about.
+                case TargetDotNetFrameworkVersion.Latest:
+                    // Latest is a special value to indicate the highest version we know about.
                     return FrameworkLocationHelper.dotNetFrameworkVersion47;
 
                 default:
@@ -3212,7 +3216,7 @@ namespace Microsoft.Build.Utilities
         /// <returns>Path string.</returns>
         public static string GetPathToDotNetFrameworkSdkFile(string fileName)
         {
-            return GetPathToDotNetFrameworkSdkFile(fileName, TargetDotNetFrameworkVersion.VersionLatest);
+            return GetPathToDotNetFrameworkSdkFile(fileName, TargetDotNetFrameworkVersion.Latest);
         }
 
         /// <summary>

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -814,6 +814,7 @@ namespace Microsoft.Build.UnitTests
             string fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK46 = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6\WinSDK-NetFx40Tools-x86";
             string fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK461 = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools-x86";
             string fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK462 = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.2\WinSDK-NetFx40Tools-x86";
+            string fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK47 = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.7\WinSDK-NetFx40Tools-x86";
 
             // v4.0
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version40, VisualStudioVersion.Version100), fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK70A);
@@ -857,6 +858,12 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.AssertThrows(typeof(ArgumentException), delegate { ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version110); });
             ObjectModelHelpers.AssertThrows(typeof(ArgumentException), delegate { ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version120); });
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version462, VisualStudioVersion.Version150), fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK462);
+
+            // v4.7
+            ObjectModelHelpers.AssertThrows(typeof(ArgumentException), delegate { ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version100); });
+            ObjectModelHelpers.AssertThrows(typeof(ArgumentException), delegate { ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version110); });
+            ObjectModelHelpers.AssertThrows(typeof(ArgumentException), delegate { ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version120); });
+            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version150), fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK47);
         }
 
         [Fact]

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -648,6 +648,8 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.Version40), FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV40);
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest), FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV40);
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatest), FrameworkLocationHelper.fullDotNetFrameworkRegistryKey);
+            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatestOnMachine), FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV40);
+            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatestOnMachine), FrameworkLocationHelper.fullDotNetFrameworkRegistryKey);
 
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version11), FrameworkLocationHelper.PathToDotNetFrameworkV11);
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version20), FrameworkLocationHelper.PathToDotNetFrameworkV20);
@@ -655,6 +657,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version35), FrameworkLocationHelper.PathToDotNetFrameworkV35);
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version40), FrameworkLocationHelper.PathToDotNetFrameworkV40);
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatest), FrameworkLocationHelper.PathToDotNetFrameworkV40);
+            Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatestOnMachine), FrameworkLocationHelper.PathToDotNetFrameworkV40);
 
             Assert.Equal(
                     ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version11, UtilitiesDotNetFrameworkArchitecture.Bitness32),
@@ -679,6 +682,10 @@ namespace Microsoft.Build.UnitTests
                 );
             Assert.Equal(
                     ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatest, UtilitiesDotNetFrameworkArchitecture.Bitness32),
+                    FrameworkLocationHelper.GetPathToDotNetFrameworkV40(SharedDotNetFrameworkArchitecture.Bitness32)
+                );
+            Assert.Equal(
+                    ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatestOnMachine, UtilitiesDotNetFrameworkArchitecture.Bitness32),
                     FrameworkLocationHelper.GetPathToDotNetFrameworkV40(SharedDotNetFrameworkArchitecture.Bitness32)
                 );
 
@@ -708,6 +715,10 @@ namespace Microsoft.Build.UnitTests
                     );
                 Assert.Equal(
                         ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatest, UtilitiesDotNetFrameworkArchitecture.Bitness64),
+                        FrameworkLocationHelper.GetPathToDotNetFrameworkV40(SharedDotNetFrameworkArchitecture.Bitness64)
+                    );
+                Assert.Equal(
+                        ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatestOnMachine, UtilitiesDotNetFrameworkArchitecture.Bitness64),
                         FrameworkLocationHelper.GetPathToDotNetFrameworkV40(SharedDotNetFrameworkArchitecture.Bitness64)
                     );
             }
@@ -864,6 +875,9 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.AssertThrows(typeof(ArgumentException), delegate { ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version110); });
             ObjectModelHelpers.AssertThrows(typeof(ArgumentException), delegate { ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version120); });
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version150), fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK47);
+
+            // VersionLatestOnMachine (v4.7)
+            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatestOnMachine, VisualStudioVersion.Version150), fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK47);
         }
 
         [Fact]

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -648,8 +648,8 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.Version40), FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV40);
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest), FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV40);
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatest), FrameworkLocationHelper.fullDotNetFrameworkRegistryKey);
-            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatestOnMachine), FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV40);
-            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatestOnMachine), FrameworkLocationHelper.fullDotNetFrameworkRegistryKey);
+            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.Latest), FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV40);
+            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkRootRegistryKey(TargetDotNetFrameworkVersion.Latest), FrameworkLocationHelper.fullDotNetFrameworkRegistryKey);
 
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version11), FrameworkLocationHelper.PathToDotNetFrameworkV11);
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version20), FrameworkLocationHelper.PathToDotNetFrameworkV20);
@@ -657,7 +657,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version35), FrameworkLocationHelper.PathToDotNetFrameworkV35);
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version40), FrameworkLocationHelper.PathToDotNetFrameworkV40);
             Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatest), FrameworkLocationHelper.PathToDotNetFrameworkV40);
-            Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatestOnMachine), FrameworkLocationHelper.PathToDotNetFrameworkV40);
+            Assert.Equal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Latest), FrameworkLocationHelper.PathToDotNetFrameworkV40);
 
             Assert.Equal(
                     ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version11, UtilitiesDotNetFrameworkArchitecture.Bitness32),
@@ -685,7 +685,7 @@ namespace Microsoft.Build.UnitTests
                     FrameworkLocationHelper.GetPathToDotNetFrameworkV40(SharedDotNetFrameworkArchitecture.Bitness32)
                 );
             Assert.Equal(
-                    ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatestOnMachine, UtilitiesDotNetFrameworkArchitecture.Bitness32),
+                    ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Latest, UtilitiesDotNetFrameworkArchitecture.Bitness32),
                     FrameworkLocationHelper.GetPathToDotNetFrameworkV40(SharedDotNetFrameworkArchitecture.Bitness32)
                 );
 
@@ -718,7 +718,7 @@ namespace Microsoft.Build.UnitTests
                         FrameworkLocationHelper.GetPathToDotNetFrameworkV40(SharedDotNetFrameworkArchitecture.Bitness64)
                     );
                 Assert.Equal(
-                        ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatestOnMachine, UtilitiesDotNetFrameworkArchitecture.Bitness64),
+                        ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Latest, UtilitiesDotNetFrameworkArchitecture.Bitness64),
                         FrameworkLocationHelper.GetPathToDotNetFrameworkV40(SharedDotNetFrameworkArchitecture.Bitness64)
                     );
             }
@@ -876,8 +876,8 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.AssertThrows(typeof(ArgumentException), delegate { ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version120); });
             Assert.Equal(ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Version47, VisualStudioVersion.Version150), fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK47);
 
-            // VersionLatestOnMachine (v4.7)
-            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatestOnMachine, VisualStudioVersion.Version150), fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK47);
+            // Latest (v4.7)
+            Assert.Equal(ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Latest, VisualStudioVersion.Version150), fullDotNetFrameworkSdkRegistryPathForV4ToolsOnManagedToolsSDK47);
         }
 
         [Fact]
@@ -2744,7 +2744,7 @@ namespace Microsoft.Build.UnitTests
 
         private static IEnumerable<TargetDotNetFrameworkVersion> EnumDotNetFrameworkVersions()
         {
-            for (TargetDotNetFrameworkVersion dotNetVersion = TargetDotNetFrameworkVersion.Version11; dotNetVersion <= TargetDotNetFrameworkVersion.VersionLatest; ++dotNetVersion)
+            for (TargetDotNetFrameworkVersion dotNetVersion = TargetDotNetFrameworkVersion.Version11; dotNetVersion <= TargetDotNetFrameworkVersion.Latest; ++dotNetVersion)
             {
                 yield return dotNetVersion;
             }

--- a/src/XMakeTasks/Al.cs
+++ b/src/XMakeTasks/Al.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Build.Tasks
             // the SDK, which may or may not be installed. The following will look there.
             if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_InstallRoot")) || !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_Version")))
             {
-                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
+                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.Latest);
             }
 
             if (String.IsNullOrEmpty(pathToTool) || !File.Exists(pathToTool))

--- a/src/XMakeTasks/AspNetCompiler.cs
+++ b/src/XMakeTasks/AspNetCompiler.cs
@@ -328,12 +328,12 @@ namespace Microsoft.Build.Tasks
             string pathToTool = null;
 
             // If ToolPath wasn't passed in, we want to default to the latest
-            pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
+            pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.Latest);
 
             if (pathToTool == null)
             {
                 Log.LogErrorWithCodeFromResources("General.FrameworksFileNotFound", ToolExe,
-                    ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
+                    ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.Latest));
             }
 
             return pathToTool;

--- a/src/XMakeTasks/GetFrameworkPath.cs
+++ b/src/XMakeTasks/GetFrameworkPath.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Build.Tasks
             s_version46Path  = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version46));
             s_version461Path = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version461));
             s_version462Path = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version462));
+            s_version47Path = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version47));
         }
 
         #region ITask Members
@@ -59,6 +60,7 @@ namespace Microsoft.Build.Tasks
         private static Lazy<string> s_version46Path;
         private static Lazy<string> s_version461Path;
         private static Lazy<string> s_version462Path;
+        private static Lazy<string> s_version47Path;
 
         /// <summary>
         /// Path to the latest framework, whatever version it happens to be
@@ -132,6 +134,11 @@ namespace Microsoft.Build.Tasks
         [Output]
         public string FrameworkVersion462Path => s_version462Path.Value;
 
+        /// <summary>
+        /// Path to the v4.7 framework, if available
+        /// </summary>
+        [Output]
+        public string FrameworkVersion47Path => s_version47Path.Value;
         #endregion
     }
 }

--- a/src/XMakeTasks/GetFrameworkPath.cs
+++ b/src/XMakeTasks/GetFrameworkPath.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Build.Tasks
     {
         static GetFrameworkPath()
         {
-            s_path           = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.VersionLatest));
+            s_path           = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Latest));
             s_version11Path  = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version11));
             s_version20Path  = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version20));
             s_version30Path  = new Lazy<string>(() => ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version30));

--- a/src/XMakeTasks/GetFrameworkSDKPath.cs
+++ b/src/XMakeTasks/GetFrameworkSDKPath.cs
@@ -38,15 +38,15 @@ namespace Microsoft.Build.Tasks
             {
                 if (s_path == null)
                 {
-                    s_path = ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.VersionLatest, VisualStudioVersion.VersionLatest);
+                    s_path = ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Latest, VisualStudioVersion.VersionLatest);
 
                     if (String.IsNullOrEmpty(s_path))
                     {
                         Log.LogMessageFromResources(
                             MessageImportance.High,
                             "GetFrameworkSdkPath.CouldNotFindSDK",
-                            ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.VersionLatest, VisualStudioVersion.VersionLatest),
-                            ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatest, VisualStudioVersion.VersionLatest)
+                            ToolLocationHelper.GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion.Latest, VisualStudioVersion.VersionLatest),
+                            ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Latest, VisualStudioVersion.VersionLatest)
                         );
 
                         s_path = String.Empty;

--- a/src/XMakeTasks/ResolveComReference.cs
+++ b/src/XMakeTasks/ResolveComReference.cs
@@ -621,7 +621,7 @@ namespace Microsoft.Build.Tasks
                 // be empty (because it's referencing the 7.0A SDK in the registry, which doesn't exist).  In that case, we 
                 // want to look for VersionLatest.  However, if ExecuteAsTool is true (default value) and SDKToolsPath is 
                 // empty, then we can safely assume that we want to get the 3.5 version of the tool.
-                TargetDotNetFrameworkVersion targetAxImpVersion = ExecuteAsTool ? TargetDotNetFrameworkVersion.Version35 : TargetDotNetFrameworkVersion.VersionLatest;
+                TargetDotNetFrameworkVersion targetAxImpVersion = ExecuteAsTool ? TargetDotNetFrameworkVersion.Version35 : TargetDotNetFrameworkVersion.Latest;
 
                 // We want to use the copy of AxImp corresponding to our targeted architecture if possible.  
                 _aximpPath = GetPathToSDKFileWithCurrentlyTargetedArchitecture("AxImp.exe", targetAxImpVersion, VisualStudioVersion.VersionLatest);

--- a/src/XMakeTasks/SGen.cs
+++ b/src/XMakeTasks/SGen.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Build.Tasks
             // the SDK, which may or may not be installed. The following will look there.
             if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_InstallRoot")) || !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_Version")))
             {
-                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
+                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.Latest);
             }
 
             if (String.IsNullOrEmpty(pathToTool) || !File.Exists(pathToTool))

--- a/src/XMakeTasks/SdkToolsPathUtility.cs
+++ b/src/XMakeTasks/SdkToolsPathUtility.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Build.Tasks
 
                 if (pathToTool == null && logErrorsAndWarnings)
                 {
-                    log.LogErrorWithCodeFromResources("General.SdkToolsPathToolDoesNotExist", toolName, sdkToolsPath, ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatest, VisualStudioVersion.VersionLatest));
+                    log.LogErrorWithCodeFromResources("General.SdkToolsPathToolDoesNotExist", toolName, sdkToolsPath, ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Latest, VisualStudioVersion.VersionLatest));
                 }
             }
 
@@ -148,7 +148,7 @@ namespace Microsoft.Build.Tasks
         internal static string FindSDKToolUsingToolsLocationHelper(string toolName)
         {
             // If it isn't there, we should find it in the SDK based on the version compiled into the utilities
-            string pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile(toolName, TargetDotNetFrameworkVersion.VersionLatest, VisualStudioVersion.VersionLatest);
+            string pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile(toolName, TargetDotNetFrameworkVersion.Latest, VisualStudioVersion.VersionLatest);
             return pathToTool;
         }
 

--- a/src/XMakeTasks/UnitTests/SdkToolsPathUtility_Tests.cs
+++ b/src/XMakeTasks/UnitTests/SdkToolsPathUtility_Tests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Build.UnitTests
             _mockEngine.AssertLogContains(comment);
             Assert.Equal(0, _mockEngine.Warnings);
 
-            comment = ResourceUtilities.FormatResourceString("General.SdkToolsPathToolDoesNotExist", _toolName, null, ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatest));
+            comment = ResourceUtilities.FormatResourceString("General.SdkToolsPathToolDoesNotExist", _toolName, null, ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Latest));
             _mockEngine.AssertLogContains(comment);
             Assert.Equal(1, _mockEngine.Errors);
         }
@@ -184,7 +184,7 @@ namespace Microsoft.Build.UnitTests
             string comment = ResourceUtilities.FormatResourceString("General.PlatformSDKFileNotFoundSdkToolsPath", _toolName, _defaultSdkToolsPath, _defaultSdkToolsPath);
             _mockEngine.AssertLogContains(comment);
 
-            comment = ResourceUtilities.FormatResourceString("General.SdkToolsPathToolDoesNotExist", _toolName, _defaultSdkToolsPath, ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.VersionLatest));
+            comment = ResourceUtilities.FormatResourceString("General.SdkToolsPathToolDoesNotExist", _toolName, _defaultSdkToolsPath, ToolLocationHelper.GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion.Latest));
             _mockEngine.AssertLogContains(comment);
             Assert.Equal(1, _mockEngine.Errors);
         }


### PR DESCRIPTION
Will likely close PR #1696 in favor of this one. Wanted to get the idea out there for review.

* Add support for .net SDK 4.7. It will release with Dev15.1.
* Update VersionLatest to remain at 4.6.2 (latest at RTM).
* Add VersionLatestOnMachine to identify latest MSBuild knows about.
* Fix issue with fallback (StackOverflow on unit tests).

@davkean Given what we have to work with, how does this sound? VersionLatest would be fixed per major update (4.6.2 for Dev15). VersionLatestOnMachine would mean use the latest whatever version it is (that MSBuild knows about, still has to be updated per sdk release). (I realize this isn't implemented, I just wanted to get the idea out for review in case anyone can think of something obvious we're missing.)