### PR TITLE
Add versioned check for GetApiContractReferences

### DIFF
--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1003,7 +1003,16 @@ namespace Microsoft.Build.Utilities
                         if (extensionSdk.SDKType == SDKType.Framework || extensionSdk.SDKType == SDKType.Platform)
                         {
                             // We don't want to attempt to gather ApiContract references if the framework isn't explicitly marked as Framework/Platform
-                            extensionSdkReferences = GetApiContractReferences(extensionSdk.ApiContracts, targetSdkPath);
+                            string platformKey = TargetPlatformSDK.GetSdkKey(targetSdkIdentifier, targetSdkVersion);
+                            PlatformManifest manifest;
+                            if (TryGetPlatformManifest(matchingSdk, platformKey, out manifest) && manifest != null && manifest.VersionedContent)
+                            {
+                                extensionSdkReferences = GetApiContractReferences(extensionSdk.ApiContracts, matchingSdk.Path, manifest.PlatformVersion);
+                            }
+                            else
+                            {
+                                extensionSdkReferences = GetApiContractReferences(extensionSdk.ApiContracts, matchingSdk.Path);
+                            }
                         }
                     }
                     else


### PR DESCRIPTION
Correct paths for reference assemblies for systemManagementContract, part of the IOT extension SDK, are not resolved with insider preview SDK, 15003 and 15021. The files are in here: 
C:\Program Files (x86)\Windows Kits\10\References\<VERSION>\Windows.System.SystemManagementContract\3.0.0.0\Windows.System.SystemManagementContract.winmd. 
The reason is when we call GetApiContractReferences we didn't check the Versioned property of the sdk. So it returned the path without <VERSION>