### PR TITLE
Introduce a new BinaryLogger logger.

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -1350,6 +1350,29 @@ namespace Microsoft.Build.Execution
 }
 namespace Microsoft.Build.Logging
 {
+    public partial class BinaryLogger : Microsoft.Build.Framework.ILogger
+    {
+        public BinaryLogger() { }
+        public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
+        public void Shutdown() { }
+    }
+    public partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
+    {
+        public BinaryLogReplayEventSource() { }
+        public void Replay(string sourceFilePath) { }
+    }
+    public partial class BuildEventArgsReader
+    {
+        public BuildEventArgsReader(System.IO.BinaryReader binaryReader) { }
+        public Microsoft.Build.Framework.BuildEventArgs Read() { throw null; }
+    }
+    public partial class BuildEventArgsWriter
+    {
+        public BuildEventArgsWriter(System.IO.BinaryWriter binaryWriter) { }
+        public void Write(Microsoft.Build.Framework.BuildEventArgs e) { }
+    }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);
     public partial class ConfigurableForwardingLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
@@ -1401,6 +1424,25 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
         public void Shutdown() { }
+    }
+    public partial class EventArgsDispatcher : Microsoft.Build.Framework.IEventSource
+    {
+        public EventArgsDispatcher() { }
+        public event Microsoft.Build.Framework.AnyEventHandler AnyEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildFinishedEventHandler BuildFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildStartedEventHandler BuildStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.CustomBuildEventHandler CustomEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildErrorEventHandler ErrorRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildMessageEventHandler MessageRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.ProjectFinishedEventHandler ProjectFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.ProjectStartedEventHandler ProjectStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildStatusEventHandler StatusEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.TargetFinishedEventHandler TargetFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.TargetStartedEventHandler TargetStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.TaskFinishedEventHandler TaskFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.TaskStartedEventHandler TaskStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildWarningEventHandler WarningRaised { add { } remove { } }
+        public void Dispatch(Microsoft.Build.Framework.BuildEventArgs buildEvent) { }
     }
     public partial class FileLogger : Microsoft.Build.Logging.ConsoleLogger
     {

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -1350,28 +1350,13 @@ namespace Microsoft.Build.Execution
 }
 namespace Microsoft.Build.Logging
 {
-    public partial class BinaryLogger : Microsoft.Build.Framework.ILogger
+    public sealed partial class BinaryLogger : Microsoft.Build.Framework.ILogger
     {
         public BinaryLogger() { }
         public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Build.Framework.LoggerVerbosity Verbosity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Shutdown() { }
-    }
-    public partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
-    {
-        public BinaryLogReplayEventSource() { }
-        public void Replay(string sourceFilePath) { }
-    }
-    public partial class BuildEventArgsReader
-    {
-        public BuildEventArgsReader(System.IO.BinaryReader binaryReader) { }
-        public Microsoft.Build.Framework.BuildEventArgs Read() { throw null; }
-    }
-    public partial class BuildEventArgsWriter
-    {
-        public BuildEventArgsWriter(System.IO.BinaryWriter binaryWriter) { }
-        public void Write(Microsoft.Build.Framework.BuildEventArgs e) { }
     }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);
@@ -1424,25 +1409,6 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
         public void Shutdown() { }
-    }
-    public partial class EventArgsDispatcher : Microsoft.Build.Framework.IEventSource
-    {
-        public EventArgsDispatcher() { }
-        public event Microsoft.Build.Framework.AnyEventHandler AnyEventRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildFinishedEventHandler BuildFinished { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildStartedEventHandler BuildStarted { add { } remove { } }
-        public event Microsoft.Build.Framework.CustomBuildEventHandler CustomEventRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildErrorEventHandler ErrorRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildMessageEventHandler MessageRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.ProjectFinishedEventHandler ProjectFinished { add { } remove { } }
-        public event Microsoft.Build.Framework.ProjectStartedEventHandler ProjectStarted { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildStatusEventHandler StatusEventRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.TargetFinishedEventHandler TargetFinished { add { } remove { } }
-        public event Microsoft.Build.Framework.TargetStartedEventHandler TargetStarted { add { } remove { } }
-        public event Microsoft.Build.Framework.TaskFinishedEventHandler TaskFinished { add { } remove { } }
-        public event Microsoft.Build.Framework.TaskStartedEventHandler TaskStarted { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildWarningEventHandler WarningRaised { add { } remove { } }
-        public void Dispatch(Microsoft.Build.Framework.BuildEventArgs buildEvent) { }
     }
     public partial class FileLogger : Microsoft.Build.Logging.ConsoleLogger
     {

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -1327,6 +1327,29 @@ namespace Microsoft.Build.Execution
 }
 namespace Microsoft.Build.Logging
 {
+    public partial class BinaryLogger : Microsoft.Build.Framework.ILogger
+    {
+        public BinaryLogger() { }
+        public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
+        public void Shutdown() { }
+    }
+    public partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
+    {
+        public BinaryLogReplayEventSource() { }
+        public void Replay(string sourceFilePath) { }
+    }
+    public partial class BuildEventArgsReader
+    {
+        public BuildEventArgsReader(System.IO.BinaryReader binaryReader) { }
+        public Microsoft.Build.Framework.BuildEventArgs Read() { throw null; }
+    }
+    public partial class BuildEventArgsWriter
+    {
+        public BuildEventArgsWriter(System.IO.BinaryWriter binaryWriter) { }
+        public void Write(Microsoft.Build.Framework.BuildEventArgs e) { }
+    }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);
     public partial class ConfigurableForwardingLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
@@ -1378,6 +1401,25 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
         public void Shutdown() { }
+    }
+    public partial class EventArgsDispatcher : Microsoft.Build.Framework.IEventSource
+    {
+        public EventArgsDispatcher() { }
+        public event Microsoft.Build.Framework.AnyEventHandler AnyEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildFinishedEventHandler BuildFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildStartedEventHandler BuildStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.CustomBuildEventHandler CustomEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildErrorEventHandler ErrorRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildMessageEventHandler MessageRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.ProjectFinishedEventHandler ProjectFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.ProjectStartedEventHandler ProjectStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildStatusEventHandler StatusEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.TargetFinishedEventHandler TargetFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.TargetStartedEventHandler TargetStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.TaskFinishedEventHandler TaskFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.TaskStartedEventHandler TaskStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildWarningEventHandler WarningRaised { add { } remove { } }
+        public void Dispatch(Microsoft.Build.Framework.BuildEventArgs buildEvent) { }
     }
     public partial class FileLogger : Microsoft.Build.Logging.ConsoleLogger
     {

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -1327,28 +1327,13 @@ namespace Microsoft.Build.Execution
 }
 namespace Microsoft.Build.Logging
 {
-    public partial class BinaryLogger : Microsoft.Build.Framework.ILogger
+    public sealed partial class BinaryLogger : Microsoft.Build.Framework.ILogger
     {
         public BinaryLogger() { }
         public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Build.Framework.LoggerVerbosity Verbosity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Shutdown() { }
-    }
-    public partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
-    {
-        public BinaryLogReplayEventSource() { }
-        public void Replay(string sourceFilePath) { }
-    }
-    public partial class BuildEventArgsReader
-    {
-        public BuildEventArgsReader(System.IO.BinaryReader binaryReader) { }
-        public Microsoft.Build.Framework.BuildEventArgs Read() { throw null; }
-    }
-    public partial class BuildEventArgsWriter
-    {
-        public BuildEventArgsWriter(System.IO.BinaryWriter binaryWriter) { }
-        public void Write(Microsoft.Build.Framework.BuildEventArgs e) { }
     }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);
@@ -1401,25 +1386,6 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
         public void Shutdown() { }
-    }
-    public partial class EventArgsDispatcher : Microsoft.Build.Framework.IEventSource
-    {
-        public EventArgsDispatcher() { }
-        public event Microsoft.Build.Framework.AnyEventHandler AnyEventRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildFinishedEventHandler BuildFinished { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildStartedEventHandler BuildStarted { add { } remove { } }
-        public event Microsoft.Build.Framework.CustomBuildEventHandler CustomEventRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildErrorEventHandler ErrorRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildMessageEventHandler MessageRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.ProjectFinishedEventHandler ProjectFinished { add { } remove { } }
-        public event Microsoft.Build.Framework.ProjectStartedEventHandler ProjectStarted { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildStatusEventHandler StatusEventRaised { add { } remove { } }
-        public event Microsoft.Build.Framework.TargetFinishedEventHandler TargetFinished { add { } remove { } }
-        public event Microsoft.Build.Framework.TargetStartedEventHandler TargetStarted { add { } remove { } }
-        public event Microsoft.Build.Framework.TaskFinishedEventHandler TaskFinished { add { } remove { } }
-        public event Microsoft.Build.Framework.TaskStartedEventHandler TaskStarted { add { } remove { } }
-        public event Microsoft.Build.Framework.BuildWarningEventHandler WarningRaised { add { } remove { } }
-        public void Dispatch(Microsoft.Build.Framework.BuildEventArgs buildEvent) { }
     }
     public partial class FileLogger : Microsoft.Build.Logging.ConsoleLogger
     {

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="BackEnd\TargetEntry_Tests.cs" />
     <Compile Include="BackEnd\TargetResult_Tests.cs" />
     <Compile Include="BackEnd\TargetUpToDateChecker_Tests.cs" />
+    <Compile Include="BinaryLogger_Tests.cs" />
     <Compile Include="BuildEnvironmentHelper_Tests.cs" />
     <Compile Include="Definition\Project_Internal_Tests.cs" />
     <Compile Include="BackEnd\TaskBuilder_Tests.cs" />

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -1,0 +1,20 @@
+﻿namespace Microsoft.Build.Logging
+{
+    internal enum BinaryLogRecordKind
+    {
+        EndOfFile = 0,
+        BuildStarted,
+        BuildFinished,
+        ProjectStarted,
+        ProjectFinished,
+        TargetStarted,
+        TargetFinished,
+        TaskStarted,
+        TaskFinished,
+        Error,
+        Warning,
+        Message,
+        TaskCommandLine,
+        CriticalBuildMessage
+    }
+}

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -23,7 +23,15 @@ namespace Microsoft.Build.Logging
                 var gzipStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
                 var binaryReader = new BinaryReader(gzipStream);
 
-                byte fileFormatVersion = binaryReader.ReadByte();
+                int fileFormatVersion = binaryReader.ReadInt32();
+
+                // the log file is written using a newer version of file format
+                // that we don't know how to read
+                if (fileFormatVersion > BinaryLogger.FileFormatVersion)
+                {
+                    var text = ResourceUtilities.FormatResourceString("UnsupportedLogFileFormat", fileFormatVersion, BinaryLogger.FileFormatVersion);
+                    throw new NotSupportedException(text);
+                }
 
                 var reader = new BuildEventArgsReader(binaryReader);
                 while (true)

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Compression;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Logging
 {
@@ -35,17 +36,19 @@ namespace Microsoft.Build.Logging
                     }
                     catch (Exception ex)
                     {
-                        var text = $"Exception while reading log file:{Environment.NewLine}{ex.ToString()}";
+                        string code;
+                        string helpKeyword;
+                        var text = ResourceUtilities.FormatResourceString(out code, out helpKeyword, "InvalidLogFileFormat", ex.Message);
                         var message = new BuildErrorEventArgs(
                             subcategory: "",
-                            code: "",
+                            code: code,
                             file: sourceFilePath,
                             lineNumber: 0,
                             columnNumber: 0,
                             endLineNumber: 0,
                             endColumnNumber: 0,
                             message: text,
-                            helpKeyword: null,
+                            helpKeyword: helpKeyword,
                             senderName: "MSBuild");
                         Dispatch(message);
                     }

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Build.Logging
     /// Provides a method to read a binary log file (*.binlog) and replay all stored BuildEventArgs
     /// by implementing IEventSource and raising corresponding events.
     /// </summary>
-    public class BinaryLogReplayEventSource : EventArgsDispatcher
+    internal class BinaryLogReplayEventSource : EventArgsDispatcher
     {
         /// <summary>
         /// Read the provided binary log file and raise corresponding events for each BuildEventArgs

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging
+{
+    /// <summary>
+    /// Provides a method to read a binary log file (*.binlog) and replay all stored BuildEventArgs
+    /// by implementing IEventSource and raising corresponding events.
+    /// </summary>
+    public class BinaryLogReplayEventSource : EventArgsDispatcher
+    {
+        /// <summary>
+        /// Read the provided binary log file and raise corresponding events for each BuildEventArgs
+        /// </summary>
+        /// <param name="sourceFilePath">The full file path of the binary log file</param>
+        public void Replay(string sourceFilePath)
+        {
+            using (var stream = new FileStream(sourceFilePath, FileMode.Open))
+            {
+                var gzipStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
+                var binaryReader = new BinaryReader(gzipStream);
+
+                byte fileFormatVersion = binaryReader.ReadByte();
+
+                var reader = new BuildEventArgsReader(binaryReader);
+                while (true)
+                {
+                    BuildEventArgs instance = null;
+
+                    try
+                    {
+                        instance = reader.Read();
+                    }
+                    catch (Exception ex)
+                    {
+                        var text = $"Exception while reading log file:{Environment.NewLine}{ex.ToString()}";
+                        var message = new BuildErrorEventArgs(
+                            subcategory: "",
+                            code: "",
+                            file: sourceFilePath,
+                            lineNumber: 0,
+                            columnNumber: 0,
+                            endLineNumber: 0,
+                            endColumnNumber: 0,
+                            message: text,
+                            helpKeyword: null,
+                            senderName: "MSBuild");
+                        Dispatch(message);
+                    }
+
+                    if (instance == null)
+                    {
+                        break;
+                    }
+
+                    Dispatch(instance);
+                }
+            }
+        }
+    }
+}

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Build.Logging
     /// analysis or visualization. Since the file format preserves structure, tools don't have to parse
     /// text logs that erase a lot of useful information.
     /// </summary>
-    public class BinaryLogger : ILogger
+    /// <remarks>The logger is public so that it can be instantiated from MSBuild.exe via command-line switch.</remarks>
+    public sealed class BinaryLogger : ILogger
     {
         internal const int FileFormatVersion = 1;
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Logging
                 // so add an explicit 0 at the end to signify end of file
                 stream.WriteByte(0);
                 stream.Flush();
-                stream.Close();
+                stream.Dispose();
                 stream = null;
             }
         }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Logging
             {
                 // It's hard to determine whether we're at the end of decoding GZipStream
                 // so add an explicit 0 at the end to signify end of file
-                stream.WriteByte(0);
+                stream.WriteByte((byte)BinaryLogRecordKind.EndOfFile);
                 stream.Flush();
                 stream.Dispose();
                 stream = null;

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Logging
+{
+    /// <summary>
+    /// A logger that serializes all incoming BuildEventArgs in a compressed binary file (*.binlog). The file
+    /// can later be played back and piped into other loggers (file, console, etc) to reconstruct the log contents
+    /// as if a real build was happening. Additionally, this format can be read by tools for
+    /// analysis or visualization. Since the file format preserves structure, tools don't have to parse
+    /// text logs that erase a lot of useful information.
+    /// </summary>
+    public class BinaryLogger : ILogger
+    {
+        private const int FileFormatVersion = 1;
+
+        private Stream stream;
+        private BinaryWriter binaryWriter;
+        private BuildEventArgsWriter eventArgsWriter;
+
+        private string FilePath { get; set; }
+
+        /// <summary>
+        /// The binary logger Verbosity is always maximum (Diagnostic). It tries to capture as much
+        /// information as possible.
+        /// </summary>
+        public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Diagnostic;
+
+        /// <summary>
+        /// The only supported parameter is the output log file path (e.g. "msbuild.binlog") 
+        /// </summary>
+        public string Parameters { get; set; }
+
+        /// <summary>
+        /// Initializes the logger by subscribing to events of IEventSource
+        /// </summary>
+        public void Initialize(IEventSource eventSource)
+        {
+            Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "true");
+
+            ProcessParameters();
+
+            try
+            {
+                stream = new FileStream(FilePath, FileMode.Create);
+            }
+            catch (Exception e)
+            {
+                string errorCode;
+                string helpKeyword;
+                string message = ResourceUtilities.FormatResourceString(out errorCode, out helpKeyword, "InvalidFileLoggerFile", FilePath, e.Message);
+                throw new LoggerException(message, e, errorCode, helpKeyword);
+            }
+
+            stream = new GZipStream(stream, CompressionLevel.Optimal);
+            binaryWriter = new BinaryWriter(stream);
+            eventArgsWriter = new BuildEventArgsWriter(binaryWriter);
+
+            binaryWriter.Write((byte)FileFormatVersion);
+
+            eventSource.AnyEventRaised += EventSource_AnyEventRaised;
+        }
+
+        /// <summary>
+        /// Closes the underlying file stream.
+        /// </summary>
+        public void Shutdown()
+        {
+            if (stream != null)
+            {
+                // It's hard to determine whether we're at the end of decoding GZipStream
+                // so add an explicit 0 at the end to signify end of file
+                stream.WriteByte(0);
+                stream.Flush();
+                stream.Close();
+                stream = null;
+            }
+        }
+
+        private void EventSource_AnyEventRaised(object sender, BuildEventArgs e)
+        {
+            Write(e);
+        }
+
+        private void Write(BuildEventArgs e)
+        {
+            if (stream != null)
+            {
+                // TODO: think about queuing to avoid contention
+                lock (eventArgsWriter)
+                {
+                    eventArgsWriter.Write(e);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Processes the parameters given to the logger from MSBuild.
+        /// </summary>
+        /// <exception cref="LoggerException">
+        /// </exception>
+        private void ProcessParameters()
+        {
+            const string invalidParamSpecificationMessage = @"Need to specify a valid log file name, such as msbuild.binlog";
+
+            if (Parameters == null)
+            {
+                throw new LoggerException(invalidParamSpecificationMessage);
+            }
+
+            string[] parameters = Parameters.Split(';');
+
+            if (parameters.Length != 1)
+            {
+                throw new LoggerException(invalidParamSpecificationMessage);
+            }
+
+            FilePath = parameters[0].TrimStart('"').TrimEnd('"');
+
+            try
+            {
+                FilePath = Path.GetFullPath(FilePath);
+            }
+            catch (Exception e)
+            {
+                string errorCode;
+                string helpKeyword;
+                string message = ResourceUtilities.FormatResourceString(out errorCode, out helpKeyword, "InvalidFileLoggerFile", FilePath, e.Message);
+                throw new LoggerException(message, e, errorCode, helpKeyword);
+            }
+        }
+    }
+}

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -104,18 +104,16 @@ namespace Microsoft.Build.Logging
         /// </exception>
         private void ProcessParameters()
         {
-            const string invalidParamSpecificationMessage = @"Need to specify a valid log file name, such as msbuild.binlog";
-
             if (Parameters == null)
             {
-                throw new LoggerException(invalidParamSpecificationMessage);
+                throw new LoggerException(ResourceUtilities.FormatResourceString("InvalidBinaryLoggerParameters", 0, Parameters));
             }
 
             string[] parameters = Parameters.Split(';');
 
             if (parameters.Length != 1)
             {
-                throw new LoggerException(invalidParamSpecificationMessage);
+                throw new LoggerException(ResourceUtilities.FormatResourceString("InvalidBinaryLoggerParameters", parameters.Length, Parameters));
             }
 
             FilePath = parameters[0].TrimStart('"').TrimEnd('"');

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Logging
     /// </summary>
     public class BinaryLogger : ILogger
     {
-        private const int FileFormatVersion = 1;
+        internal const int FileFormatVersion = 1;
 
         private Stream stream;
         private BinaryWriter binaryWriter;
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Logging
             binaryWriter = new BinaryWriter(stream);
             eventArgsWriter = new BuildEventArgsWriter(binaryWriter);
 
-            binaryWriter.Write((byte)FileFormatVersion);
+            binaryWriter.Write(FileFormatVersion);
 
             eventSource.AnyEventRaised += EventSource_AnyEventRaised;
         }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Build.Logging
     /// <summary>
     /// An implementation of IEventSource that raises appropriate events for a provided BuildEventArgs object.
     /// </summary>
-    public class EventArgsDispatcher : IEventSource
+    internal class EventArgsDispatcher : IEventSource
     {
         /// <summary>
         /// This event is raised for all BuildEventArgs objects after a more type-specific event

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
@@ -1,0 +1,141 @@
+﻿using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging
+{
+    /// <summary>
+    /// An implementation of IEventSource that raises appropriate events for a provided BuildEventArgs object.
+    /// </summary>
+    public class EventArgsDispatcher : IEventSource
+    {
+        /// <summary>
+        /// This event is raised for all BuildEventArgs objects after a more type-specific event
+        /// </summary>
+        public event AnyEventHandler AnyEventRaised;
+
+        /// <summary>
+        /// Raised for BuildStatusEventArgs instances
+        /// </summary>
+        public event BuildStatusEventHandler StatusEventRaised;
+
+        /// <summary>
+        /// Raised for CustomBuildEventArgs instances
+        /// </summary>
+        public event CustomBuildEventHandler CustomEventRaised;
+
+        /// <summary>
+        /// Raised for BuildStartedEventArgs instances
+        /// </summary>
+        public event BuildStartedEventHandler BuildStarted;
+
+        /// <summary>
+        /// Raised for BuildFinishedEventArgs instances
+        /// </summary>
+        public event BuildFinishedEventHandler BuildFinished;
+
+        /// <summary>
+        /// Raised for ProjectStartedEventArgs instances
+        /// </summary>
+        public event ProjectStartedEventHandler ProjectStarted;
+
+        /// <summary>
+        /// Raised for ProjectFinishedEventArgs instances
+        /// </summary>
+        public event ProjectFinishedEventHandler ProjectFinished;
+
+        /// <summary>
+        /// Raised for TargetStartedEventArgs instances
+        /// </summary>
+        public event TargetStartedEventHandler TargetStarted;
+
+        /// <summary>
+        /// Raised for TargetFinishedEventArgs instances
+        /// </summary>
+        public event TargetFinishedEventHandler TargetFinished;
+
+        /// <summary>
+        /// Raised for TaskStartedEventArgs instances
+        /// </summary>
+        public event TaskStartedEventHandler TaskStarted;
+
+        /// <summary>
+        /// Raised for TaskFinishedEventArgs instances
+        /// </summary>
+        public event TaskFinishedEventHandler TaskFinished;
+
+        /// <summary>
+        /// Raised for BuildErrorEventArgs instances
+        /// </summary>
+        public event BuildErrorEventHandler ErrorRaised;
+
+        /// <summary>
+        /// Raised for BuildWarningEventArgs instances
+        /// </summary>
+        public event BuildWarningEventHandler WarningRaised;
+
+        /// <summary>
+        /// Raised for BuildMessageEventArgs instances
+        /// </summary>
+        public event BuildMessageEventHandler MessageRaised;
+
+        /// <summary>
+        /// Raise one of the events that is appropriate for the type of the BuildEventArgs
+        /// </summary>
+        public void Dispatch(BuildEventArgs buildEvent)
+        {
+            if (buildEvent is BuildMessageEventArgs)
+            {
+                MessageRaised?.Invoke(null, (BuildMessageEventArgs)buildEvent);
+            }
+            else if (buildEvent is TaskStartedEventArgs)
+            {
+                TaskStarted?.Invoke(null, (TaskStartedEventArgs)buildEvent);
+            }
+            else if (buildEvent is TaskFinishedEventArgs)
+            {
+                TaskFinished?.Invoke(null, (TaskFinishedEventArgs)buildEvent);
+            }
+            else if (buildEvent is TargetStartedEventArgs)
+            {
+                TargetStarted?.Invoke(null, (TargetStartedEventArgs)buildEvent);
+            }
+            else if (buildEvent is TargetFinishedEventArgs)
+            {
+                TargetFinished?.Invoke(null, (TargetFinishedEventArgs)buildEvent);
+            }
+            else if (buildEvent is ProjectStartedEventArgs)
+            {
+                ProjectStarted?.Invoke(null, (ProjectStartedEventArgs)buildEvent);
+            }
+            else if (buildEvent is ProjectFinishedEventArgs)
+            {
+                ProjectFinished?.Invoke(null, (ProjectFinishedEventArgs)buildEvent);
+            }
+            else if (buildEvent is BuildStartedEventArgs)
+            {
+                BuildStarted?.Invoke(null, (BuildStartedEventArgs)buildEvent);
+            }
+            else if (buildEvent is BuildFinishedEventArgs)
+            {
+                BuildFinished?.Invoke(null, (BuildFinishedEventArgs)buildEvent);
+            }
+            else if (buildEvent is CustomBuildEventArgs)
+            {
+                CustomEventRaised?.Invoke(null, (CustomBuildEventArgs)buildEvent);
+            }
+            else if (buildEvent is BuildStatusEventArgs)
+            {
+                StatusEventRaised?.Invoke(null, (BuildStatusEventArgs)buildEvent);
+            }
+            else if (buildEvent is BuildWarningEventArgs)
+            {
+                WarningRaised?.Invoke(null, (BuildWarningEventArgs)buildEvent);
+            }
+            else if (buildEvent is BuildErrorEventArgs)
+            {
+                ErrorRaised?.Invoke(null, (BuildErrorEventArgs)buildEvent);
+            }
+
+            AnyEventRaised?.Invoke(null, buildEvent);
+        }
+    }
+}

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsFieldFlags.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsFieldFlags.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Microsoft.Build.Logging
+{
+    /// <summary>
+    /// A bitmask to specify which fields on a BuildEventArgs object are present; used in serialization
+    /// </summary>
+    [Flags]
+    internal enum BuildEventArgsFieldFlags
+    {
+        None = 0,
+        BuildEventContext = 1 << 0,
+        HelpHeyword = 1 << 1,
+        Message = 1 << 2,
+        SenderName = 1 << 3,
+        ThreadId = 1 << 4,
+        Timestamp = 1 << 5,
+        Subcategory = 1 << 6,
+        Code = 1 << 7,
+        File = 1 << 8,
+        ProjectFile = 1 << 9,
+        LineNumber = 1 << 10,
+        ColumnNumber = 1 << 11,
+        EndLineNumber = 1 << 12,
+        EndColumnNumber = 1 << 13
+    }
+}

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsFields.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsFields.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging
+{
+    /// <summary>
+    /// Represents a collective set of common properties on BuildEventArgs. Used for deserialization.
+    /// </summary>
+    internal class BuildEventArgsFields
+    {
+        public BuildEventArgsFieldFlags Flags { get; set; }
+
+        public string Message { get; set; }
+        public BuildEventContext BuildEventContext { get; set; }
+        public int ThreadId { get; set; }
+        public string HelpKeyword { get; set; }
+        public string SenderName { get; set; }
+        public DateTime Timestamp { get; set; }
+
+        public string Subcategory { get; set; }
+        public string Code { get; set; }
+        public string File { get; set; }
+        public string ProjectFile { get; set; }
+        public int LineNumber { get; set; }
+        public int ColumnNumber { get; set; }
+        public int EndLineNumber { get; set; }
+        public int EndColumnNumber { get; set; }
+    }
+}

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Build.Logging
     /// <summary>
     /// Deserializes and returns BuildEventArgs-derived objects from a BinaryReader
     /// </summary>
-    public class BuildEventArgsReader
+    internal class BuildEventArgsReader
     {
         private readonly BinaryReader binaryReader;
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -1,0 +1,673 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging
+{
+    /// <summary>
+    /// Deserializes and returns BuildEventArgs-derived objects from a BinaryReader
+    /// </summary>
+    public class BuildEventArgsReader
+    {
+        private readonly BinaryReader binaryReader;
+
+        // reflection is needed to set these three fields because public constructors don't provide
+        // a way to set these from the outside
+        private static FieldInfo buildEventArgsFieldThreadId =
+            typeof(BuildEventArgs).GetField("threadId", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static FieldInfo buildEventArgsFieldSenderName =
+            typeof(BuildEventArgs).GetField("senderName", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static FieldInfo buildEventArgsFieldTimestamp =
+            typeof(BuildEventArgs).GetField("timestamp", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// Initializes a new instance of BuildEventArgsReader using a BinaryReader instance
+        /// </summary>
+        /// <param name="binaryReader">The BinaryReader to read BuildEventArgs from</param>
+        public BuildEventArgsReader(BinaryReader binaryReader)
+        {
+            this.binaryReader = binaryReader;
+        }
+
+        /// <summary>
+        /// Reads the next log record from the binary reader. If there are no more records, returns null.
+        /// </summary>
+        public BuildEventArgs Read()
+        {
+            BinaryLogRecordKind recordKind = (BinaryLogRecordKind)ReadInt32();
+
+            BuildEventArgs result = null;
+            switch (recordKind)
+            {
+                case BinaryLogRecordKind.EndOfFile:
+                    break;
+                case BinaryLogRecordKind.BuildStarted:
+                    result = ReadBuildStartedEventArgs();
+                    break;
+                case BinaryLogRecordKind.BuildFinished:
+                    result = ReadBuildFinishedEventArgs();
+                    break;
+                case BinaryLogRecordKind.ProjectStarted:
+                    result = ReadProjectStartedEventArgs();
+                    break;
+                case BinaryLogRecordKind.ProjectFinished:
+                    result = ReadProjectFinishedEventArgs();
+                    break;
+                case BinaryLogRecordKind.TargetStarted:
+                    result = ReadTargetStartedEventArgs();
+                    break;
+                case BinaryLogRecordKind.TargetFinished:
+                    result = ReadTargetFinishedEventArgs();
+                    break;
+                case BinaryLogRecordKind.TaskStarted:
+                    result = ReadTaskStartedEventArgs();
+                    break;
+                case BinaryLogRecordKind.TaskFinished:
+                    result = ReadTaskFinishedEventArgs();
+                    break;
+                case BinaryLogRecordKind.Error:
+                    result = ReadBuildErrorEventArgs();
+                    break;
+                case BinaryLogRecordKind.Warning:
+                    result = ReadBuildWarningEventArgs();
+                    break;
+                case BinaryLogRecordKind.Message:
+                    result = ReadBuildMessageEventArgs();
+                    break;
+                case BinaryLogRecordKind.CriticalBuildMessage:
+                    result = ReadCriticalBuildMessageEventArgs();
+                    break;
+                case BinaryLogRecordKind.TaskCommandLine:
+                    result = ReadTaskCommandLineEventArgs();
+                    break;
+                default:
+                    break;
+            }
+
+            return result;
+        }
+
+        private BuildEventArgs ReadBuildStartedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var environment = ReadStringDictionary();
+
+            var e = new BuildStartedEventArgs(
+                fields.Message,
+                fields.HelpKeyword,
+                environment);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadBuildFinishedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var succeeded = ReadBoolean();
+
+            var e = new BuildFinishedEventArgs(
+                fields.Message,
+                fields.HelpKeyword,
+                succeeded,
+                fields.Timestamp);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadProjectStartedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            BuildEventContext parentContext = null;
+            if (ReadBoolean())
+            {
+                parentContext = ReadBuildEventContext();
+            }
+
+            var projectFile = ReadOptionalString();
+            var projectId = ReadInt32();
+            var targetNames = ReadString();
+            var toolsVersion = ReadOptionalString();
+            var propertyList = ReadPropertyList();
+            var itemList = ReadItems();
+
+            var e = new ProjectStartedEventArgs(
+                projectId,
+                fields.Message,
+                fields.HelpKeyword,
+                projectFile,
+                targetNames,
+                propertyList,
+                itemList,
+                parentContext,
+                null,
+                toolsVersion);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadProjectFinishedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var projectFile = ReadOptionalString();
+            var succeeded = ReadBoolean();
+
+            var e = new ProjectFinishedEventArgs(
+                fields.Message,
+                fields.HelpKeyword,
+                projectFile,
+                succeeded,
+                fields.Timestamp);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadTargetStartedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var targetName = ReadOptionalString();
+            var projectFile = ReadOptionalString();
+            var targetFile = ReadOptionalString();
+            var parentTarget = ReadOptionalString();
+
+            var e = new TargetStartedEventArgs(
+                fields.Message,
+                fields.HelpKeyword,
+                targetName,
+                projectFile,
+                targetFile,
+                parentTarget,
+                fields.Timestamp);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadTargetFinishedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var succeeded = ReadBoolean();
+            var projectFile = ReadOptionalString();
+            var targetFile = ReadOptionalString();
+            var targetName = ReadOptionalString();
+            var targetOutputItemList = ReadItemList();
+
+            var e = new TargetFinishedEventArgs(
+                fields.Message,
+                fields.HelpKeyword,
+                targetName,
+                projectFile,
+                targetFile,
+                succeeded,
+                fields.Timestamp,
+                targetOutputItemList);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadTaskStartedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var taskName = ReadOptionalString();
+            var projectFile = ReadOptionalString();
+            var taskFile = ReadOptionalString();
+
+            var e = new TaskStartedEventArgs(
+                fields.Message,
+                fields.HelpKeyword,
+                projectFile,
+                taskFile,
+                taskName,
+                fields.Timestamp);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadTaskFinishedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var succeeded = ReadBoolean();
+            var taskName = ReadOptionalString();
+            var projectFile = ReadOptionalString();
+            var taskFile = ReadOptionalString();
+
+            var e = new TaskFinishedEventArgs(
+                fields.Message,
+                fields.HelpKeyword,
+                projectFile,
+                taskFile,
+                taskName,
+                succeeded,
+                fields.Timestamp);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadBuildErrorEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            ReadDiagnosticFields(fields);
+
+            var e = new BuildErrorEventArgs(
+                fields.Subcategory,
+                fields.Code,
+                fields.File,
+                fields.LineNumber,
+                fields.ColumnNumber,
+                fields.EndLineNumber,
+                fields.EndColumnNumber,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                fields.Timestamp);
+            e.BuildEventContext = fields.BuildEventContext;
+            e.ProjectFile = fields.ProjectFile;
+            return e;
+        }
+
+        private BuildEventArgs ReadBuildWarningEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            ReadDiagnosticFields(fields);
+
+            var e = new BuildWarningEventArgs(
+                fields.Subcategory,
+                fields.Code,
+                fields.File,
+                fields.LineNumber,
+                fields.ColumnNumber,
+                fields.EndLineNumber,
+                fields.EndColumnNumber,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                fields.Timestamp);
+            e.BuildEventContext = fields.BuildEventContext;
+            e.ProjectFile = fields.ProjectFile;
+            return e;
+        }
+
+        private BuildEventArgs ReadBuildMessageEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+
+            var e = new BuildMessageEventArgs(
+                fields.Subcategory,
+                fields.Code,
+                fields.File,
+                fields.LineNumber,
+                fields.ColumnNumber,
+                fields.EndLineNumber,
+                fields.EndColumnNumber,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                importance,
+                fields.Timestamp);
+            e.BuildEventContext = fields.BuildEventContext;
+            e.ProjectFile = fields.ProjectFile;
+            return e;
+        }
+
+        private BuildEventArgs ReadTaskCommandLineEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+            var commandLine = ReadOptionalString();
+            var taskName = ReadOptionalString();
+
+            var e = new TaskCommandLineEventArgs(
+                commandLine,
+                taskName,
+                importance,
+                fields.Timestamp);
+            e.BuildEventContext = fields.BuildEventContext;
+            e.ProjectFile = fields.ProjectFile;
+            return e;
+        }
+
+        private BuildEventArgs ReadCriticalBuildMessageEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+
+            var e = new CriticalBuildMessageEventArgs(
+                fields.Subcategory,
+                fields.Code,
+                fields.File,
+                fields.LineNumber,
+                fields.ColumnNumber,
+                fields.EndLineNumber,
+                fields.EndColumnNumber,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                fields.Timestamp);
+            e.BuildEventContext = fields.BuildEventContext;
+            e.ProjectFile = fields.ProjectFile;
+            return e;
+        }
+
+        /// <summary>
+        /// For errors and warnings these 8 fields are written out explicitly
+        /// (their presence is not marked as a bit in the flags). So we have to
+        /// read explicitly.
+        /// </summary>
+        /// <param name="fields"></param>
+        private void ReadDiagnosticFields(BuildEventArgsFields fields)
+        {
+            fields.Subcategory = ReadOptionalString();
+            fields.Code = ReadOptionalString();
+            fields.File = ReadOptionalString();
+            fields.ProjectFile = ReadOptionalString();
+            fields.LineNumber = ReadInt32();
+            fields.ColumnNumber = ReadInt32();
+            fields.EndLineNumber = ReadInt32();
+            fields.EndColumnNumber = ReadInt32();
+        }
+
+        private BuildEventArgsFields ReadBuildEventArgsFields()
+        {
+            BuildEventArgsFieldFlags flags = (BuildEventArgsFieldFlags)ReadInt32();
+            var result = new BuildEventArgsFields();
+            result.Flags = flags;
+
+            if ((flags & BuildEventArgsFieldFlags.Message) != 0)
+            {
+                result.Message = ReadString();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.BuildEventContext) != 0)
+            {
+                result.BuildEventContext = ReadBuildEventContext();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.ThreadId) != 0)
+            {
+                result.ThreadId = ReadInt32();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.HelpHeyword) != 0)
+            {
+                result.HelpKeyword = ReadString();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.SenderName) != 0)
+            {
+                result.SenderName = ReadString();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.Timestamp) != 0)
+            {
+                result.Timestamp = ReadDateTime();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.Subcategory) != 0)
+            {
+                result.Subcategory = ReadString();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.Code) != 0)
+            {
+                result.Code = ReadString();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.File) != 0)
+            {
+                result.File = ReadString();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.ProjectFile) != 0)
+            {
+                result.ProjectFile = ReadString();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.LineNumber) != 0)
+            {
+                result.LineNumber = ReadInt32();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.ColumnNumber) != 0)
+            {
+                result.ColumnNumber = ReadInt32();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.EndLineNumber) != 0)
+            {
+                result.EndLineNumber = ReadInt32();
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.EndColumnNumber) != 0)
+            {
+                result.EndColumnNumber = ReadInt32();
+            }
+
+            return result;
+        }
+
+        private void SetCommonFields(BuildEventArgs buildEventArgs, BuildEventArgsFields fields)
+        {
+            buildEventArgs.BuildEventContext = fields.BuildEventContext;
+
+            if ((fields.Flags & BuildEventArgsFieldFlags.ThreadId) != 0)
+            {
+                buildEventArgsFieldThreadId.SetValue(buildEventArgs, fields.ThreadId);
+            }
+
+            if ((fields.Flags & BuildEventArgsFieldFlags.SenderName) != 0)
+            {
+                buildEventArgsFieldSenderName.SetValue(buildEventArgs, fields.SenderName);
+            }
+
+            if ((fields.Flags & BuildEventArgsFieldFlags.Timestamp) != 0)
+            {
+                buildEventArgsFieldTimestamp.SetValue(buildEventArgs, fields.Timestamp);
+            }
+        }
+
+        private ArrayList ReadPropertyList()
+        {
+            var properties = ReadStringDictionary();
+            if (properties == null)
+            {
+                return null;
+            }
+
+            var list = new ArrayList();
+            foreach (var property in properties)
+            {
+                var entry = new DictionaryEntry(property.Key, property.Value);
+                list.Add(entry);
+            }
+
+            return list;
+        }
+
+        private BuildEventContext ReadBuildEventContext()
+        {
+            int nodeId = ReadInt32();
+            int projectContextId = ReadInt32();
+            int targetId = ReadInt32();
+            int taskId = ReadInt32();
+            int submissionId = ReadInt32();
+            int projectInstanceId = ReadInt32();
+
+            var result = new BuildEventContext(
+                submissionId,
+                nodeId,
+                projectInstanceId,
+                projectContextId,
+                targetId,
+                taskId);
+            return result;
+        }
+
+        private Dictionary<string, string> ReadStringDictionary()
+        {
+            int count = ReadInt32();
+
+            if (count == 0)
+            {
+                return null;
+            }
+
+            Dictionary<string, string> result = new Dictionary<string, string>();
+            for (int i = 0; i < count; i++)
+            {
+                string key = ReadString();
+                string value = ReadString();
+                result[key] = value;
+            }
+
+            return result;
+        }
+
+        private class TaskItem : ITaskItem
+        {
+            public string ItemSpec { get; set; }
+            public Dictionary<string, string> Metadata { get; } = new Dictionary<string, string>();
+
+            public int MetadataCount => Metadata.Count;
+
+            public ICollection MetadataNames => Metadata.Keys;
+
+            public IDictionary CloneCustomMetadata()
+            {
+                return Metadata;
+            }
+
+            public void CopyMetadataTo(ITaskItem destinationItem)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetMetadata(string metadataName)
+            {
+                return Metadata[metadataName];
+            }
+
+            public void RemoveMetadata(string metadataName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SetMetadata(string metadataName, string metadataValue)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private ITaskItem ReadItem()
+        {
+            var item = new TaskItem();
+            item.ItemSpec = ReadString();
+
+            int count = ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                string name = ReadString();
+                string value = ReadString();
+                item.Metadata[name] = value;
+            }
+
+            return item;
+        }
+
+        private IEnumerable ReadItems()
+        {
+            int count = ReadInt32();
+            if (count == 0)
+            {
+                return null;
+            }
+
+            var list = new List<DictionaryEntry>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                string key = ReadString();
+                ITaskItem item = ReadItem();
+                list.Add(new DictionaryEntry(key, item));
+            }
+
+            return list;
+        }
+
+        private IEnumerable ReadItemList()
+        {
+            int count = ReadInt32();
+            if (count == 0)
+            {
+                return null;
+            }
+
+            var list = new List<ITaskItem>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                ITaskItem item = ReadItem();
+                list.Add(item);
+            }
+
+            return list;
+        }
+
+        private string ReadOptionalString()
+        {
+            if (ReadBoolean())
+            {
+                return ReadString();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private string ReadString()
+        {
+            return binaryReader.ReadString();
+        }
+
+        private int ReadInt32()
+        {
+            return Read7BitEncodedInt(binaryReader);
+        }
+
+        private bool ReadBoolean()
+        {
+            return binaryReader.ReadBoolean();
+        }
+
+        private DateTime ReadDateTime()
+        {
+            return new DateTime(binaryReader.ReadInt64(), (DateTimeKind)ReadInt32());
+        }
+
+        private int Read7BitEncodedInt(BinaryReader reader)
+        {
+            // Read out an Int32 7 bits at a time.  The high bit
+            // of the byte when on means to continue reading more bytes.
+            int count = 0;
+            int shift = 0;
+            byte b;
+            do
+            {
+                // Check for a corrupted stream.  Read a max of 5 bytes.
+                // In a future version, add a DataFormatException.
+                if (shift == 5 * 7)  // 5 bytes max per Int32, shift += 7
+                {
+                    throw new FormatException();
+                }
+
+                // ReadByte handles end of stream cases for us.
+                b = reader.ReadByte();
+                count |= (b & 0x7F) << shift;
+                shift += 7;
+            } while ((b & 0x80) != 0);
+            return count;
+        }
+    }
+}

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Build.Logging
     /// <summary>
     /// Serializes BuildEventArgs-derived objects into a provided BinaryWriter
     /// </summary>
-    public class BuildEventArgsWriter
+    internal class BuildEventArgsWriter
     {
         private readonly BinaryWriter binaryWriter;
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -1,0 +1,600 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging
+{
+    /// <summary>
+    /// Serializes BuildEventArgs-derived objects into a provided BinaryWriter
+    /// </summary>
+    public class BuildEventArgsWriter
+    {
+        private readonly BinaryWriter binaryWriter;
+
+        // these are used to access the Message without forcing formatting the message
+        private static FieldInfo lazyFormattedArgumentsField =
+            typeof(LazyFormattedBuildEventArgs).GetField("arguments", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static FieldInfo buildEventArgsMessageField =
+            typeof(BuildEventArgs).GetField("message", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static Func<CultureInfo, string, object[], string> formatStringDelegate =
+            (Func<CultureInfo, string, object[], string>)Delegate.CreateDelegate(
+                typeof(Func<CultureInfo, string, object[], string>),
+                typeof(LazyFormattedBuildEventArgs).GetMethod("FormatString", BindingFlags.Static | BindingFlags.NonPublic));
+
+        /// <summary>
+        /// Initializes a new instance of BuildEventArgsWriter with a BinaryWriter
+        /// </summary>
+        /// <param name="binaryWriter">A BinaryWriter to write the BuildEventArgs instances to</param>
+        public BuildEventArgsWriter(BinaryWriter binaryWriter)
+        {
+            this.binaryWriter = binaryWriter;
+        }
+
+        /// <summary>
+        /// Write a provided instance of BuildEventArgs to the BinaryWriter
+        /// </summary>
+        public void Write(BuildEventArgs e)
+        {
+            // the cases are ordered by most used first for performance
+            if (e is BuildMessageEventArgs)
+            {
+                Write((BuildMessageEventArgs)e);
+            }
+            else if (e is TaskStartedEventArgs)
+            {
+                Write((TaskStartedEventArgs)e);
+            }
+            else if (e is TaskFinishedEventArgs)
+            {
+                Write((TaskFinishedEventArgs)e);
+            }
+            else if (e is TargetStartedEventArgs)
+            {
+                Write((TargetStartedEventArgs)e);
+            }
+            else if (e is TargetFinishedEventArgs)
+            {
+                Write((TargetFinishedEventArgs)e);
+            }
+            else if (e is BuildErrorEventArgs)
+            {
+                Write((BuildErrorEventArgs)e);
+            }
+            else if (e is BuildWarningEventArgs)
+            {
+                Write((BuildWarningEventArgs)e);
+            }
+            else if (e is ProjectStartedEventArgs)
+            {
+                Write((ProjectStartedEventArgs)e);
+            }
+            else if (e is ProjectFinishedEventArgs)
+            {
+                Write((ProjectFinishedEventArgs)e);
+            }
+            else if (e is BuildStartedEventArgs)
+            {
+                Write((BuildStartedEventArgs)e);
+            }
+            else if (e is BuildFinishedEventArgs)
+            {
+                Write((BuildFinishedEventArgs)e);
+            }
+            else
+            {
+                // convert all unrecognized objects to message
+                // and just preserve the message
+                var buildMessageEventArgs = new BuildMessageEventArgs(
+                    e.Message,
+                    e.HelpKeyword,
+                    e.SenderName,
+                    MessageImportance.Normal);
+                Write(buildMessageEventArgs);
+            }
+        }
+
+        private void Write(BuildStartedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.BuildStarted);
+            WriteBuildEventArgsFields(e);
+            Write(e.BuildEnvironment);
+        }
+
+        private void Write(BuildFinishedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.BuildFinished);
+            WriteBuildEventArgsFields(e);
+            Write(e.Succeeded);
+        }
+
+        private void Write(ProjectStartedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.ProjectStarted);
+            WriteBuildEventArgsFields(e);
+
+            if (e.ParentProjectBuildEventContext == null)
+            {
+                Write(false);
+            }
+            else
+            {
+                Write(true);
+                Write(e.ParentProjectBuildEventContext);
+            }
+
+            WriteOptionalString(e.ProjectFile);
+
+            Write(e.ProjectId);
+            Write(e.TargetNames);
+            WriteOptionalString(e.ToolsVersion);
+
+            WriteProperties(e.Properties);
+
+            WriteItems(e.Items);
+        }
+
+        private void Write(ProjectFinishedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.ProjectFinished);
+            WriteBuildEventArgsFields(e);
+            WriteOptionalString(e.ProjectFile);
+            Write(e.Succeeded);
+        }
+
+        private void Write(TargetStartedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.TargetStarted);
+            WriteBuildEventArgsFields(e);
+            WriteOptionalString(e.TargetName);
+            WriteOptionalString(e.ProjectFile);
+            WriteOptionalString(e.TargetFile);
+            WriteOptionalString(e.ParentTarget);
+        }
+
+        private void Write(TargetFinishedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.TargetFinished);
+            WriteBuildEventArgsFields(e);
+            Write(e.Succeeded);
+            WriteOptionalString(e.ProjectFile);
+            WriteOptionalString(e.TargetFile);
+            WriteOptionalString(e.TargetName);
+            WriteItemList(e.TargetOutputs);
+        }
+
+        private void Write(TaskStartedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.TaskStarted);
+            WriteBuildEventArgsFields(e);
+            WriteOptionalString(e.TaskName);
+            WriteOptionalString(e.ProjectFile);
+            WriteOptionalString(e.TaskFile);
+        }
+
+        private void Write(TaskFinishedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.TaskFinished);
+            WriteBuildEventArgsFields(e);
+            Write(e.Succeeded);
+            WriteOptionalString(e.TaskName);
+            WriteOptionalString(e.ProjectFile);
+            WriteOptionalString(e.TaskFile);
+        }
+
+        private void Write(BuildErrorEventArgs e)
+        {
+            Write(BinaryLogRecordKind.Error);
+            WriteBuildEventArgsFields(e);
+            WriteOptionalString(e.Subcategory);
+            WriteOptionalString(e.Code);
+            WriteOptionalString(e.File);
+            WriteOptionalString(e.ProjectFile);
+            Write(e.LineNumber);
+            Write(e.ColumnNumber);
+            Write(e.EndLineNumber);
+            Write(e.EndColumnNumber);
+        }
+
+        private void Write(BuildWarningEventArgs e)
+        {
+            Write(BinaryLogRecordKind.Warning);
+            WriteBuildEventArgsFields(e);
+            WriteOptionalString(e.Subcategory);
+            WriteOptionalString(e.Code);
+            WriteOptionalString(e.File);
+            WriteOptionalString(e.ProjectFile);
+            Write(e.LineNumber);
+            Write(e.ColumnNumber);
+            Write(e.EndLineNumber);
+            Write(e.EndColumnNumber);
+        }
+
+        private void Write(BuildMessageEventArgs e)
+        {
+            if (e is CriticalBuildMessageEventArgs)
+            {
+                Write((CriticalBuildMessageEventArgs)e);
+                return;
+            }
+            else if (e is TaskCommandLineEventArgs)
+            {
+                Write((TaskCommandLineEventArgs)e);
+                return;
+            }
+
+            Write(BinaryLogRecordKind.Message);
+            WriteMessageFields(e);
+        }
+
+        private void Write(CriticalBuildMessageEventArgs e)
+        {
+            Write(BinaryLogRecordKind.CriticalBuildMessage);
+            WriteMessageFields(e);
+        }
+
+        private void Write(TaskCommandLineEventArgs e)
+        {
+            Write(BinaryLogRecordKind.TaskCommandLine);
+            WriteMessageFields(e);
+            WriteOptionalString(e.CommandLine);
+            WriteOptionalString(e.TaskName);
+        }
+
+        private void WriteBuildEventArgsFields(BuildEventArgs e)
+        {
+            var flags = GetBuildEventArgsFieldFlags(e);
+            Write((int)flags);
+            WriteBaseFields(e, flags);
+        }
+
+        private void WriteBaseFields(BuildEventArgs e, BuildEventArgsFieldFlags flags)
+        {
+            if ((flags & BuildEventArgsFieldFlags.Message) != 0)
+            {
+                WriteMessage((LazyFormattedBuildEventArgs)e);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.BuildEventContext) != 0)
+            {
+                Write(e.BuildEventContext);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.ThreadId) != 0)
+            {
+                Write(e.ThreadId);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.HelpHeyword) != 0)
+            {
+                Write(e.HelpKeyword);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.SenderName) != 0)
+            {
+                Write(e.SenderName);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.Timestamp) != 0)
+            {
+                Write(e.Timestamp);
+            }
+        }
+
+        private void WriteMessageFields(BuildMessageEventArgs e)
+        {
+            var flags = GetBuildEventArgsFieldFlags(e);
+            flags = GetMessageFlags(e, flags);
+
+            Write((int)flags);
+
+            WriteBaseFields(e, flags);
+
+            if ((flags & BuildEventArgsFieldFlags.Subcategory) != 0)
+            {
+                Write(e.Subcategory);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.Code) != 0)
+            {
+                Write(e.Code);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.File) != 0)
+            {
+                Write(e.File);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.ProjectFile) != 0)
+            {
+                Write(e.ProjectFile);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.LineNumber) != 0)
+            {
+                Write(e.LineNumber);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.ColumnNumber) != 0)
+            {
+                Write(e.ColumnNumber);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.EndLineNumber) != 0)
+            {
+                Write(e.EndLineNumber);
+            }
+
+            if ((flags & BuildEventArgsFieldFlags.EndColumnNumber) != 0)
+            {
+                Write(e.EndColumnNumber);
+            }
+
+            Write((int)e.Importance);
+        }
+
+        private static BuildEventArgsFieldFlags GetMessageFlags(BuildMessageEventArgs e, BuildEventArgsFieldFlags flags)
+        {
+            if (e.Subcategory != null)
+            {
+                flags |= BuildEventArgsFieldFlags.Subcategory;
+            }
+
+            if (e.Code != null)
+            {
+                flags |= BuildEventArgsFieldFlags.Code;
+            }
+
+            if (e.File != null)
+            {
+                flags |= BuildEventArgsFieldFlags.File;
+            }
+
+            if (e.ProjectFile != null)
+            {
+                flags |= BuildEventArgsFieldFlags.ProjectFile;
+            }
+
+            if (e.LineNumber != 0)
+            {
+                flags |= BuildEventArgsFieldFlags.LineNumber;
+            }
+
+            if (e.ColumnNumber != 0)
+            {
+                flags |= BuildEventArgsFieldFlags.ColumnNumber;
+            }
+
+            if (e.EndLineNumber != 0)
+            {
+                flags |= BuildEventArgsFieldFlags.EndLineNumber;
+            }
+
+            if (e.EndColumnNumber != 0)
+            {
+                flags |= BuildEventArgsFieldFlags.EndColumnNumber;
+            }
+
+            return flags;
+        }
+
+        private static BuildEventArgsFieldFlags GetBuildEventArgsFieldFlags(BuildEventArgs e)
+        {
+            var flags = BuildEventArgsFieldFlags.None;
+            if (e.BuildEventContext != null)
+            {
+                flags |= BuildEventArgsFieldFlags.BuildEventContext;
+            }
+
+            if (e.HelpKeyword != null)
+            {
+                flags |= BuildEventArgsFieldFlags.HelpHeyword;
+            }
+
+            // don't want to force evaluation of e.Message, so accessing the field directly
+            if (buildEventArgsMessageField.GetValue(e) is string)
+            {
+                flags |= BuildEventArgsFieldFlags.Message;
+            }
+
+            // no need to waste space for the default sender name
+            if (e.SenderName != null && e.SenderName != "MSBuild")
+            {
+                flags |= BuildEventArgsFieldFlags.SenderName;
+            }
+
+            if (e.ThreadId > 0)
+            {
+                flags |= BuildEventArgsFieldFlags.ThreadId;
+            }
+
+            if (e.Timestamp != default(DateTime))
+            {
+                flags |= BuildEventArgsFieldFlags.Timestamp;
+            }
+
+            return flags;
+        }
+
+        private void WriteItemList(IEnumerable items)
+        {
+            var taskItems = items as IEnumerable<ITaskItem>;
+            if (taskItems != null)
+            {
+                Write(taskItems.Count());
+
+                foreach (var item in taskItems)
+                {
+                    Write(item);
+                }
+
+                return;
+            }
+
+            Write(0);
+        }
+
+        private void WriteItems(IEnumerable items)
+        {
+            if (items == null)
+            {
+                Write(0);
+                return;
+            }
+
+            var entries = items.OfType<DictionaryEntry>()
+                .Where(e => e.Key is string && e.Value is ITaskItem);
+            Write(entries.Count());
+
+            foreach (DictionaryEntry entry in entries)
+            {
+                string key = entry.Key as string;
+                ITaskItem item = entry.Value as ITaskItem;
+                Write(key);
+                Write(item);
+            }
+        }
+
+        private void Write(ITaskItem item)
+        {
+            Write(item.ItemSpec);
+            IDictionary customMetadata = item.CloneCustomMetadata();
+            Write(customMetadata.Count);
+
+            foreach (string metadataName in customMetadata.Keys)
+            {
+                Write(metadataName);
+                Write(item.GetMetadata(metadataName));
+            }
+        }
+
+        private void WriteProperties(IEnumerable properties)
+        {
+            if (properties == null)
+            {
+                Write(0);
+                return;
+            }
+
+            Write(properties.Cast<object>().Count());
+
+            foreach (DictionaryEntry entry in properties)
+            {
+                if (entry.Key is string && entry.Value is string)
+                {
+                    Write((string)entry.Key);
+                    Write((string)entry.Value);
+                }
+                else
+                {
+                    // to keep the count accurate
+                    Write("");
+                    Write("");
+                }
+            }
+        }
+
+        private void Write(BuildEventContext buildEventContext)
+        {
+            Write(buildEventContext.NodeId);
+            Write(buildEventContext.ProjectContextId);
+            Write(buildEventContext.TargetId);
+            Write(buildEventContext.TaskId);
+            Write(buildEventContext.SubmissionId);
+            Write(buildEventContext.ProjectInstanceId);
+        }
+
+        private void WriteMessage(LazyFormattedBuildEventArgs e)
+        {
+            string message = buildEventArgsMessageField.GetValue(e) as string;
+
+            var arguments = (object[])lazyFormattedArgumentsField.GetValue(e);
+            if (arguments != null && arguments.Length > 0)
+            {
+                message = formatStringDelegate(CultureInfo.CurrentCulture, message, arguments);
+            }
+
+            Write(message);
+        }
+
+        private void Write<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs)
+        {
+            if (keyValuePairs != null && keyValuePairs.Any())
+            {
+                Write(keyValuePairs.Count());
+                foreach (var kvp in keyValuePairs)
+                {
+                    Write(kvp.Key.ToString());
+                    Write(kvp.Value.ToString());
+                }
+            }
+            else
+            {
+                Write(false);
+            }
+        }
+
+        private void Write(BinaryLogRecordKind kind)
+        {
+            Write((int)kind);
+        }
+
+        private void Write(int value)
+        {
+            Write7BitEncodedInt(binaryWriter, value);
+        }
+
+        private void Write7BitEncodedInt(BinaryWriter writer, int value)
+        {
+            // Write out an int 7 bits at a time.  The high bit of the byte,
+            // when on, tells reader to continue reading more bytes.
+            uint v = (uint)value;   // support negative numbers
+            while (v >= 0x80)
+            {
+                writer.Write((byte)(v | 0x80));
+                v >>= 7;
+            }
+            writer.Write((byte)v);
+        }
+
+        private void Write(bool boolean)
+        {
+            binaryWriter.Write(boolean);
+        }
+
+        private void Write(string text)
+        {
+            if (text != null)
+            {
+                binaryWriter.Write(text);
+            }
+            else
+            {
+                binaryWriter.Write(false);
+            }
+        }
+
+        private void WriteOptionalString(string text)
+        {
+            if (text == null)
+            {
+                Write(false);
+            }
+            else
+            {
+                Write(true);
+                Write(text);
+            }
+        }
+
+        private void Write(DateTime timestamp)
+        {
+            binaryWriter.Write(timestamp.Ticks);
+            Write((int)timestamp.Kind);
+        }
+    }
+}

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -545,6 +545,14 @@
     <Compile Include="Logging\BaseConsoleLogger.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Logging\BinaryLogger\BinaryLogger.cs" />
+    <Compile Include="Logging\BinaryLogger\BinaryLogRecordKind.cs" />
+    <Compile Include="Logging\BinaryLogger\BinaryLogReplayEventSource.cs" />
+    <Compile Include="Logging\BinaryLogger\BuildEventArgsDispatcher.cs" />
+    <Compile Include="Logging\BinaryLogger\BuildEventArgsFieldFlags.cs" />
+    <Compile Include="Logging\BinaryLogger\BuildEventArgsFields.cs" />
+    <Compile Include="Logging\BinaryLogger\BuildEventArgsReader.cs" />
+    <Compile Include="Logging\BinaryLogger\BuildEventArgsWriter.cs" />
     <Compile Include="Logging\ConsoleLogger.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1193,6 +1193,10 @@
     <value>MSB4068: The element &lt;{0}&gt; is unrecognized, or not supported in this context.</value>
     <comment>{StrBegin="MSB4068: "}</comment>
   </data>
+  <data name="UnsupportedLogFileFormat" UESanitized="false" Visibility="Public">
+    <value>MSB4235: The log file format version is {0}, whereas this version of MSBuild only supports versions up to {1}.</value>
+    <comment>{StrBegin="MSB4235: "}</comment>
+  </data>
   <data name="UnsupportedTaskParameterTypeError" UESanitized="false" Visibility="Public">
     <value>MSB4069: The "{0}" type of the "{1}" parameter of the "{2}" task is not supported by MSBuild.</value>
     <comment>{StrBegin="MSB4069: "}LOCALIZATION: "MSBuild" should not be localized.</comment>
@@ -1593,7 +1597,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4235.
+        Next message code should be MSB4236.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -444,6 +444,10 @@
     <comment>{StrBegin="MSB4102: "}UE: This is a generic message that is displayed when we find a project element with an incorrect value for one of its
         attributes. At the end of the message we show the exception text we got trying to use the value.</comment>
   </data>
+  <data name="InvalidBinaryLoggerParameters" UESanitized="false" Visibility="Public">
+    <value>MSB4234: The binary logger expects a single parameter (the output file name). {0} parameters were passed: "{1}".</value>
+    <comment>{StrBegin="MSB4234: "}This is shown when the Binary Logger is passed zero or more than one parameter.</comment>
+  </data>
   <data name="InvalidContinueOnErrorAttribute" UESanitized="false" Visibility="Public">
     <value>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</value>
     <comment>{StrBegin="MSB4021: "}LOCALIZATION: "ContinueOnError" should not be localized. "{1}" is a message from another exception explaining the problem.</comment>
@@ -462,6 +466,10 @@
     <comment>{StrBegin="MSB4024: "}UE: This message is shown when an imported project file cannot be loaded because of incorrect XML. The project
     filename is not part of the message because it is provided separately to loggers.
     LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</comment>
+  </data>
+  <data name="InvalidLogFileFormat" UESanitized="false" Visibility="Public">
+    <value>MSB4233: There was an exception while reading the log file: {0}</value>
+    <comment>{StrBegin="MSB4233: "}This is shown when the Binary Logger can't read the log file.</comment>
   </data>
   <data name="InvalidPropertyNameInToolset" UESanitized="false" Visibility="Private_OM">
     <value>MSB4147: The property "{0}" at "{1}" is invalid. {2}</value>
@@ -1585,7 +1593,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4233.
+        Next message code should be MSB4235.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Build.CommandLine
 #endif
             WarningsAsErrors,
             WarningsAsMessages,
+            BinaryLogger,
             NumberOfParameterizedSwitches
         }
 
@@ -211,34 +212,34 @@ namespace Microsoft.Build.CommandLine
         // WARNING: keep this map in the same order as the ParameterlessSwitch enumeration
         private static readonly ParameterlessSwitchInfo[] s_parameterlessSwitchesMap =
         {
-            //-------------------------------------------------------------------------------------------------------------------------------------------
+            //---------------------------------------------------------------------------------------------------------------------------------------------------
             //                                          Switch Names                        Switch Id                             Dup Error  Light up key
-            //-------------------------------------------------------------------------------------------------------------------------------------------
-            new ParameterlessSwitchInfo(  new string[] { "help", "h", "?" },                ParameterlessSwitch.Help,                  null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "version", "ver" },                ParameterlessSwitch.Version,               null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "nologo" },                        ParameterlessSwitch.NoLogo,                null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "noautoresponse", "noautorsp" },   ParameterlessSwitch.NoAutoResponse,        null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "noconsolelogger", "noconlog" },   ParameterlessSwitch.NoConsoleLogger,       null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger", "fl" },              ParameterlessSwitch.FileLogger,            null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger1", "fl1" },            ParameterlessSwitch.FileLogger1,           null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger2", "fl2" },            ParameterlessSwitch.FileLogger2,           null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger3", "fl3" },            ParameterlessSwitch.FileLogger3,           null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger4", "fl4" },            ParameterlessSwitch.FileLogger4,           null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger5", "fl5" },            ParameterlessSwitch.FileLogger5,           null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger6", "fl6" },            ParameterlessSwitch.FileLogger6,           null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger7", "fl7" },            ParameterlessSwitch.FileLogger7,           null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger8", "fl8" },            ParameterlessSwitch.FileLogger8,           null, null    ),
-            new ParameterlessSwitchInfo(  new string[] { "filelogger9", "fl9" },            ParameterlessSwitch.FileLogger9,           null, null    ),
+            //---------------------------------------------------------------------------------------------------------------------------------------------------
+            new ParameterlessSwitchInfo(  new string[] { "help", "h", "?" },                ParameterlessSwitch.Help,                  null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "version", "ver" },                ParameterlessSwitch.Version,               null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "nologo" },                        ParameterlessSwitch.NoLogo,                null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "noautoresponse", "noautorsp" },   ParameterlessSwitch.NoAutoResponse,        null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "noconsolelogger", "noconlog" },   ParameterlessSwitch.NoConsoleLogger,       null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger", "fl" },              ParameterlessSwitch.FileLogger,            null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger1", "fl1" },            ParameterlessSwitch.FileLogger1,           null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger2", "fl2" },            ParameterlessSwitch.FileLogger2,           null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger3", "fl3" },            ParameterlessSwitch.FileLogger3,           null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger4", "fl4" },            ParameterlessSwitch.FileLogger4,           null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger5", "fl5" },            ParameterlessSwitch.FileLogger5,           null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger6", "fl6" },            ParameterlessSwitch.FileLogger6,           null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger7", "fl7" },            ParameterlessSwitch.FileLogger7,           null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger8", "fl8" },            ParameterlessSwitch.FileLogger8,           null, null              ),
+            new ParameterlessSwitchInfo(  new string[] { "filelogger9", "fl9" },            ParameterlessSwitch.FileLogger9,           null, null              ),
 #if (!STANDALONEBUILD)
-            new ParameterlessSwitchInfo(  new string[] { "oldom" },                         ParameterlessSwitch.OldOM,                 null, null    ),
+            new ParameterlessSwitchInfo(  new string[] { "oldom" },                         ParameterlessSwitch.OldOM,                 null, null              ),
 #endif
-            new ParameterlessSwitchInfo(  new string[] { "distributedfilelogger", "dfl" },  ParameterlessSwitch.DistributedFileLogger, null, null    ),
+            new ParameterlessSwitchInfo(  new string[] { "distributedfilelogger", "dfl" },  ParameterlessSwitch.DistributedFileLogger, null, null              ),
 #if FEATURE_MSBUILD_DEBUGGER
-            new ParameterlessSwitchInfo(  new string[] { "debug", "d" },         ParameterlessSwitch.Debugger,                         null, "DebuggerEnabled"),
+            new ParameterlessSwitchInfo(  new string[] { "debug", "d" },                    ParameterlessSwitch.Debugger,              null, "DebuggerEnabled" ),
 #endif
-            new ParameterlessSwitchInfo(  new string[] { "detailedsummary", "ds" },         ParameterlessSwitch.DetailedSummary,       null , null   ),
+            new ParameterlessSwitchInfo(  new string[] { "detailedsummary", "ds" },         ParameterlessSwitch.DetailedSummary,       null , null             ),
 #if DEBUG
-            new ParameterlessSwitchInfo(  new string[] { "waitfordebugger", "wfd" },        ParameterlessSwitch.WaitForDebugger,       null , null   ),
+            new ParameterlessSwitchInfo(  new string[] { "waitfordebugger", "wfd" },        ParameterlessSwitch.WaitForDebugger,       null , null             ),
 #endif
         };
 
@@ -246,9 +247,9 @@ namespace Microsoft.Build.CommandLine
         // WARNING: keep this map in the same order as the ParameterizedSwitch enumeration
         private static readonly ParameterizedSwitchInfo[] s_parameterizedSwitchesMap =
         {
-            //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+            //------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
             //                                          Switch Names                            Switch Id                                       Duplicate Switch Error          Multi Params?   Missing Parameters Error           Unquote?    Empty?
-            //-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+            //------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
             new ParameterizedSwitchInfo(  new string[] { null },                                ParameterizedSwitch.Project,                    "DuplicateProjectSwitchError",  false,          null,                                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "target", "t"},                        ParameterizedSwitch.Target,                     null,                           true,           "MissingTargetError",                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "property", "p" },                     ParameterizedSwitch.Property,                   null,                           true,           "MissingPropertyError",                true,   false  ),
@@ -281,8 +282,9 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "clientToServerPipeHandle", "c2s" },   ParameterizedSwitch.ClientToServerPipeHandle,   null,                           false,          null,                                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "serverToClientPipeHandle", "s2c" },   ParameterizedSwitch.ServerToClientPipeHandle,   null,                           false,          null,                                  true,   false  ),
 #endif
-            new ParameterizedSwitchInfo(  new string[] { "warnaserror", "err" },                ParameterizedSwitch.WarningsAsErrors,           null,                           true,           null,                                  true,   true  ),
-            new ParameterizedSwitchInfo(  new string[] { "warnasmessage", "nowarn" },           ParameterizedSwitch.WarningsAsMessages,         null,                           true,           "MissingWarnAsMessageParameterError",  true,   false ),
+            new ParameterizedSwitchInfo(  new string[] { "warnaserror", "err" },                ParameterizedSwitch.WarningsAsErrors,           null,                           true,           null,                                  true,   true   ),
+            new ParameterizedSwitchInfo(  new string[] { "warnasmessage", "nowarn" },           ParameterizedSwitch.WarningsAsMessages,         null,                           true,           "MissingWarnAsMessageParameterError",  true,   false  ),
+            new ParameterizedSwitchInfo(  new string[] { "binarylogger", "binlog", "bl" },      ParameterizedSwitch.BinaryLogger,               null,                           false,          null,                                  true,   false  ),
         };
 
         /// <summary>
@@ -366,7 +368,7 @@ namespace Microsoft.Build.CommandLine
             {
                 foreach (string parameterizedSwitchName in switchInfo.switchNames)
                 {
-                    if (String.Compare(switchName, parameterizedSwitchName, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (String.Equals(switchName, parameterizedSwitchName, StringComparison.OrdinalIgnoreCase))
                     {
                         parameterizedSwitch = switchInfo.parameterizedSwitch;
                         duplicateSwitchErrorMessage = switchInfo.duplicateSwitchErrorMessage;

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Build.CommandLine
 #endif
             new ParameterizedSwitchInfo(  new string[] { "warnaserror", "err" },                ParameterizedSwitch.WarningsAsErrors,           null,                           true,           null,                                  true,   true   ),
             new ParameterizedSwitchInfo(  new string[] { "warnasmessage", "nowarn" },           ParameterizedSwitch.WarningsAsMessages,         null,                           true,           "MissingWarnAsMessageParameterError",  true,   false  ),
-            new ParameterizedSwitchInfo(  new string[] { "binarylogger", "binlog", "bl" },      ParameterizedSwitch.BinaryLogger,               null,                           false,          null,                                  true,   false  ),
+            new ParameterizedSwitchInfo(  new string[] { "binarylogger", "bl" },                ParameterizedSwitch.BinaryLogger,               null,                           false,          null,                                  true,   false  ),
         };
 
         /// <summary>

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -18,6 +18,7 @@
     <RootNamespace>Microsoft.Build.CommandLine</RootNamespace>
     <AssemblyName>MSBuild</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
     <ApplicationManifest>MSBuild.exe.manifest</ApplicationManifest>
     <AppConfig>app.config</AppConfig>
     <!-- Temporary solution for
@@ -77,7 +78,7 @@
       <Link>FileUtilities.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="..\Shared\FileUtilities.GetFolderPath.cs" >
+    <Compile Include="..\Shared\FileUtilities.GetFolderPath.cs">
       <Link>FileUtilities.GetFolderPath.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -629,12 +629,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      text logs and used by other analysis tools. A binary log
                      is usually 10-20x smaller than the most detailed text
                      diagnostic-level log, but it contains more information.
-                     (Short form: /bl or /binlog)
+                     (Short form: /bl)
 
                      Examples:
                        /bl
                        /bl:output.binlog
-                       /binlog:..\..\custom.binlog
+                       /bl:..\..\custom.binlog
                        /binaryLogger
     </value>
     <comment>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -620,6 +620,31 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </comment>
   </data>
+  <data name="HelpMessage_30_BinaryLoggerSwitch" UESanitized="false" Visibility="Public">
+    <value>  /binaryLogger[:output.binlog]
+                     Serializes all build events to a compressed binary file.
+                     By default the file is in the current directory and named
+                     "msbuild.binlog". The binary log is a detailed description
+                     of the build process that can later be used to reconstruct
+                     text logs and used by other analysis tools. A binary log
+                     is usually 10-20x smaller than the most detailed text
+                     diagnostic-level log, but it contains more information.
+                     (Short form: /bl or /binlog)
+
+                     Examples:
+                       /bl
+                       /bl:output.binlog
+                       /binlog:..\..\custom.binlog
+                       /binaryLogger
+    </value>
+    <comment>
+      LOCALIZATION: The following should not be localized:
+      1) "msbuild" 
+      2) the string "binlog" that describes the file extension
+      3) all switch names and their short forms e.g. /bl, /binlog and /binaryLogger
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </comment>
+  </data>
   <data name="InvalidConfigurationFile" Visibility="Public">
     <value>MSBUILD : Configuration error MSB1043: The application could not start. {0}</value>
     <comment>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1456,7 +1456,6 @@ namespace Microsoft.Build.CommandLine
                                 switchParameters = ":" + numberOfCpus;
                             }
                             else if (String.Equals(switchName, "bl", StringComparison.OrdinalIgnoreCase) ||
-                                String.Equals(switchName, "binlog", StringComparison.OrdinalIgnoreCase) ||
                                 String.Equals(switchName, "binarylogger", StringComparison.OrdinalIgnoreCase))
                             {
                                 // we have to specify at least one parameter otherwise it's impossible to distinguish the situation

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -638,15 +638,14 @@ namespace Microsoft.Build.UnitTests
         }
 
         internal static void BuildProjectExpectSuccess
-           (
-           string projectContents,
-            ILogger logger
-           )
+            (
+            string projectContents,
+            params ILogger[] loggers
+            )
         {
-            Project project = ObjectModelHelpers.CreateInMemoryProject(projectContents, logger);
-
-            bool success = project.Build(logger);
-            Assert.True(success); // "Build failed.  See Standard Out tab for details"
+            Project project = CreateInMemoryProject(projectContents, logger: null); // logger is null so we take care of loggers ourselves
+            bool success = project.Build(loggers);
+            Assert.True(success);
         }
 
         /// <summary>


### PR DESCRIPTION
/binaryLogger[:output.binlog]

Serializes all build events to a compressed binary file. By default the file is in the current directory and named "msbuild.binlog". The binary log is a detailed description of the build process that can later be used to reconstruct text logs and used by other analysis tools. A binary log is usually 10-20x smaller than the most detailed text diagnostic-level log, but it contains more information. (Short form: /bl or /binlog)

Examples:
  /bl
  bl:output.binlog
  binlog:..\..\custom.binlog
  binaryLogger

For now this commit only includes the logger (writer), but the reader is disconnected. In subsequent PRs we will add an option to playback the binary log into any other set of existing loggers.

Support for the new format will be added to MSBuild Structured Log Viewer so that you can view the .binlog files.

BuildEventArgsWriter and BuildEventArgsReader are general purpose custom binary serializers for BuildEventArgs objects.

BinaryLogReplayEventSource is a way to playback events from the log to subscribers of IEventSource.

A set of unit-tests is to follow in a separate PR.