### PR TITLE
Log task inputs when using binary logger.

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2632,7 +2632,7 @@ namespace Microsoft.Build.CommandLine
 
             ProcessFileLoggers(groupedFileLoggerParameters, distributedLoggerRecords, verbosity, cpuCount, loggers);
 
-            ProcessBinaryLogger(binaryLoggerParameters, loggers);
+            ProcessBinaryLogger(binaryLoggerParameters, loggers, ref verbosity);
 
             if (verbosity == LoggerVerbosity.Diagnostic)
             {
@@ -2719,7 +2719,7 @@ namespace Microsoft.Build.CommandLine
             }
         }
 
-        private static void ProcessBinaryLogger(string[] binaryLoggerParameters, ArrayList loggers)
+        private static void ProcessBinaryLogger(string[] binaryLoggerParameters, ArrayList loggers, ref LoggerVerbosity verbosity)
         {
             if (binaryLoggerParameters == null || binaryLoggerParameters.Length == 0)
             {
@@ -2730,6 +2730,11 @@ namespace Microsoft.Build.CommandLine
 
             BinaryLogger logger = new BinaryLogger();
             logger.Parameters = outputLogFilePath;
+
+            // If we have a binary logger, force verbosity to diagnostic.
+            // The only place where verbosity is used downstream is to determine whether to log task inputs.
+            // Since we always want task inputs for a binary logger, set it to diagnostic.
+            verbosity = LoggerVerbosity.Diagnostic;
 
             loggers.Add(logger);
         }


### PR DESCRIPTION
I've discovered that task inputs are not logged when using binary logger. This is because the logic here only logs task inputs if verbosity is Diagnostic or the env. variable MSBUILDLOGTASKINPUTS is set to 1.

http://source.dot.net/#MSBuild/XMake.cs,948
http://source.dot.net/#Microsoft.Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs,168

It is safe to set the "global" verbosity to diagnostic where I'm setting it, because from eyeballing the data flow from that point the only place it's consumed at is the check for log task inputs.