### PR TITLE
Fix GetLastWriteFileUtcTime function for a directories

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -900,6 +900,10 @@ namespace Microsoft.Build.Shared
             {
                 fileModifiedTime = File.GetLastWriteTimeUtc(fullPath);
             }
+            else if (Directory.Exists(fullPath))
+            {
+                fileModifiedTime = Directory.GetLastWriteTimeUtc(fullPath);
+            }
 
             return fileModifiedTime;
         }

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -880,7 +880,7 @@ namespace Microsoft.Build.Shared
                 {
                     using (SafeFileHandle handle =
                         CreateFile(fullPath, GENERIC_READ, FILE_SHARE_READ, IntPtr.Zero, OPEN_EXISTING,
-                            FILE_ATTRIBUTE_NORMAL, IntPtr.Zero))
+                            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS, IntPtr.Zero))
                     {
                         if (!handle.IsInvalid)
                         {
@@ -1305,6 +1305,7 @@ namespace Microsoft.Build.Shared
         internal const uint GENERIC_READ = 0x80000000;
         internal const uint FILE_SHARE_READ = 0x1;
         internal const uint FILE_ATTRIBUTE_NORMAL = 0x80;
+        internal const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
         internal const uint FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
         internal const uint OPEN_EXISTING = 3;
 

--- a/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
+++ b/src/Shared/UnitTests/NativeMethodsShared_Tests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.UnitTests
 
         /// <summary>
         /// Verifies that when NativeMethodsShared.GetLastWriteFileUtcTime() is called on a
-        /// missing time, DateTime.MinValue is returned.
+        /// missing file, DateTime.MinValue is returned.
         /// </summary>
         [Fact]
         public void GetLastWriteFileUtcTimeReturnsMinValueForMissingFile()
@@ -81,6 +81,23 @@ namespace Microsoft.Build.UnitTests
 
             DateTime nonexistentFileTime = NativeMethodsShared.GetLastWriteFileUtcTime(nonexistentFile);
             Assert.Equal(DateTime.MinValue, nonexistentFileTime);
+        }
+
+        /// <summary>
+        /// Verifies that when NativeMethodsShared.GetLastWriteFileUtcTime() is called on a
+        /// existing directory, not DateTime.MinValue is returned.
+        /// </summary>
+        [Fact]
+        public void GetLastWriteFileUtcTimeReturnsNotMinValueForExistingDirectory()
+        {
+            string tempDirectory = FileUtilities.GetTemporaryDirectory();
+            // Make sure that the directory exists, create if not.
+            if (!Directory.Exists(tempDirectory))
+                Directory.CreateDirectory(tempDirectory);
+
+            DateTime existsDirectoryTime = NativeMethodsShared.GetLastWriteFileUtcTime(tempDirectory);
+            Assert.NotEqual(DateTime.MinValue, existsDirectoryTime);
+            Directory.Delete(tempDirectory);
         }
 
         /// <summary>


### PR DESCRIPTION
If some additional item in GenerateResource Task will be a director ResourceCreateFile in GetLastWriteFileUtcTime return invalid handle and then resource item would be marked as dirty. I add FILE_FLAG_BACKUP_SEMANTICS file flag for avoiding it problem.