### PR TITLE
Replay

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -1358,7 +1358,7 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Shutdown() { }
     }
-    public partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
+    public sealed partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
     {
         public BinaryLogReplayEventSource() { }
         public void Replay(string sourceFilePath) { }

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -1358,6 +1358,11 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Shutdown() { }
     }
+    public partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
+    {
+        public BinaryLogReplayEventSource() { }
+        public void Replay(string sourceFilePath) { }
+    }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);
     public partial class ConfigurableForwardingLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
@@ -1409,6 +1414,25 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
         public void Shutdown() { }
+    }
+    public partial class EventArgsDispatcher : Microsoft.Build.Framework.IEventSource
+    {
+        public EventArgsDispatcher() { }
+        public event Microsoft.Build.Framework.AnyEventHandler AnyEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildFinishedEventHandler BuildFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildStartedEventHandler BuildStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.CustomBuildEventHandler CustomEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildErrorEventHandler ErrorRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildMessageEventHandler MessageRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.ProjectFinishedEventHandler ProjectFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.ProjectStartedEventHandler ProjectStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildStatusEventHandler StatusEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.TargetFinishedEventHandler TargetFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.TargetStartedEventHandler TargetStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.TaskFinishedEventHandler TaskFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.TaskStartedEventHandler TaskStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildWarningEventHandler WarningRaised { add { } remove { } }
+        public void Dispatch(Microsoft.Build.Framework.BuildEventArgs buildEvent) { }
     }
     public partial class FileLogger : Microsoft.Build.Logging.ConsoleLogger
     {

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -1335,7 +1335,7 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Shutdown() { }
     }
-    public partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
+    public sealed partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
     {
         public BinaryLogReplayEventSource() { }
         public void Replay(string sourceFilePath) { }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -1335,6 +1335,11 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Shutdown() { }
     }
+    public partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
+    {
+        public BinaryLogReplayEventSource() { }
+        public void Replay(string sourceFilePath) { }
+    }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);
     public partial class ConfigurableForwardingLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
@@ -1386,6 +1391,25 @@ namespace Microsoft.Build.Logging
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
         public void Shutdown() { }
+    }
+    public partial class EventArgsDispatcher : Microsoft.Build.Framework.IEventSource
+    {
+        public EventArgsDispatcher() { }
+        public event Microsoft.Build.Framework.AnyEventHandler AnyEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildFinishedEventHandler BuildFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildStartedEventHandler BuildStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.CustomBuildEventHandler CustomEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildErrorEventHandler ErrorRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildMessageEventHandler MessageRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.ProjectFinishedEventHandler ProjectFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.ProjectStartedEventHandler ProjectStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildStatusEventHandler StatusEventRaised { add { } remove { } }
+        public event Microsoft.Build.Framework.TargetFinishedEventHandler TargetFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.TargetStartedEventHandler TargetStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.TaskFinishedEventHandler TaskFinished { add { } remove { } }
+        public event Microsoft.Build.Framework.TaskStartedEventHandler TaskStarted { add { } remove { } }
+        public event Microsoft.Build.Framework.BuildWarningEventHandler WarningRaised { add { } remove { } }
+        public void Dispatch(Microsoft.Build.Framework.BuildEventArgs buildEvent) { }
     }
     public partial class FileLogger : Microsoft.Build.Logging.ConsoleLogger
     {

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Build.Logging
     /// Provides a method to read a binary log file (*.binlog) and replay all stored BuildEventArgs
     /// by implementing IEventSource and raising corresponding events.
     /// </summary>
-    internal class BinaryLogReplayEventSource : EventArgsDispatcher
+    public class BinaryLogReplayEventSource : EventArgsDispatcher
     {
         /// <summary>
         /// Read the provided binary log file and raise corresponding events for each BuildEventArgs

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Build.Logging
     /// <summary>
     /// An implementation of IEventSource that raises appropriate events for a provided BuildEventArgs object.
     /// </summary>
+    /// <remarks>This class is public because BinaryLogReplayEventSource is a derived class.
+    /// This is abstracted into its own class because it's a useful single-purpose helper that
+    /// can be used independently as a generic implementation of IEventSource.</remarks>
     public class EventArgsDispatcher : IEventSource
     {
         /// <summary>

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsDispatcher.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Build.Logging
     /// <summary>
     /// An implementation of IEventSource that raises appropriate events for a provided BuildEventArgs object.
     /// </summary>
-    internal class EventArgsDispatcher : IEventSource
+    public class EventArgsDispatcher : IEventSource
     {
         /// <summary>
         /// This event is raised for all BuildEventArgs objects after a more type-specific event

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -602,15 +602,7 @@ namespace Microsoft.Build.CommandLine
                     // as if a build is happening
                     if (FileUtilities.IsBinaryLogFilename(projectFile))
                     {
-                        if (AnySwitchesIncompatibleWithLogReplay(targets, toolsVersion, globalProperties, distributedLoggerRecords))
-                        {
-                            Console.WriteLine();
-                            exitType = ExitType.SwitchError;
-                        }
-                        else
-                        {
-                            ReplayBinaryLog(projectFile, loggers, verbosity);
-                        }
+                        ReplayBinaryLog(projectFile, loggers);
                     }
                     else // regular build
                     {
@@ -3183,9 +3175,7 @@ namespace Microsoft.Build.CommandLine
         private static void ReplayBinaryLog
         (
             string binaryLogFilePath,
-            ILogger[] loggers,
-            LoggerVerbosity verbosity
-        )
+            ILogger[] loggers)
         {
             var replayEventSource = new Logging.BinaryLogReplayEventSource();
 
@@ -3194,23 +3184,19 @@ namespace Microsoft.Build.CommandLine
                 logger.Initialize(replayEventSource);
             }
 
-            replayEventSource.Replay(binaryLogFilePath);
+            try
+            {
+                replayEventSource.Replay(binaryLogFilePath);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
 
             foreach (var logger in loggers)
             {
                 logger.Shutdown();
             }
-        }
-
-        private static bool AnySwitchesIncompatibleWithLogReplay
-        (
-            string[] targets,
-            string toolsVersion,
-            Dictionary<string, string> globalProperties,
-            List<DistributedLoggerRecord> distributedLoggerRecords
-        )
-        {
-            return false;
         }
 
         /// <summary>

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -883,6 +883,11 @@ namespace Microsoft.Build.Shared
             return (String.Equals(Path.GetExtension(filename), ".metaproj", PathComparison));
         }
 
+        internal static bool IsBinaryLogFilename(string filename)
+        {
+            return (String.Equals(Path.GetExtension(filename), ".binlog", PathComparison));
+        }
+
         /// <summary>
         /// Given the absolute location of a file, and a disc location, returns relative file path to that disk location. 
         /// Throws UriFormatException.


### PR DESCRIPTION
Binary log replay functionality. 

Instead of specifying a project or solution, you can specify a .binlog file to "build" and it will replay all the events in the source log into the usual loggers.

Note that BuildLogReplayEventArgs and its base class EventArgsDispatcher need to be made public for the replay functionality in MSBuild.exe to work. I've made the class sealed and added <remarks> with explanations.