### PR TITLE
Enable XmlPeek and XmlPoke tasks for .NET Core. 

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -59,6 +59,8 @@
         <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
         <dependency id="System.Xml.XDocument" version="4.0.11" />
         <dependency id="System.Xml.XmlDocument" version="4.0.1" />
+        <dependency id="System.Xml.XPath" version="4.0.1" />
+        <dependency id="System.Xml.XPath.XmlDocument" version="4.0.1" />
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
@@ -104,6 +106,8 @@
         <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
         <dependency id="System.Xml.XDocument" version="4.0.11" />
         <dependency id="System.Xml.XmlDocument" version="4.0.1" />
+        <dependency id="System.Xml.XPath" version="4.0.1" />
+        <dependency id="System.Xml.XPath.XmlDocument" version="4.0.1" />
       </group>
     </dependencies>
   </metadata>

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -637,6 +637,27 @@ namespace Microsoft.Build.Tasks
         public bool WriteOnlyWhenDifferent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
+    public partial class XmlPeek : Microsoft.Build.Tasks.TaskExtension
+    {
+        public XmlPeek() { }
+        public string Namespaces { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Result { get { throw null; } }
+        public string XmlContent { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public partial class XmlPoke : Microsoft.Build.Tasks.TaskExtension
+    {
+        public XmlPoke() { }
+        public string Namespaces { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem Value { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
 }
 namespace Microsoft.Build.Tasks.Hosting
 {

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -94,7 +94,6 @@
     <Compile Include="WriteCodeFragment_Tests.cs" />
     <Compile Include="XmlPeek_Tests.cs" />
     <Compile Include="XmlPoke_Tests.cs" />
-    <Compile Include="XslTransformation_Tests.cs" />
     <EmbeddedResource Include="SampleResx" />
     <None Include="..\Shared\UnitTests\App.config">
       <Link>App.config</Link>
@@ -160,6 +159,7 @@
     <Compile Include="VisualBasicParserUtilitites_Tests.cs" />
     <Compile Include="VisualBasicTokenizer_Tests.cs" />
     <Compile Include="WinMDExp_Tests.cs" />
+    <Compile Include="XslTransformation_Tests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj">

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -92,6 +92,9 @@
     <Compile Include="Touch_Tests.cs" />
     <Compile Include="TrustInfo_Tests.cs" />
     <Compile Include="WriteCodeFragment_Tests.cs" />
+    <Compile Include="XmlPeek_Tests.cs" />
+    <Compile Include="XmlPoke_Tests.cs" />
+    <Compile Include="XslTransformation_Tests.cs" />
     <EmbeddedResource Include="SampleResx" />
     <None Include="..\Shared\UnitTests\App.config">
       <Link>App.config</Link>
@@ -157,9 +160,6 @@
     <Compile Include="VisualBasicParserUtilitites_Tests.cs" />
     <Compile Include="VisualBasicTokenizer_Tests.cs" />
     <Compile Include="WinMDExp_Tests.cs" />
-    <Compile Include="XmlPeek_Tests.cs" />
-    <Compile Include="XmlPoke_Tests.cs" />
-    <Compile Include="XslTransformation_Tests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj">

--- a/src/Tasks.UnitTests/XmlPeek_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPeek_Tests.cs
@@ -19,7 +19,6 @@ using System.Reflection.Emit;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Text;
-using System.Xml.Xsl;
 using System.Xml;
 using Xunit;
 
@@ -315,11 +314,7 @@ namespace Microsoft.Build.UnitTests
             string dir = Path.Combine(Path.GetTempPath(), DateTime.Now.Ticks.ToString());
             Directory.CreateDirectory(dir);
             xmlInputPath = dir + Path.DirectorySeparatorChar + "doc.xml";
-            using (StreamWriter sw = new StreamWriter(xmlInputPath, false))
-            {
-                sw.Write(xmlFile);
-                sw.Close();
-            }
+            File.WriteAllText(xmlInputPath, xmlFile);
         }
     }
 }

--- a/src/Tasks.UnitTests/XmlPoke_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPoke_Tests.cs
@@ -66,32 +66,6 @@ namespace Microsoft.Build.UnitTests
             Assert.True(nodes?.All(i => i.Value.Equals("Mert")), $"All <variable /> elements should have Name=\"Mert\" {Environment.NewLine}{xmlDocument.OuterXml}");
         }
 
-        private XmlDocument ExecuteXmlPoke(string query, bool useNamespace = false, string value = null)
-        {
-            MockEngine engine = new MockEngine(true);
-
-            string xmlInputPath;
-            Prepare(useNamespace ? _xmlFileWithNs : _xmlFileNoNs, out xmlInputPath);
-
-            XmlPoke p = new XmlPoke
-            {
-                BuildEngine = engine,
-                XmlInputPath = new TaskItem(xmlInputPath),
-                Query = query,
-                Namespaces = useNamespace ? $"<Namespace Prefix=\"s\" Uri=\"{XmlNamespaceUsedByTests}\" />" : null,
-                Value = value == null ? null : new TaskItem(value)
-            };
-            Assert.True(p.Execute(), engine.Log);
-
-            string result = File.ReadAllText(xmlInputPath);
-
-            XmlDocument xmlDocument = new XmlDocument();
-            
-            xmlDocument.LoadXml(result);
-
-            return xmlDocument;
-        }
-
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         public void PokeNoNamespace()
@@ -307,6 +281,39 @@ namespace Microsoft.Build.UnitTests
             Directory.CreateDirectory(dir);
             xmlInputPath = dir + Path.DirectorySeparatorChar + "doc.xml";
             File.WriteAllText(xmlInputPath, xmlFile);
+        }
+
+        /// <summary>
+        /// Executes an <see cref="XmlPoke"/> task with the specified arguments.
+        /// </summary>
+        /// <param name="query">The query to use.</param>
+        /// <param name="useNamespace"><code>true</code> to use namespaces, otherwise <code>false</code> (Default).</param>
+        /// <param name="value">The value to use.</param>
+        /// <returns>An <see cref="XmlDocument"/> containing the resulting XML after the XmlPoke task has executed.</returns>
+        private XmlDocument ExecuteXmlPoke(string query, bool useNamespace = false, string value = null)
+        {
+            MockEngine engine = new MockEngine(true);
+
+            string xmlInputPath;
+            Prepare(useNamespace ? _xmlFileWithNs : _xmlFileNoNs, out xmlInputPath);
+
+            XmlPoke p = new XmlPoke
+            {
+                BuildEngine = engine,
+                XmlInputPath = new TaskItem(xmlInputPath),
+                Query = query,
+                Namespaces = useNamespace ? $"<Namespace Prefix=\"s\" Uri=\"{XmlNamespaceUsedByTests}\" />" : null,
+                Value = value == null ? null : new TaskItem(value)
+            };
+            Assert.True(p.Execute(), engine.Log);
+
+            string result = File.ReadAllText(xmlInputPath);
+
+            XmlDocument xmlDocument = new XmlDocument();
+
+            xmlDocument.LoadXml(result);
+
+            return xmlDocument;
         }
     }
 }

--- a/src/Tasks.UnitTests/XmlPoke_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPoke_Tests.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.IO;
-using System.Text.RegularExpressions;
+using System.Linq;
 using System.Text;
 using System.Xml;
 using Xunit;
@@ -26,9 +26,11 @@ namespace Microsoft.Build.UnitTests
 {
     sealed public class XmlPoke_Tests
     {
-        private string _xmlFileWithNs = @"<?xml version='1.0' encoding='utf-8'?>
+        private const string XmlNamespaceUsedByTests = "http://nsurl";
+
+        private string _xmlFileWithNs = $@"<?xml version='1.0' encoding='utf-8'?>
         
-<class AccessModifier='public' Name='test' xmlns:s='http://nsurl'>
+<class AccessModifier='public' Name='test' xmlns:s='{XmlNamespaceUsedByTests}'>
   <s:variable Type='String' Name='a'></s:variable>
   <s:variable Type='String' Name='b'></s:variable>
   <s:variable Type='String' Name='c'></s:variable>
@@ -47,99 +49,97 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void PokeWithNamespace()
         {
+            const string query = "//s:variable/@Name";
+
+            XmlDocument xmlDocument = ExecuteXmlPoke(
+                query: query,
+                useNamespace: true,
+                value: "Mert");
+
+            XmlNamespaceManager ns = new XmlNamespaceManager(xmlDocument.NameTable);
+            ns.AddNamespace("s", XmlNamespaceUsedByTests);
+
+            List<XmlAttribute> nodes = xmlDocument.SelectNodes(query, ns)?.Cast<XmlAttribute>().ToList();
+
+            Assert.True(nodes?.Count == 3, $"There should be 3 <variable /> elements with a Name attribute {Environment.NewLine}{xmlDocument.OuterXml}");
+
+            Assert.True(nodes?.All(i => i.Value.Equals("Mert")), $"All <variable /> elements should have Name=\"Mert\" {Environment.NewLine}{xmlDocument.OuterXml}");
+        }
+
+        private XmlDocument ExecuteXmlPoke(string query, bool useNamespace = false, string value = null)
+        {
             MockEngine engine = new MockEngine(true);
+
             string xmlInputPath;
-            Prepare(_xmlFileWithNs, out xmlInputPath);
+            Prepare(useNamespace ? _xmlFileWithNs : _xmlFileNoNs, out xmlInputPath);
 
-            XmlPoke p = new XmlPoke();
-            p.BuildEngine = engine;
-            p.XmlInputPath = new TaskItem(xmlInputPath);
-            p.Query = "//s:variable/@Name";
-            p.Namespaces = "<Namespace Prefix=\"s\" Uri=\"http://nurl\" />";
-            p.Value = new TaskItem("Mert");
-            p.Execute();
-
-            List<int> positions = new List<int>();
-            positions.AddRange(new int[] {141, 200, 259});
+            XmlPoke p = new XmlPoke
+            {
+                BuildEngine = engine,
+                XmlInputPath = new TaskItem(xmlInputPath),
+                Query = query,
+                Namespaces = useNamespace ? $"<Namespace Prefix=\"s\" Uri=\"{XmlNamespaceUsedByTests}\" />" : null,
+                Value = value == null ? null : new TaskItem(value)
+            };
+            Assert.True(p.Execute(), engine.Log);
 
             string result = File.ReadAllText(xmlInputPath);
-            Regex r = new Regex("Mert");
-            MatchCollection mc = r.Matches(result);
 
-            foreach (Match m in mc)
-            {
-                Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
-            }
+            XmlDocument xmlDocument = new XmlDocument();
+            
+            xmlDocument.LoadXml(result);
+
+            return xmlDocument;
         }
 
         [Fact]
         [Trait("Category", "mono-osx-failing")]
         public void PokeNoNamespace()
         {
-            MockEngine engine = new MockEngine(true);
-            string xmlInputPath;
-            Prepare(_xmlFileNoNs, out xmlInputPath);
+            const string query = "//variable/@Name";
+            const string value = "Mert";
 
-            XmlPoke p = new XmlPoke();
-            p.BuildEngine = engine;
-            p.XmlInputPath = new TaskItem(xmlInputPath);
-            p.Query = "//variable/@Name";
-            p.Value = new TaskItem("Mert");
-            p.Execute();
+            XmlDocument xmlDocument = ExecuteXmlPoke(query: query, value: value);
 
-            List<int> positions = new List<int>();
-            positions.AddRange(new int[] {117, 172, 227});
+            List<XmlAttribute> nodes = xmlDocument.SelectNodes(query)?.Cast<XmlAttribute>().ToList();
 
-            string result = File.ReadAllText(xmlInputPath);
-            Regex r = new Regex("Mert");
-            MatchCollection mc = r.Matches(result);
+            Assert.True(nodes?.Count == 3, $"There should be 3 <variable /> elements with a Name attribute {Environment.NewLine}{xmlDocument.OuterXml}");
 
-            foreach (Match m in mc)
-            {
-                Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
-            }
+            Assert.True(nodes?.All(i => i.Value.Equals(value)), $"All <variable /> elements should have Name=\"{value}\" {Environment.NewLine}{xmlDocument.OuterXml}");
         }
 
         [Fact]
         public void PokeAttribute()
         {
-            MockEngine engine = new MockEngine(true);
-            string xmlInputPath;
-            Prepare(_xmlFileNoNs, out xmlInputPath);
+            const string query = "//class[1]/@AccessModifier";
+            const string value = "<Test>Testing</Test>";
 
-            XmlPoke p = new XmlPoke();
-            p.BuildEngine = engine;
-            p.XmlInputPath = new TaskItem(xmlInputPath);
-            p.Query = "//class[1]/@AccessModifier";
-            p.Value = new TaskItem("<Test>Testing</Test>");
-            p.Execute();
-            string result = File.ReadAllText(xmlInputPath);
-            Regex r = new Regex("AccessModifier=\"&lt;Test&gt;Testing&lt;/Test&gt;\"");
-            MatchCollection mc = r.Matches(result);
+            XmlDocument xmlDocument = ExecuteXmlPoke(query: query, value: value);
 
-            Assert.Equal(1, mc.Count); // "Should match once"
+            List<XmlAttribute> nodes = xmlDocument.SelectNodes(query)?.Cast<XmlAttribute>().ToList();
+
+            Assert.True(nodes?.Count == 1, $"There should be 1 <class /> element with an AccessModifier attribute {Environment.NewLine}{xmlDocument.OuterXml}");
+
+            Assert.Equal(value, nodes?.First().Value);
         }
 
         [Fact]
         public void PokeChildren()
         {
-            MockEngine engine = new MockEngine(true);
-            string xmlInputPath;
-            Prepare(_xmlFileNoNs, out xmlInputPath);
+            const string query = "//class/.";
+            const string value = "<Test>Testing</Test>";
 
-            XmlPoke p = new XmlPoke();
-            p.BuildEngine = engine;
-            p.XmlInputPath = new TaskItem(xmlInputPath);
-            p.Query = "//class/.";
-            p.Value = new TaskItem("<Test>Testing</Test>");
-            Assert.True(p.Execute(), engine.Log);
+            XmlDocument xmlDocument = ExecuteXmlPoke(query: query, value: value);
 
-            string result = File.ReadAllText(xmlInputPath);
+            List<XmlElement> nodes = xmlDocument.SelectNodes(query)?.Cast<XmlElement>().ToList();
 
-            Regex r = new Regex("<Test>Testing</Test>");
-            MatchCollection mc = r.Matches(result);
+            Assert.True(nodes?.Count == 1, $"There should be 1 <class /> element {Environment.NewLine}{xmlDocument.OuterXml}");
 
-            Assert.Equal(1, mc.Count); // "Should match once"
+            var testNodes = nodes?.First().ChildNodes.Cast<XmlElement>().ToList();
+
+            Assert.True(testNodes?.Count == 1, $"There should be 1 <class /> element with one child Test element {Environment.NewLine}{xmlDocument.OuterXml}");
+
+            Assert.Equal("Testing", testNodes?.First().InnerText);
         }
 
         [Fact]
@@ -269,33 +269,18 @@ namespace Microsoft.Build.UnitTests
         [Trait("Category", "mono-osx-failing")]
         public void PokeElement()
         {
-            MockEngine engine = new MockEngine(true);
-            string xmlInputPath;
-            Prepare(_xmlFileNoNs, out xmlInputPath);
+            const string query = "//variable/.";
+            const string value = "<testing the=\"element\">With<somewhat complex=\"value\" /></testing>";
 
-            XmlPoke p = new XmlPoke();
-            p.BuildEngine = engine;
-            p.XmlInputPath = new TaskItem(xmlInputPath);
-            Assert.True(p.XmlInputPath.ItemSpec.Equals(xmlInputPath));
-            p.Query = "//variable/.";
-            Assert.True(p.Query.Equals("//variable/."));
-            string valueString = "<testing the=\"element\">With<somewhat complex=\"value\" /></testing>";
-            p.Value = new TaskItem(valueString);
-            Assert.True(p.Value.ItemSpec.Equals(valueString));
+            XmlDocument xmlDocument = ExecuteXmlPoke(query: query, value: value);
 
-            Assert.True(p.Execute());
+            List<XmlElement> nodes = xmlDocument.SelectNodes(query)?.Cast<XmlElement>().ToList();
 
-            List<int> positions = new List<int>();
-            positions.AddRange(new int[] {126, 249, 372});
+            Assert.True(nodes?.Count == 3, $"There should be 3 <variable/> elements {Environment.NewLine}{xmlDocument.OuterXml}");
 
-            string result = File.ReadAllText(xmlInputPath);
-
-            Regex r = new Regex("<testing the=\"element\">With<somewhat complex=\"value\" /></testing>");
-            MatchCollection mc = r.Matches(result);
-
-            foreach (Match m in mc)
+            foreach (var node in nodes)
             {
-                Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
+                Assert.Equal(value, node.InnerXml);
             }
         }
 

--- a/src/Tasks.UnitTests/XmlPoke_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPoke_Tests.cs
@@ -19,7 +19,6 @@ using System.Reflection.Emit;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Text;
-using System.Xml.Xsl;
 using System.Xml;
 using Xunit;
 
@@ -61,19 +60,15 @@ namespace Microsoft.Build.UnitTests
             p.Execute();
 
             List<int> positions = new List<int>();
-            positions.AddRange(new int[] { 141, 200, 259 });
+            positions.AddRange(new int[] {141, 200, 259});
 
-            string result;
-            using (StreamReader sr = new StreamReader(xmlInputPath))
+            string result = File.ReadAllText(xmlInputPath);
+            Regex r = new Regex("Mert");
+            MatchCollection mc = r.Matches(result);
+
+            foreach (Match m in mc)
             {
-                result = sr.ReadToEnd();
-                Regex r = new Regex("Mert");
-                MatchCollection mc = r.Matches(result);
-
-                foreach (Match m in mc)
-                {
-                    Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
-                }
+                Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
             }
         }
 
@@ -93,19 +88,15 @@ namespace Microsoft.Build.UnitTests
             p.Execute();
 
             List<int> positions = new List<int>();
-            positions.AddRange(new int[] { 117, 172, 227 });
+            positions.AddRange(new int[] {117, 172, 227});
 
-            string result;
-            using (StreamReader sr = new StreamReader(xmlInputPath))
+            string result = File.ReadAllText(xmlInputPath);
+            Regex r = new Regex("Mert");
+            MatchCollection mc = r.Matches(result);
+
+            foreach (Match m in mc)
             {
-                result = sr.ReadToEnd();
-                Regex r = new Regex("Mert");
-                MatchCollection mc = r.Matches(result);
-
-                foreach (Match m in mc)
-                {
-                    Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
-                }
+                Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
             }
         }
 
@@ -122,15 +113,11 @@ namespace Microsoft.Build.UnitTests
             p.Query = "//class[1]/@AccessModifier";
             p.Value = new TaskItem("<Test>Testing</Test>");
             p.Execute();
-            string result;
-            using (StreamReader sr = new StreamReader(xmlInputPath))
-            {
-                result = sr.ReadToEnd();
-                Regex r = new Regex("AccessModifier=\"&lt;Test&gt;Testing&lt;/Test&gt;\"");
-                MatchCollection mc = r.Matches(result);
+            string result = File.ReadAllText(xmlInputPath);
+            Regex r = new Regex("AccessModifier=\"&lt;Test&gt;Testing&lt;/Test&gt;\"");
+            MatchCollection mc = r.Matches(result);
 
-                Assert.Equal(1, mc.Count); // "Should match once"
-            }
+            Assert.Equal(1, mc.Count); // "Should match once"
         }
 
         [Fact]
@@ -147,16 +134,12 @@ namespace Microsoft.Build.UnitTests
             p.Value = new TaskItem("<Test>Testing</Test>");
             Assert.True(p.Execute(), engine.Log);
 
-            string result;
-            using (StreamReader sr = new StreamReader(xmlInputPath))
-            {
-                result = sr.ReadToEnd();
+            string result = File.ReadAllText(xmlInputPath);
 
-                Regex r = new Regex("<Test>Testing</Test>");
-                MatchCollection mc = r.Matches(result);
+            Regex r = new Regex("<Test>Testing</Test>");
+            MatchCollection mc = r.Matches(result);
 
-                Assert.Equal(1, mc.Count); // "Should match once"
-            }
+            Assert.Equal(1, mc.Count); // "Should match once"
         }
 
         [Fact]
@@ -303,20 +286,16 @@ namespace Microsoft.Build.UnitTests
             Assert.True(p.Execute());
 
             List<int> positions = new List<int>();
-            positions.AddRange(new int[] { 126, 249, 372 });
+            positions.AddRange(new int[] {126, 249, 372});
 
-            string result;
-            using (StreamReader sr = new StreamReader(xmlInputPath))
+            string result = File.ReadAllText(xmlInputPath);
+
+            Regex r = new Regex("<testing the=\"element\">With<somewhat complex=\"value\" /></testing>");
+            MatchCollection mc = r.Matches(result);
+
+            foreach (Match m in mc)
             {
-                result = sr.ReadToEnd();
-
-                Regex r = new Regex("<testing the=\"element\">With<somewhat complex=\"value\" /></testing>");
-                MatchCollection mc = r.Matches(result);
-
-                foreach (Match m in mc)
-                {
-                    Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
-                }
+                Assert.True(positions.Contains(m.Index), "This test should effect 3 positions. There should be 3 occurances of 'Mert'\n" + result);
             }
         }
 
@@ -342,11 +321,7 @@ namespace Microsoft.Build.UnitTests
             string dir = Path.Combine(Path.GetTempPath(), DateTime.Now.Ticks.ToString());
             Directory.CreateDirectory(dir);
             xmlInputPath = dir + Path.DirectorySeparatorChar + "doc.xml";
-            using (StreamWriter sw = new StreamWriter(xmlInputPath, false))
-            {
-                sw.Write(xmlFile);
-                sw.Close();
-            }
+            File.WriteAllText(xmlInputPath, xmlFile);
         }
     }
 }

--- a/src/Tasks.UnitTests/project.json
+++ b/src/Tasks.UnitTests/project.json
@@ -25,6 +25,8 @@
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",
         "System.Xml.XmlDocument": "4.0.1",
+        "System.Xml.XPath": "4.0.1",
+        "System.Xml.XPath.XmlDocument":  "4.0.1",
         "Microsoft.Win32.Primitives": "4.0.1",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
         "Microsoft.NETCore.TestHost": "1.0.0",

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -520,6 +520,8 @@
     <Compile Include="Culture.cs" />
     <Compile Include="CultureInfoCache.cs" />
     <Compile Include="WriteCodeFragment.cs" />
+    <Compile Include="XmlPeek.cs" />
+    <Compile Include="XmlPoke.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <Compile Include="Al.cs">
@@ -679,8 +681,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="WinMDExp.cs" />
-    <Compile Include="XmlPeek.cs" />
-    <Compile Include="XmlPoke.cs" />
     <Compile Include="XslTransformation.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureXamlTypes)' == 'true'">

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -679,6 +679,9 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="WinMDExp.cs" />
+    <Compile Include="XmlPeek.cs" />
+    <Compile Include="XmlPoke.cs" />
+    <Compile Include="XslTransformation.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureXamlTypes)' == 'true'">
     <Compile Include="XamlTaskFactory\CommandLineGenerator.cs" />
@@ -697,9 +700,6 @@
     <Compile Include="XamlTaskFactory\XamlTaskFactory.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
-    <Compile Include="XmlPeek.cs" />
-    <Compile Include="XmlPoke.cs" />
-    <Compile Include="XslTransformation.cs" />
     <!-- Shim targets only work when the destination targets are installed. -->
     <Content Include="Microsoft.Data.Entity.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Tasks/XmlPeek.cs
+++ b/src/Tasks/XmlPeek.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Build.Tasks
                 using (XmlReader xr = xmlinput.CreateReader())
                 {
                     xpathdoc = new XPathDocument(xr);
-                    xr.Close();
+                    xr.Dispose();
                 }
             }
             catch (Exception e)
@@ -401,7 +401,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (_fs != null)
                 {
-                    _fs.Close();
+                    _fs.Dispose();
                     _fs = null;
                 }
             }

--- a/src/Tasks/XmlPoke.cs
+++ b/src/Tasks/XmlPoke.cs
@@ -223,7 +223,14 @@ namespace Microsoft.Build.Tasks
 
             if (iter.Count > 0)
             {
+#if RUNTIME_TYPE_NETCORE
+                using (Stream stream = File.Create(_xmlInputPath.ItemSpec))
+                {
+                    xmlDoc.Save(stream);
+                }
+#else
                 xmlDoc.Save(_xmlInputPath.ItemSpec);
+#endif
             }
 
             return true;

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -22,7 +22,9 @@
         "System.Runtime.Serialization.Xml": "4.1.1",
         "System.Security.Cryptography.Algorithms": "4.2.0",
         "System.Threading.Thread": "4.0.0",
-        "System.Xml.XmlDocument": "4.0.1"
+        "System.Xml.XmlDocument": "4.0.1",
+        "System.Xml.XPath": "4.0.1",
+        "System.Xml.XPath.XmlDocument":  "4.0.1"
       }
     }
   }


### PR DESCRIPTION
Had to add some additional dependencies and fix up some tests to use `netstandard` APIs.

Closes #1731