### PR TITLE
Fix DescendingByElapsedTimeComparer

### DIFF
--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -978,7 +978,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     }
                     else
                     {
-                        // both reentrant; sort properly to avoid throwing
+                        // both reentrant; sort stably by another field to avoid throwing
                         return string.Compare(p1.ScopeName, p2.ScopeName, StringComparison.Ordinal);
                     }
                 }

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -966,15 +966,20 @@ namespace Microsoft.Build.BackEnd.Logging
                     {
                         return 0;
                     }
-                    else if (p1.reenteredScope)
+                    else if (p1.reenteredScope && !p2.reenteredScope)
                     {
                         // p1 was reentrant; sort first
                         return -1;
                     }
-                    else
+                    else if (!p1.reenteredScope && p2.reenteredScope)
                     {
                         // p2 was reentrant; sort first
                         return 1;
+                    }
+                    else
+                    {
+                        // both reentrant; sort properly to avoid throwing
+                        return string.Compare(p1.ScopeName, p2.ScopeName, StringComparison.Ordinal);
                     }
                 }
             }


### PR DESCRIPTION
When replaying a binary log with multiproc I've discovered a crash in the DescendingByElapsedTimeComparer. In the case when both p1 and p2 were reentrant we were returning -1 always even if they were different objects.

This resulted in a crash:
```
There was an exception while reading the log file: Unable to sort because the IComparer.Compare() method returns inconsistent results. Either a value does not compare equal to itself, or one value repeatedly compared to another value yields different results. IComparer: 'Microsoft.Build.BackEnd.Logging.BaseConsoleLogger+PerformanceCounter+DescendingByElapsedTime'.
```

In the case when both performance counters are reentrant let's sort them by name such that it's stable.

The bug was always reproducible and after the fix I've never seen it again. The user impact if we don't fix is that they won't be able to replay logs with /m specified (because when printing perf summary all reentrant times are 00:00:00).