### PR TITLE
Bump build version offset for vs15.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,6 @@
 {
   "version": "15.1",
+  "buildNumberOffset": "452",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/xplat$"


### PR DESCRIPTION
Bumps the build version to 1000 (as of 6 commits ago when the branch diverged). We will now be at `15.1.1006`.