### PR TITLE
Synchronize Dataflow dependency to what VS uses

### DIFF
--- a/src/Build.UnitTests/project.json
+++ b/src/Build.UnitTests/project.json
@@ -1,6 +1,5 @@
 ﻿{
   "dependencies": {
-    "System.Threading.Tasks.Dataflow": "4.6.0",
     "xunit": "2.1.0",
     "microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00629-09",
     "xunit.core": "2.1.0",
@@ -9,7 +8,8 @@
   },
   "frameworks": {
     "net46": {
-      "Microsoft.Net.Compilers": "2.0.0-beta3"
+      "Microsoft.Net.Compilers": "2.0.0-beta3",
+      "System.Threading.Tasks.Dataflow": "4.5.24.0"
     },
     "netstandard1.3": {
       "dependencies": {
@@ -22,6 +22,7 @@
         "System.Diagnostics.FileVersionInfo": "4.0.0",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TraceSource": "4.0.0",
+        "System.Threading.Tasks.Dataflow": "4.6.0.0",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",
         "System.Xml.XmlDocument": "4.0.1",

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -1,12 +1,10 @@
 ﻿{
-  "dependencies": {
-    "System.Threading.Tasks.Dataflow": "4.6.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
-        "System.Collections.Immutable": "1.3.1"
+        "System.Collections.Immutable": "1.3.1",
+        "System.Threading.Tasks.Dataflow": "4.5.24.0"
       }
     },
     "netstandard1.5": {
@@ -26,6 +24,7 @@
         "System.Runtime": "4.1.0",
         "System.Runtime.Loader": "4.0.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
+        "System.Threading.Tasks.Dataflow": "4.6.0.0",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",
         "System.Xml.XmlDocument": "4.0.1",

--- a/targets/runtimeDependencies/project.json
+++ b/targets/runtimeDependencies/project.json
@@ -19,7 +19,7 @@
         "xunit.runner.visualstudio": "2.1.0",
         "System.Collections.Immutable": "1.3.1",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
-        "System.Threading.Tasks.Dataflow": "4.6.0",
+        "System.Threading.Tasks.Dataflow": "4.5.24.0",
         "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01"
       }
     },
@@ -46,6 +46,7 @@
         "System.Reflection.Metadata": "1.3.0",
         "System.Runtime.Extensions": "4.1.0",
         "System.Runtime.Loader": "4.0.0",
+        "System.Threading.Tasks.Dataflow": "4.6.0.0",
         "System.Xml.XmlDocument": "4.0.1",
         "System.Xml.XPath": "4.0.1",
         "System.Xml.XPath.XmlDocument": "4.0.1",


### PR DESCRIPTION
devenv.exe has a binding redirect for Dataflow of `oldVersion="4.0.0.0-4.5.65535.65535" newVersion="4.5.24.0"`. We need to have the same dependency, otherwise msbuild crashes when loaded in-proc inside devenv.exe