### PR TITLE
Fix crash parsing Clang/GCC messages with no text

### DIFF
--- a/src/Shared/CanonicalError.cs
+++ b/src/Shared/CanonicalError.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Build.Shared
                 + "(?<SUBCATEGORY>(()|([^:]*? )))"
                     // Match 'error' or 'warning'.
                 + @"(?<CATEGORY>(error|warning))"
-                    // Match anything starting with a space that's not a colon/space, followed by a colon. 
+                    // Match anything starting with a space that's not a colon/space, followed by a colon.
                     // Error code is optional in which case "error"/"warning" can be followed immediately by a colon.
                 + @"( \s*(?<CODE>[^: ]*))?\s*:"
                     // Whatever's left on this line, including colons.
@@ -280,7 +280,7 @@ namespace Microsoft.Build.Shared
         internal static Parts Parse(string message)
         {
             // An unusually long string causes pathologically slow Regex back-tracking.
-            // To avoid that, only scan the first 400 characters. That's enough for 
+            // To avoid that, only scan the first 400 characters. That's enough for
             // the longest possible prefix: MAX_PATH, plus a huge subcategory string, and an error location.
             // After the regex is done, we can append the overflow.
             string messageOverflow = String.Empty;
@@ -291,7 +291,7 @@ namespace Microsoft.Build.Shared
             }
 
             // If a tool has a large amount of output that isn't an error or warning (eg., "dir /s %hugetree%")
-            // the regex below is slow. It's faster to pre-scan for "warning" and "error" 
+            // the regex below is slow. It's faster to pre-scan for "warning" and "error"
             // and bail out if neither are present.
             if (message.IndexOf("warning", StringComparison.OrdinalIgnoreCase) == -1 &&
                 message.IndexOf("error", StringComparison.OrdinalIgnoreCase) == -1)
@@ -306,7 +306,7 @@ namespace Microsoft.Build.Shared
             //      Main.cs(17,20):Command line warning CS0168: The variable 'foo' is declared but never used
             //      -------------- ------------ ------- ------  ----------------------------------------------
             //      Origin         SubCategory  Cat.    Code    Text
-            // 
+            //
             // To accommodate absolute filenames in Origin, tolerate a colon in the second position
             // as long as its preceded by a letter.
             //
@@ -325,6 +325,10 @@ namespace Microsoft.Build.Shared
             if (!match.Success)
             {
                 // try again with the Clang/GCC matcher
+                // Example,
+                //       err.cpp:6:3: error: use of undeclared identifier 'force_an_error'
+                //       -----------  -----  ---------------------------------------------
+                //       Origin       Cat.   Text
                 match = s_originCategoryCodeTextExpression2.Value.Match(message);
                 if (!match.Success)
                 {
@@ -349,7 +353,17 @@ namespace Microsoft.Build.Shared
                 parsedMessage.column = ConvertToIntWithDefault(match.Groups["COLUMN"].Value.Trim());
                 parsedMessage.text = (match.Groups["TEXT"].Value + messageOverflow).Trim();
                 parsedMessage.origin = match.Groups["FILENAME"].Value.Trim();
-                parsedMessage.code = "G" + parsedMessage.text.Split(new char[] { '\'' }, StringSplitOptions.RemoveEmptyEntries)[0].GetHashCode().ToString("X8");
+
+                string[] explodedText = parsedMessage.text.Split(new char[] {'\''}, StringSplitOptions.RemoveEmptyEntries);
+                if (explodedText.Length > 0)
+                {
+                    parsedMessage.code = "G" + explodedText[0].GetHashCode().ToString("X8");
+                }
+                else
+                {
+                    parsedMessage.code = "G00000000";
+                }
+
                 return parsedMessage;
             }
 

--- a/src/Utilities.UnitTests/CanonicalError_Tests.cs
+++ b/src/Utilities.UnitTests/CanonicalError_Tests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void LinkWithFilename()
         {
-            // From Link.exe 
+            // From Link.exe
             // Note that this is impossible to distinguish from a tool error without
             // actually looking at the disk to see if the given file is there.
             ValidateFileNameError(@"foo.cpp : fatal error LNK1106: invalid file or disk full: cannot seek to 0x5361", @"foo.cpp", CanonicalError.Parts.Category.Error, "LNK1106", "invalid file or disk full: cannot seek to 0x5361");
@@ -199,7 +199,7 @@ namespace Microsoft.Build.UnitTests
                 "Main.cs", CanonicalError.Parts.numberNotSpecified, CanonicalError.Parts.numberNotSpecified, CanonicalError.Parts.numberNotSpecified, CanonicalError.Parts.numberNotSpecified,
                 CanonicalError.Parts.Category.Warning, "CS0168", "The variable 'foo' is declared but never used");
 
-            // This one actually falls under the (line-line) category. I'm not going to tweak the regex for this incorrect input just so we can 
+            // This one actually falls under the (line-line) category. I'm not going to tweak the regex for this incorrect input just so we can
             // pretend -3 == 0, and just leaving it here for completeness
             ValidateFileNameMultiLineColumnError("Main.cs(-3):Command line warning CS0168: The variable 'foo' is declared but never used",
                 "Main.cs", CanonicalError.Parts.numberNotSpecified, CanonicalError.Parts.numberNotSpecified, 3, CanonicalError.Parts.numberNotSpecified,
@@ -231,7 +231,7 @@ namespace Microsoft.Build.UnitTests
                 "Main.cs", 1, CanonicalError.Parts.numberNotSpecified, CanonicalError.Parts.numberNotSpecified, CanonicalError.Parts.numberNotSpecified,
                 CanonicalError.Parts.Category.Warning, "CS0168", "The variable 'foo' is declared but never used");
 
-            // Similarly to the previous odd case, this really falls under (line,col-col). Included for completeness, even if results are 
+            // Similarly to the previous odd case, this really falls under (line,col-col). Included for completeness, even if results are
             // not intuitive
             ValidateFileNameMultiLineColumnError("Main.cs(,-2):Command line warning CS0168: The variable 'foo' is declared but never used",
                 "Main.cs", CanonicalError.Parts.numberNotSpecified, CanonicalError.Parts.numberNotSpecified, CanonicalError.Parts.numberNotSpecified, 2,
@@ -302,7 +302,39 @@ namespace Microsoft.Build.UnitTests
                 CanonicalError.Parts.Category.Warning, "CS0168", "The variable 'foo' is declared but never used");
         }
 
-        #region Support functions.        
+        [Fact]
+        public void ClangGccError()
+        {
+            CanonicalError.Parts errorParts = CanonicalError.Parse(
+                "err.cpp:6:3: error: use of undeclared identifier 'force_an_error'");
+
+            Assert.NotNull(errorParts);
+            AssertEqual(errorParts.origin, "err.cpp");
+            AssertEqual(errorParts.category, CanonicalError.Parts.Category.Error);
+            Assert.StartsWith("G", errorParts.code);
+            AssertEqual(errorParts.code.Length, 9);
+            AssertEqual(errorParts.text, "use of undeclared identifier 'force_an_error'");
+            AssertEqual(errorParts.line, 6);
+            AssertEqual(errorParts.column, 3);
+            AssertEqual(errorParts.endLine, CanonicalError.Parts.numberNotSpecified);
+            AssertEqual(errorParts.endColumn, CanonicalError.Parts.numberNotSpecified);
+        }
+
+        [Fact]
+        public void ClangGccErrorWithEmptyText()
+        {
+            ValidateFileNameMultiLineColumnError(
+                "tests\\Tests\\Syntax.hs:1:1: error:",
+                "tests\\Tests\\Syntax.hs",
+                1, 1,
+                CanonicalError.Parts.numberNotSpecified,
+                CanonicalError.Parts.numberNotSpecified,
+                CanonicalError.Parts.Category.Error,
+                "G00000000",
+                string.Empty);
+        }
+
+        #region Support functions.
         private static void AssertEqual(string str1, string str2)
         {
             if (str1 != str2)
@@ -390,8 +422,3 @@ namespace Microsoft.Build.UnitTests
     }
     #endregion
 }
-
-
-
-
-


### PR DESCRIPTION
If a Clang/GCC-style error didn't have any text, an
IndexOutOfRangeException exception was thrown. This guards against that.
Unit tests for a normal Clang/GCC error and a degenerate one have been
added.

Fixes https://github.com/Microsoft/msbuild/issues/1796