### PR TITLE
Fix issue where build succeeds even though a warning was treated as a…

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1841,7 +1841,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void SetOverallResultIfWarningsAsErrors(BuildResult result)
         {
-            if (result.OverallResult == BuildResultCode.Success)
+            if (result != null && result.OverallResult == BuildResultCode.Success)
             {
                 ILoggingService loggingService = ((IBuildComponentHost)this).LoggingService;
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1589,8 +1589,6 @@ namespace Microsoft.Build.Execution
                 {
                     BuildSubmission submission = _buildSubmissions[result.SubmissionId];
 
-                    SetOverallResultIfWarningsAsErrors(result);
-
                     submission.CompleteResults(result);
 
                     // If the request failed because we caught an exception from the loggers, we can assume we will receive no more logging messages for
@@ -1621,6 +1619,8 @@ namespace Microsoft.Build.Execution
                 // If the submission has completed or never started, remove it.
                 if (submission.IsCompleted || submission.BuildRequest == null)
                 {
+                    SetOverallResultIfWarningsAsErrors(submission.BuildResult);
+
                     _buildSubmissions.Remove(submission.SubmissionId);
                 }
 
@@ -1848,6 +1848,8 @@ namespace Microsoft.Build.Execution
                 if (loggingService.HasBuildSubmissionLoggedErrors(result.SubmissionId))
                 {
                     result.SetOverallResult(overallResult: false);
+
+                    _overallBuildSuccess = false;
                 }
             }
         }


### PR DESCRIPTION
…n error on a multi-proc build

This only repro'd on an optimized, ngen'd build out of VS which is why we didn't catch it.  There was a timing issue where the overall build result was set too early before logging was complete and errors were still in the queue.  Moving around the decision logic has fixed it.  I tested this by doing a full build of Visual Studio and installing it on a test machine.

Closes #1791 