### PR TITLE
PVS-Studio: fixed vulnerabilities

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -626,7 +626,7 @@ namespace Microsoft.Build.CommandLine
 
                     if (!String.IsNullOrEmpty(timerOutputFilename))
                     {
-                        AppendOutputFile(timerOutputFilename, elapsedTime.Milliseconds);
+                        AppendOutputFile(timerOutputFilename, (long)elapsedTime.TotalMilliseconds);
                     }
                 }
                 else

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -612,7 +612,7 @@ namespace Microsoft.Build.Internal
                     {
                         string message = String.Format(CultureInfo.CurrentCulture, format, args);
                         long now = DateTime.UtcNow.Ticks;
-                        float millisecondsSinceLastLog = (float)((now - s_lastLoggedTicks) / 10000L);
+                        float millisecondsSinceLastLog = (float)(now - s_lastLoggedTicks) / 10000L;
                         s_lastLoggedTicks = now;
                         file.WriteLine("{0} (TID {1}) {2,15} +{3,10}ms: {4}", Thread.CurrentThread.Name, Thread.CurrentThread.ManagedThreadId, now, millisecondsSinceLastLog, message);
                     }

--- a/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -226,16 +226,17 @@ namespace Microsoft.Build.Tasks
                     }
 
                     var name = assemblyIdentity.Attribute("name");
-                    var nameValue = name.Value;
                     var publicKeyToken = assemblyIdentity.Attribute("publicKeyToken");
-                    var publicKeyTokenValue = publicKeyToken.Value;
-                    var culture = assemblyIdentity.Attribute("culture");
-                    var cultureValue = culture == null ? String.Empty : culture.Value;
 
                     if (name == null || publicKeyToken == null)
                     {
                         continue;
                     }
+
+                    var nameValue = name.Value;
+                    var publicKeyTokenValue = publicKeyToken.Value;
+                    var culture = assemblyIdentity.Attribute("culture");
+                    var cultureValue = culture == null ? String.Empty : culture.Value;
 
                     var oldVersionAttribute = bindingRedirect.Attribute("oldVersion");
                     var newVersionAttribute = bindingRedirect.Attribute("newVersion");


### PR DESCRIPTION
[V3041](https://www.viva64.com/en/w/V3041/) The expression was implicitly cast from 'long' type to 'float' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;. Microsoft.Build CommunicationsUtilities.cs 615

[V3118](https://www.viva64.com/en/w/V3118/) Milliseconds component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalMilliseconds' value was intended instead. MSBuild XMake.cs 629

[V3095](https://www.viva64.com/en/w/V3095/) The 'name' object was used before it was verified against null. Check lines: 229, 235. Microsoft.Build.Tasks GenerateBindingRedirects.cs 229
[V3095](https://www.viva64.com/en/w/V3095/) The 'publicKeyToken' object was used before it was verified against null. Check lines: 231, 235. Microsoft.Build.Tasks GenerateBindingRedirects.cs 231

V3095 = CWE-476 (NULL Pointer Dereference)