### PR TITLE
Update EditBin target to use VsInstallRoot property

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -152,10 +152,18 @@
            produce the right outputs. Continuing on error to allow
            test results even on a misconfigured build machine. -->
       <EditBinContinueOnError Condition="'$(TF_BUILD)' == 'True' or '$(JENKINS_URL)' != ''">ErrorAndContinue</EditBinContinueOnError>
+
+      <!--
+        * VSINSTALLDIR is set by the Developer Command Prompt. When building from MicroBuild, this isn't set.
+        * VsInstallRoot is discovered by MSBuild, but in our bootstrapped build it's wrong (VS isn't installed
+          to our 'bin' folder). When building from MicroBuild (or any installed VS), this value is correct.
+      -->
+      <EditBinCommand Condition="'$(VSINSTALLDIR)' != ''">call &quot;$(VSINSTALLDIR)\Common7\Tools\VsDevCmd.bat&quot; &amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)</EditBinCommand>
+      <EditBinCommand Condition="'$(VsInstallRoot)' != '' and '$(EditBinCommand)' != ''">call &quot;$(VsInstallRoot)\Common7\Tools\VsDevCmd.bat&quot; &amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)</EditBinCommand>
     </PropertyGroup>
 
     <Exec Condition="'$(EditBinFlags)'!=''"
-          Command="call &quot;$(VS150COMNTOOLS)..\Tools\VsDevCmd.bat&quot; &amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)"
+          Command="$(EditBinCommand)"
           ContinueOnError="$(EditBinContinueOnError)" />
 
   </Target>


### PR DESCRIPTION
VS150COMNTOOLS is not defined in our MicroBuild environment.