### PR TITLE
_ignoreStandardErrorWarningFormat defaults to false

### DIFF
--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Whether to use pick out lines in the output that match
         /// the standard error/warning format, and log them as errors/warnings.
-        /// Defaults to true.
+        /// Defaults to false.
         /// </summary>
         public bool IgnoreStandardErrorWarningFormat
         {


### PR DESCRIPTION
Comment correction. Comment states that _ignoreStandardErrorWarningFormat defaults to true, but it defaults to false. Brought up in discussion https://github.com/Microsoft/msbuild/issues/766.