### PR TITLE
Adding MSBuildProjectFile to CoreCompileInputs.cache filename

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3233,7 +3233,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target Name="_GenerateCompileDependencyCache" DependsOnTargets="ResolveAssemblyReferences">
     <ItemGroup>
-      <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)CoreCompileInputs.cache" />
+      <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
       <CoreCompileCache Include="@(Compile->'%(FullPath)')" />
       <CoreCompileCache Include="@(ReferencePath->'%(FullPath)')" />
     </ItemGroup>
@@ -3242,10 +3242,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="HashResult" PropertyName="CoreCompileDependencyHash" />
     </Hash>
 
-    <WriteLinesToFile Lines="$(CoreCompileDependencyHash)" File="$(IntermediateOutputPath)CoreCompileInputs.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
+    <WriteLinesToFile Lines="$(CoreCompileDependencyHash)" File="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" Overwrite="True" WriteOnlyWhenDifferent="True" />
 
     <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)CoreCompileInputs.cache" />
+      <FileWrites Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This prevents conflicts while building large solutions with projects
that share intermediate output directories.

I was receiving the error "**Could not write lines to file 'CoreCompileInputs.cache' because it is in use...**"  using the **VS 2017 RC** while building a 120+ project solution that shares intermediate output directories. This change brings the CoreCompileInputs.cache in line with other intermediate output files.


Fixes Issue #1645