### PR TITLE
Change the log file name in unit-test to save it on the CI server as …

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -33,7 +33,10 @@ namespace Microsoft.Build.UnitTests
             try
             {
                 var binaryLogger = new BinaryLogger();
-                var logFilePath = "BinaryLoggerTest.binlog";
+
+                // with this file name, the file will be archived as as build artifact so we can inspect it later
+                // this is needed to investigate an intermittent failure of this test on Ubuntu 14
+                var logFilePath = "Microsoft.Build.Engine.UnitTests.dll_TestBinaryLoggerRoundtrip.binlog";
                 binaryLogger.Parameters = logFilePath;
 
                 var mockLogger1 = new MockLogger();


### PR DESCRIPTION
…an artifact in case the unit-test fails. We need this to investigate an intermittent failure of this test.