### PR TITLE
Fix a unit-test.

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -30,10 +30,11 @@ namespace Microsoft.Build.UnitTests
         {
             var originalTargetOutputLogging = Environment.GetEnvironmentVariable(MSBUILDTARGETOUTPUTLOGGING);
 
+            var logFilePath = $"BinaryLoggerTest{Environment.TickCount}.binlog";
+
             try
             {
                 var binaryLogger = new BinaryLogger();
-                var logFilePath = "BinaryLoggerTest.binlog";
                 binaryLogger.Parameters = logFilePath;
 
                 var mockLogger1 = new MockLogger();
@@ -49,15 +50,15 @@ namespace Microsoft.Build.UnitTests
                 // read the binary log and replay into mockLogger2
                 binaryLogReader.Replay(logFilePath);
 
+                Assert.Equal(mockLogger1.FullLog, mockLogger2.FullLog);
+            }
+            finally
+            {
                 if (File.Exists(logFilePath))
                 {
                     File.Delete(logFilePath);
                 }
 
-                Assert.Equal(mockLogger1.FullLog, mockLogger2.FullLog);
-            }
-            finally
-            {
                 Environment.SetEnvironmentVariable(MSBUILDTARGETOUTPUTLOGGING, originalTargetOutputLogging);
             }
         }


### PR DESCRIPTION
A theory I have is that the file name needs to be unique to avoid two different processes accessing the same file name at the same time.