### PR TITLE
Enable task factories for .NET Core

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -336,6 +336,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_USERDOMAINNAME</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_VARIOUS_EXCEPTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XAML_TYPES</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_XAMLTASKFACTORY</DefineConstants>
     <FeatureXamlTypes>true</FeatureXamlTypes>
     <DefineConstants>$(DefineConstants);FEATURE_XML_SOURCE_URI</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XML_LOADPATH</DefineConstants>

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Tasks
         public bool UseResultsCache { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
-    [System.ObsoleteAttribute("The CodeTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.")]
+    [System.ObsoleteAttribute("The CodeTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.", true)]
     public sealed partial class CodeTaskFactory : Microsoft.Build.Framework.ITaskFactory
     {
         public CodeTaskFactory() { }
@@ -648,7 +648,7 @@ namespace Microsoft.Build.Tasks
         public bool WriteOnlyWhenDifferent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
-    [System.ObsoleteAttribute("The XamlTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.")]
+    [System.ObsoleteAttribute("The XamlTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.", true)]
     public sealed partial class XamlTaskFactory : Microsoft.Build.Framework.ITaskFactory
     {
         public XamlTaskFactory() { }

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -64,6 +64,17 @@ namespace Microsoft.Build.Tasks
         public bool UseResultsCache { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    [System.ObsoleteAttribute("The CodeTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.")]
+    public sealed partial class CodeTaskFactory : Microsoft.Build.Framework.ITaskFactory
+    {
+        public CodeTaskFactory() { }
+        public string FactoryName { get { throw null; } }
+        public System.Type TaskType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public void CleanupTask(Microsoft.Build.Framework.ITask task) { }
+        public Microsoft.Build.Framework.ITask CreateTask(Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+        public Microsoft.Build.Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.TaskPropertyInfo> parameterGroup, string taskBody, Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
     public partial class CombinePath : Microsoft.Build.Tasks.TaskExtension
     {
         public CombinePath() { }
@@ -636,6 +647,17 @@ namespace Microsoft.Build.Tasks
         public bool Overwrite { get { throw null; } set { } }
         public bool WriteOnlyWhenDifferent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
+    }
+    [System.ObsoleteAttribute("The XamlTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.")]
+    public sealed partial class XamlTaskFactory : Microsoft.Build.Framework.ITaskFactory
+    {
+        public XamlTaskFactory() { }
+        public string FactoryName { get { throw null; } }
+        public System.Type TaskType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public void CleanupTask(Microsoft.Build.Framework.ITask task) { }
+        public Microsoft.Build.Framework.ITask CreateTask(Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+        public Microsoft.Build.Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.TaskPropertyInfo> parameterGroup, string taskBody, Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
     }
     public partial class XmlPeek : Microsoft.Build.Tasks.TaskExtension
     {

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1568,11 +1568,6 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   
   <!-- Engine errors for features not supported on .NET Core have the arbitrarily-chosen 48 prefix -->
-  <data name="TaskFactoryNotSupportedFailure" xml:space="preserve">
-    <value>MSB4801: The task factory "{0}" could not be loaded because this version of MSBuild does not support it.</value>
-    <comment>{StrBegin="MSB4801: "}</comment>
-  </data>
-
   <data name="TaskInstantiationFailureNotSupported" xml:space="preserve">
     <value>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</value>
     <comment>{StrBegin="MSB4802: "}</comment>

--- a/src/Shared/TaskEngineAssemblyResolver.cs
+++ b/src/Shared/TaskEngineAssemblyResolver.cs
@@ -7,16 +7,21 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 
+#if !FEATURE_ASSEMBLY_LOADFROM
+using System.Runtime.Loader;
+#endif
 using Microsoft.Build.Shared;
 
-#if FEATURE_APPDOMAIN
+
 namespace Microsoft.Build.BackEnd.Logging
 {
     /// <summary>
     /// This is a helper class to install an AssemblyResolver event handler in whatever AppDomain this class is created in.
     /// </summary>
     internal class TaskEngineAssemblyResolver
+#if FEATURE_APPDOMAIN
         : MarshalByRefObject
+#endif
     {
         /// <summary>
         /// This public default constructor is needed so that instances of this class can be created by NDP.
@@ -44,12 +49,20 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal void InstallHandler()
         {
+#if FEATURE_APPDOMAIN
             Debug.Assert(_eventHandler == null, "The TaskEngineAssemblyResolver.InstallHandler method should only be called once!");
 
             _eventHandler = new ResolveEventHandler(ResolveAssembly);
 
             AppDomain.CurrentDomain.AssemblyResolve += _eventHandler;
+#else
+            _eventHandler = new Func<AssemblyLoadContext, AssemblyName, Assembly>(ResolveAssembly);
+
+            AssemblyLoadContext.Default.Resolving += _eventHandler;
+#endif
         }
+
+        
 
         /// <summary>
         /// Removes the event handler.
@@ -58,7 +71,11 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             if (_eventHandler != null)
             {
+#if FEATURE_APPDOMAIN
                 AppDomain.CurrentDomain.AssemblyResolve -= _eventHandler;
+#else
+                AssemblyLoadContext.Default.Resolving -= _eventHandler;
+#endif
                 _eventHandler = null;
             }
             else
@@ -68,6 +85,7 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// This is an assembly resolution handler necessary for fixing up types instantiated in different
         /// AppDomains and loaded with a Assembly.LoadFrom equivalent call. See comments in TaskEngine.ExecuteTask
@@ -77,6 +95,9 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="args"></param>
         /// <returns></returns>
         internal Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+#else
+        private Assembly ResolveAssembly(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName)
+#endif
         {
             // Is this our task assembly?
             if (_taskAssemblyFile != null)
@@ -85,6 +106,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 {
                     try
                     {
+#if FEATURE_APPDOMAIN
                         AssemblyNameExtension taskAssemblyName = new AssemblyNameExtension(AssemblyName.GetAssemblyName(_taskAssemblyFile));
                         AssemblyNameExtension argAssemblyName = new AssemblyNameExtension(args.Name);
 
@@ -95,7 +117,16 @@ namespace Microsoft.Build.BackEnd.Logging
 #else
                             return Assembly.LoadFrom(_taskAssemblyFile);
 #endif
+
                         }
+#else
+                        AssemblyNameExtension taskAssemblyName = new AssemblyNameExtension(AssemblyLoadContext.GetAssemblyName(_taskAssemblyFile));
+                        AssemblyNameExtension argAssemblyName = new AssemblyNameExtension(assemblyName);
+                        if (taskAssemblyName.Equals(argAssemblyName))
+                        {
+                            return AssemblyLoadContext.Default.LoadFromAssemblyPath(_taskAssemblyFile);
+                        }
+#endif
                     }
                     // any problems with the task assembly? return null.
                     catch (FileNotFoundException)
@@ -113,6 +144,7 @@ namespace Microsoft.Build.BackEnd.Logging
             return null;
         }
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Overridden to give this class infinite lease time. Otherwise we end up with a limited
         /// lease (5 minutes I think) and instances can expire if they take long time processing.
@@ -124,11 +156,13 @@ namespace Microsoft.Build.BackEnd.Logging
             return null;
         }
 
-        // path to the task assembly, but only if it's loaded using LoadFrom. If it's loaded with Load, this is null.
-        private string _taskAssemblyFile = null;
 
         // we have to store the event handler instance in case we have to remove it
         private ResolveEventHandler _eventHandler = null;
+#else
+        private Func<AssemblyLoadContext, AssemblyName, Assembly> _eventHandler = null;
+#endif
+        // path to the task assembly, but only if it's loaded using LoadFrom. If it's loaded with Load, this is null.
+        private string _taskAssemblyFile = null;
     }
 }
-#endif

--- a/src/Shared/TaskEngineAssemblyResolver.cs
+++ b/src/Shared/TaskEngineAssemblyResolver.cs
@@ -12,7 +12,6 @@ using System.Runtime.Loader;
 #endif
 using Microsoft.Build.Shared;
 
-
 namespace Microsoft.Build.BackEnd.Logging
 {
     /// <summary>
@@ -119,7 +118,7 @@ namespace Microsoft.Build.BackEnd.Logging
 #endif
 
                         }
-#else
+#else // !FEATURE_APPDOMAIN
                         AssemblyNameExtension taskAssemblyName = new AssemblyNameExtension(AssemblyLoadContext.GetAssemblyName(_taskAssemblyFile));
                         AssemblyNameExtension argAssemblyName = new AssemblyNameExtension(assemblyName);
                         if (taskAssemblyName.Equals(argAssemblyName))

--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.Build.UnitTests
 {
-#if !RUNTIME_TYPE_NETCORE
+#if FEATURE_CODETASKFACTORY
 
     using System.CodeDom.Compiler;
 

--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -1,17 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Build.Evaluation;
 using System.IO;
 using System;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System.CodeDom.Compiler;
 using Microsoft.Build.Shared;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests
 {
-    sealed public class CodeTaskFactoryTests
+#if !RUNTIME_TYPE_NETCORE
+
+    using System.CodeDom.Compiler;
+
+    public sealed class CodeTaskFactoryTests
     {
         /// <summary>
         /// Test the simple case where we have a string parameter and we want to log that.
@@ -109,11 +114,8 @@ namespace Microsoft.Build.UnitTests
         /// being in MSBuildToolsPath anymore, that this does NOT affect full fusion AssemblyNames -- 
         /// it's picked up from the GAC, where it is anyway, so there's no need to redirect. 
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "FEATURE: LEGACY TASKS")]
-#else
+
         [Fact]
-#endif
         public void BuildTaskSimpleCodeFactory_NoAssemblyNameRedirect()
         {
             string projectFileContents = @"
@@ -1105,5 +1107,37 @@ namespace Microsoft.Build.UnitTests
             }
         }
     }
+#else
+    public sealed class CodeTaskFactoryTests
+    {
+        [Fact]
+        public void CodeTaskFactoryNotSupported()
+        {
+            string projectFileContents = @"
+                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' ToolsVersion='msbuilddefaulttoolsversion'>
+                        <UsingTask TaskName=`CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactory` TaskFactory=`CodeTaskFactory` AssemblyFile=`$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll` >
+                         <ParameterGroup>     
+                             <Text/>
+                          </ParameterGroup>
+                            <Task>
+                                <Code>
+                                     Log.LogMessage(MessageImportance.High, Text);
+                                </Code>
+                            </Task>
+                        </UsingTask>
+                        <Target Name=`Build`>
+                            <CustomTaskFromCodeFactory_BuildTaskSimpleCodeFactory Text=`Hello, World!` />
+                        </Target>
+                    </Project>";
+
+            MockLogger mockLogger = Helpers.BuildProjectWithNewOMExpectFailure(projectFileContents, allowTaskCrash: false);
+
+            BuildErrorEventArgs error = mockLogger.Errors.FirstOrDefault();
+
+            Assert.NotNull(error);
+            Assert.Equal("MSB4801: The task factory \"CodeTaskFactory\" is not supported on the .NET Core version of MSBuild.", error.Message);
+        }
+    }
+#endif
 }
 

--- a/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
+++ b/src/Tasks.UnitTests/CodeTaskFactoryTests.cs
@@ -114,7 +114,6 @@ namespace Microsoft.Build.UnitTests
         /// being in MSBuildToolsPath anymore, that this does NOT affect full fusion AssemblyNames -- 
         /// it's picked up from the GAC, where it is anyway, so there's no need to redirect. 
         /// </summary>
-
         [Fact]
         public void BuildTaskSimpleCodeFactory_NoAssemblyNameRedirect()
         {

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="WriteCodeFragment_Tests.cs" />
     <Compile Include="XmlPeek_Tests.cs" />
     <Compile Include="XmlPoke_Tests.cs" />
+    <Compile Include="CodeTaskFactoryTests.cs" />
     <EmbeddedResource Include="SampleResx" />
     <None Include="..\Shared\UnitTests\App.config">
       <Link>App.config</Link>
@@ -115,7 +116,6 @@
     <Compile Include="AssignProjectConfiguration_Tests.cs" />
     <Compile Include="AxImp_Tests.cs" />
     <Compile Include="AxTlbBaseTask_Tests.cs" />
-    <Compile Include="CodeTaskFactoryTests.cs" />
     <Compile Include="CommandLine_Support.cs" />
     <Compile Include="ComReferenceWalker_Tests.cs" />
     <Compile Include="ComReference_Tests.cs" />

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -1022,7 +1022,7 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     /// <remarks>CodeDom is not supported for .NET Core so this code task factory simply logs an error that it isn't supported.
     /// If we don't compile this class, then the user will get an error that the class doesn't exist which is a bad experience.</remarks>
-    [Obsolete("The CodeTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.")]
+    [Obsolete("The CodeTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.", error: true)]
     public sealed class CodeTaskFactory : ITaskFactory
     {
         public string FactoryName => "Code Task Factory";

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -7,24 +7,24 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.CodeDom.Compiler;
-using System.Reflection;
-using System.Xml;
-using System.Diagnostics;
-using System.IO;
-
 using Microsoft.Build.Framework;
-using System.CodeDom;
-using System.Globalization;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Shared;
-using System.Collections.Concurrent;
-
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
+#if !RUNTIME_TYPE_NETCORE
+    using System.CodeDom.Compiler;
+    using System.CodeDom;
+    using System.Collections.Concurrent;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Reflection;
+    using System.Text;
+    using System.Xml;
+
     /// <summary>
     /// A task factory which can take code dom supported languages and create a task out of it
     /// </summary>
@@ -1016,4 +1016,46 @@ namespace Microsoft.Build.Tasks
             }
         }
     }
+#else
+    /// <summary>
+    /// A task factory which can take code dom supported languages and create a task out of it
+    /// </summary>
+    /// <remarks>CodeDom is not supported for .NET Core so this code task factory simply logs an error that it isn't supported.
+    /// If we don't compile this class, then the user will get an error that the class doesn't exist which is a bad experience.</remarks>
+    [Obsolete("The CodeTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.")]
+    public sealed class CodeTaskFactory : ITaskFactory
+    {
+        public string FactoryName => "Code Task Factory";
+
+        public Type TaskType { get; } = null;
+
+        public bool Initialize(string taskName, IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost)
+        {
+            TaskLoggingHelper log = new TaskLoggingHelper(taskFactoryLoggingHost, taskName)
+            {
+                TaskResources = AssemblyResources.PrimaryResources,
+                HelpKeywordPrefix = "MSBuild."
+            };
+            
+            log.LogErrorFromResources("TaskFactoryNotSupportedFailure", nameof(CodeTaskFactory));
+
+            return false;
+        }
+
+        public TaskPropertyInfo[] GetTaskParameters()
+        {
+            throw new NotSupportedException();
+        }
+
+        public ITask CreateTask(IBuildEngine taskFactoryLoggingHost)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void CleanupTask(ITask task)
+        {
+            throw new NotSupportedException();
+        }
+    }
+#endif
 }

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -13,7 +13,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
-#if !RUNTIME_TYPE_NETCORE
+#if FEATURE_CODETASKFACTORY
     using System.CodeDom.Compiler;
     using System.CodeDom;
     using System.Collections.Concurrent;

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -522,6 +522,7 @@
     <Compile Include="WriteCodeFragment.cs" />
     <Compile Include="XmlPeek.cs" />
     <Compile Include="XmlPoke.cs" />
+    <Compile Include="CodeTaskFactory.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <Compile Include="Al.cs">
@@ -552,8 +553,7 @@
     <Compile Include="AxTlbBaseTask.cs" />
     <Compile Include="BootstrapperUtil\*.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="CodeTaskFactory.cs" />
+    </Compile>    
     <Compile Include="ComDependencyWalker.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -697,6 +697,8 @@
     <Compile Include="XamlTaskFactory\XamlDataDrivenToolTask.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="XamlTaskFactory\XamlTaskFactory.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -523,6 +523,7 @@
     <Compile Include="XmlPeek.cs" />
     <Compile Include="XmlPoke.cs" />
     <Compile Include="CodeTaskFactory.cs" />
+    <Compile Include="XamlTaskFactory\XamlTaskFactory.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <Compile Include="Al.cs">
@@ -697,9 +698,6 @@
     <Compile Include="XamlTaskFactory\XamlDataDrivenToolTask.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="XamlTaskFactory\XamlTaskFactory.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <!-- Shim targets only work when the destination targets are installed. -->

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2628,6 +2628,12 @@
     <!-- When a user did not specify a message to an <Error /> or <Warning /> task -->
     <value>(No message specified)</value>
   </data>
+
+  <!-- Engine errors for features not supported on .NET Core have the arbitrarily-chosen 48 prefix -->
+  <data name="TaskFactoryNotSupportedFailure" xml:space="preserve">
+    <value>MSB4801: The task factory "{0}" is not supported on the .NET Core version of MSBuild.</value>
+    <comment>{StrBegin="MSB4801: "}</comment>
+  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 

--- a/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
+++ b/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     /// <remarks>Xaml is not supported on .NET Core so this task factory simply logs an error that it isn't supported.
     /// If we don't compile this class, then the user will get an error that the class doesn't exist which is a bad experience.</remarks>
-    [Obsolete("The XamlTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.")]
+    [Obsolete("The XamlTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.", error: true)]
     public sealed class XamlTaskFactory : ITaskFactory
     {
         public string FactoryName => "XamlTaskFactory";

--- a/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
+++ b/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
@@ -6,22 +6,24 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
-using System.Text;
-using System.CodeDom.Compiler;
-using System.Reflection;
-using System.Xml;
-using System.IO;
-using System.Threading;
-
 using Microsoft.Build.Framework;
-using Microsoft.Build.Tasks.Xaml;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
+#if !RUNTIME_TYPE_NETCORE
+
+    using Microsoft.Build.Tasks.Xaml;
+    using System.CodeDom.Compiler;
+    using System.CodeDom;
+    using System.IO;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading;
+    using System.Xml;
+
     /// <summary>
     /// The task factory provider for XAML tasks.
     /// </summary>
@@ -249,4 +251,46 @@ namespace Microsoft.Build.Tasks
             return propertyInfos;
         }
     }
+#else
+    /// <summary>
+    /// The task factory provider for XAML tasks.
+    /// </summary>
+    /// <remarks>Xaml is not supported on .NET Core so this task factory simply logs an error that it isn't supported.
+    /// If we don't compile this class, then the user will get an error that the class doesn't exist which is a bad experience.</remarks>
+    [Obsolete("The XamlTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.")]
+    public sealed class XamlTaskFactory : ITaskFactory
+    {
+        public string FactoryName => "XamlTaskFactory";
+    
+        public Type TaskType { get; } = null;
+
+        public bool Initialize(string taskName, IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost)
+        {
+            TaskLoggingHelper log = new TaskLoggingHelper(taskFactoryLoggingHost, taskName)
+            {
+                TaskResources = AssemblyResources.PrimaryResources,
+                HelpKeywordPrefix = "MSBuild."
+            };
+            
+            log.LogErrorFromResources("TaskFactoryNotSupportedFailure", nameof(XamlTaskFactory));
+
+            return false;
+        }
+
+        public TaskPropertyInfo[] GetTaskParameters()
+        {
+            throw new NotSupportedException();
+        }
+
+        public ITask CreateTask(IBuildEngine taskFactoryLoggingHost)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void CleanupTask(ITask task)
+        {
+            throw new NotSupportedException();
+        }
+    }
+#endif
 }

--- a/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
+++ b/src/Tasks/XamlTaskFactory/XamlTaskFactory.cs
@@ -13,7 +13,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
-#if !RUNTIME_TYPE_NETCORE
+#if FEATURE_XAMLTASKFACTORY
 
     using Microsoft.Build.Tasks.Xaml;
     using System.CodeDom.Compiler;


### PR DESCRIPTION
1. Allow task factories to load on .NET Core
2. Update TaskEngineAssemblyResolver for .NET Core
3. Log an error for CodeTaskFactory and XamlTaskFactory when running on .NET Core
4. Update unit tests

Related to #304