### PR TITLE
Fix P2P build failure in MicroBuild

### DIFF
--- a/setup/Microsoft.Build.vsmanproj
+++ b/setup/Microsoft.Build.vsmanproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="Microsoft.Build.swixproj" />
+    <ProjectReference Include="Microsoft.Build.swixproj" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves a build failure in the vsmanproj project. The P2P swixproj project does not
import common targets and does not have GetTargetFrameworkProperties target.