### PR TITLE
Move an exception one level up.

### DIFF
--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -467,10 +467,6 @@
     filename is not part of the message because it is provided separately to loggers.
     LOCALIZATION: {0} is a localized message from the CLR/FX explaining why the project is invalid.</comment>
   </data>
-  <data name="InvalidLogFileFormat" UESanitized="false" Visibility="Public">
-    <value>MSB4233: There was an exception while reading the log file: {0}</value>
-    <comment>{StrBegin="MSB4233: "}This is shown when the Binary Logger can't read the log file.</comment>
-  </data>
   <data name="InvalidPropertyNameInToolset" UESanitized="false" Visibility="Private_OM">
     <value>MSB4147: The property "{0}" at "{1}" is invalid. {2}</value>
     <comment>{StrBegin="MSB4147: "}</comment>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3195,7 +3195,8 @@ namespace Microsoft.Build.CommandLine
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                var message = ResourceUtilities.FormatResourceString("InvalidLogFileFormat", ex.Message);
+                Console.WriteLine(message);
             }
 
             foreach (var logger in loggers)

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -89,6 +89,10 @@
     <value>MSB4103: "{0}" is not a valid logger verbosity level.</value>
     <comment>{StrBegin="MSB4103: "}</comment>
   </data>
+  <data name="InvalidLogFileFormat" UESanitized="false" Visibility="Public">
+    <value>MSB4233: There was an exception while reading the log file: {0}</value>
+    <comment>{StrBegin="MSB4233: "}This is shown when the Binary Logger can't read the log file.</comment>
+  </data>
   <data name="MissingProject" UESanitized="false" Visibility="Private_OM">
     <value>MSBuild is expecting a valid "{0}" object.</value>
   </data>


### PR DESCRIPTION
To see more details from a unit-test exception let's not catch the exception inside the Replay() method but instead catch it at the caller site.

To still give a meaningful user message we need to share the resource for "InvalidLogFileFormat".