### PR TITLE
Don't set console color from FileLogger

### DIFF
--- a/src/Build/Logging/ConsoleLogger.cs
+++ b/src/Build/Logging/ConsoleLogger.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Build.Logging
             ColorResetter colorReset
         )
         {
-            ErrorUtilities.VerifyThrowArgumentNull(write, "write");
             _verbosity = verbosity;
             _write = write;
             _colorSet = colorSet;

--- a/src/Build/Logging/FileLogger.cs
+++ b/src/Build/Logging/FileLogger.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Text;
 
+using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -28,7 +29,12 @@ namespace Microsoft.Build.Logging
         /// <summary>
         /// Default constructor.
         /// </summary>
-        public FileLogger() : base(LoggerVerbosity.Normal)
+        public FileLogger()
+            : base(
+                LoggerVerbosity.Normal,
+                write: null, // Overwritten below
+                colorSet: BaseConsoleLogger.DontSetColor,
+                colorReset: BaseConsoleLogger.DontResetColor)
         {
             this.WriteHandler = new WriteHandler(Write);
         }


### PR DESCRIPTION
Because FileLogger used the default value of the SetColor and ResetColor
delegates, it was quietly changing and resetting console color for every
log message that was considered by the FileLogger. On Windows, this was
unnecessary but not too noticeable. On Unix systems, though, console
colors are set by emitting an escape code to the output stream, so this
became observable.

Explicitly passing the Dont* mechanisms to prevent the unnecessary work
from happening. I removed the null check for the `write` delegate from
ConsoleLogger's constructor because it seemed cleaner to set the
delegate to `null` from FileLogger than to explicitly specify the
default `Console.Out.Write`.

Fixes #1792.