### PR TITLE
Ask ProjectReferences if they cross-target

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
@@ -104,6 +104,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <!--
+    ============================================================
+                                         IsCrossTargetingProject
+
+    Indicate that this project cross-targets, so before building
+    it, a referring project must call GetTargetFrameworkProperties
+    to get the matching TargetFramework to specify.
+  -->
+  <Target Name="IsCrossTargetingProject" Returns="true" />
+
+  <!--
     This will import NuGet restore targets, which is a special case separate from the package -> project extension 
     mechanism below. For obvious reasons,  we need restore to work before any package assets are available.
 

--- a/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/XMakeTasks/Microsoft.Common.CrossTargeting.targets
@@ -104,16 +104,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <!--
-    ============================================================
-                                         IsCrossTargetingProject
-
-    Indicate that this project cross-targets, so before building
-    it, a referring project must call GetTargetFrameworkProperties
-    to get the matching TargetFramework to specify.
-  -->
-  <Target Name="IsCrossTargetingProject" Returns="true" />
-
-  <!--
     This will import NuGet restore targets, which is a special case separate from the package -> project extension 
     mechanism below. For obvious reasons,  we need restore to work before any package assets are available.
 

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1542,14 +1542,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);$(PropertiesToRemoveWhenQueryingForDesiredProperties)"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
 
-      <Output TaskParameter="TargetOutputs" ItemName="_MSBuildProjectReferenceCrossTargetingResults" />
+      <Output TaskParameter="TargetOutputs" ItemName="_MSBuildProjectReferenceWithDesiredPropertiesResults" />
     </MSBuild>
 
     <ItemGroup>
-      <_MSBuildProjectReferenceCrossTargeting Include="@(_MSBuildProjectReferenceCrossTargetingResults->'%(OriginalItemSpec)')"
-                                              Condition="'%(_MSBuildProjectReferenceCrossTargetingResults.Identity)' == 'true'" />
+      <_MSBuildProjectReferenceWithDesiredProperties Include="@(_MSBuildProjectReferenceWithDesiredPropertiesResults->'%(OriginalItemSpec)')"
+                                              Condition="'%(_MSBuildProjectReferenceWithDesiredPropertiesResults.Identity)' == 'true'" />
       <_MSBuildProjectReferenceNoCrossTargeting Include="@(_MSBuildProjectReferenceExistent)"
-                                                Exclude="@(_MSBuildProjectReferenceCrossTargeting)" />
+                                                Exclude="@(_MSBuildProjectReferenceWithDesiredProperties)" />
 
     </ItemGroup>
   </Target>
@@ -1581,13 +1581,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
 
     <MSBuild
-        Projects="@(_MSBuildProjectReferenceCrossTargeting)"
+        Projects="@(_MSBuildProjectReferenceWithDesiredProperties)"
         Targets="GetReferenceProperties"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceCrossTargeting.SetConfiguration); %(_MSBuildProjectReferenceCrossTargeting.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
+        Properties="%(_MSBuildProjectReferenceWithDesiredProperties.SetConfiguration); %(_MSBuildProjectReferenceWithDesiredProperties.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceCrossTargeting.GlobalPropertiesToRemove);$(PropertiesToRemoveWhenQueryingForDesiredProperties)"
-        Condition="'%(_MSBuildProjectReferenceCrossTargeting.SkipGetTargetFrameworkProperties)' != 'true'">
+        RemoveProperties="%(_MSBuildProjectReferenceWithDesiredProperties.GlobalPropertiesToRemove);$(PropertiesToRemoveWhenQueryingForDesiredProperties)"
+        Condition="'%(_MSBuildProjectReferenceWithDesiredProperties.SkipGetTargetFrameworkProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1499,33 +1499,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ====================================================================================
-                                        _GetProjectReferenceTargetFrameworkProperties
+                                        _GetProjectReferencesThatCrossTarget
 
-    Builds the GetTargetFrameworkProperties target of all existent project references,
-    passing $(TargetFrameworkMoniker) as $(ReferringTargetFramework) and sets the
-    SetTargetFramework metadata of the project reference to the value that is returned.
+    Builds the IsCrossTargetingProject target of all existent project references,
+    removing any TargetFramework and RuntimeIdentifier properties that are set as
+    global properties in this project.
 
-    This allows a cross-targeting project to select how it should be configured to
-    build against the most appropriate target for the referring target framework.
+    This allows a cross-targeting project to indicate that it should be asked
+    for a compatible TargetFramework before building.
 
     ======================================================================================
   -->
-  <Target Name="_GetProjectReferenceTargetFrameworkProperties"
-          Outputs="%(_MSBuildProjectReferenceExistent.Identity)">
-    <!--
-      Honor SkipGetTargetFrameworkProperties=true metadata on project references
-      to mean that the project reference is known not to target multiple frameworks
-      and the mechanism here for selecting the best one can be skipped as an optimization.
-
-      We give this treatment to .vcxproj by default since no .vcxproj can target more
-      than one framework.
-   -->
-   <ItemGroup>
-      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and '%(Extension)' == '.vcxproj'">
-        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-      </_MSBuildProjectReferenceExistent>
-   </ItemGroup>
-
+  <Target Name="_GetProjectReferencesThatCrossTarget">
     <!--
        Allow project references to specify which target framework properties to set and their values
        without consulting the referenced project. This has two use cases:
@@ -1544,6 +1529,47 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <!--
+      Honor SkipGetTargetFrameworkProperties=true metadata on project references
+      to mean that the project reference is known not to target multiple frameworks
+      and the mechanism here for selecting the best one can be skipped as an optimization.
+    -->
+    <MSBuild
+        Projects="@(_MSBuildProjectReferenceExistent)"
+        Targets="IsCrossTargetingProject"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        ContinueOnError="!$(BuildingProject)"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
+        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
+
+      <Output TaskParameter="TargetOutputs" ItemName="_MSBuildProjectReferenceCrossTargetingResults" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_MSBuildProjectReferenceCrossTargeting Include="@(_MSBuildProjectReferenceCrossTargetingResults->'%(OriginalItemSpec)')"
+                                              Condition="'%(_MSBuildProjectReferenceCrossTargetingResults.Identity)' == 'true'" />
+      <_MSBuildProjectReferenceNoCrossTargeting Include="@(_MSBuildProjectReferenceExistent)"
+                                                Exclude="@(_MSBuildProjectReferenceCrossTargeting)" />
+
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ====================================================================================
+                                        _GetProjectReferenceTargetFrameworkProperties
+
+    Builds the GetTargetFrameworkProperties target of all existent project references,
+    passing $(TargetFrameworkMoniker) as $(ReferringTargetFramework) and sets the
+    SetTargetFramework metadata of the project reference to the value that is returned.
+
+    This allows a cross-targeting project to select how it should be configured to
+    build against the most appropriate target for the referring target framework.
+
+    ======================================================================================
+  -->
+  <Target Name="_GetProjectReferenceTargetFrameworkProperties"
+          DependsOnTargets="_GetProjectReferencesThatCrossTarget">
+    <!--
       Select the moniker to send to each project reference  if not already set. NugetTargetMoniker (NTM) is preferred by default over 
       TargetFrameworkMoniker (TFM) because it is required to disambiguate the UWP case where TFM is fixed at .NETCore,Version=v5.0 and 
       has floating NTM=UAP,Version=vX.Y.Z. However, in other cases (classic PCLs), NTM contains multiple values and that will cause the MSBuild
@@ -1555,7 +1581,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
 
     <MSBuild
-        Projects="%(_MSBuildProjectReferenceExistent.Identity)"
+        Projects="@(_MSBuildProjectReferenceCrossTargeting)"
         Targets="GetTargetFrameworkProperties"
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
@@ -1563,30 +1589,32 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
 
-      <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkProperties" />
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>
 
     <ItemGroup>
-      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.Identity)' == '%(Identity)' and '$(_ProjectReferenceTargetFrameworkProperties)' != ''">
-        <SetTargetFramework>$(_ProjectReferenceTargetFrameworkProperties)</SetTargetFramework>
+      <!-- Build an item that has Identity matching _MSBuildProjectReferenceExistent and metadata for properties to set. -->
+      <_ProjectReferencesWithTargetFrameworkProperties Include="@(_ProjectReferenceTargetFrameworkProperties->'%(OriginalItemSpec)')" />
+      <_ProjectReferencesWithTargetFrameworkProperties Include="@(_MSBuildProjectReferenceNoCrossTargeting)">
+        <HasSingleTargetFramework>true</HasSingleTargetFramework>
+        <IsRidAgnostic>true</IsRidAgnostic>
+      </_ProjectReferencesWithTargetFrameworkProperties>
 
-        <UndefineProperties Condition="$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectHasSingleTargetFramework=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);TargetFramework;ProjectHasSingleTargetFramework</UndefineProperties>
-        <!-- Unconditionally remove the property that was set as a marker to indicate that for this call we should remove TargetFramework -->
-        <UndefineProperties Condition="!$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectHasSingleTargetFramework=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);ProjectHasSingleTargetFramework</UndefineProperties>
+      <!-- Set the project's returned TargetFramework -->
+      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' != 'true'">
+        <SetTargetFramework>@(_ProjectReferencesWithTargetFrameworkProperties->'%(DesiredTargetFrameworkProperties)')</SetTargetFramework>
+      </_MSBuildProjectReferenceExistent>
+
+      <!-- If the project has only one TF, don't specify it. It will go directly to the inner build anyway and we don't want to redundantly specify a global property, which can cause a race. -->
+      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' == 'true'">
+        <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');TargetFramework</UndefineProperties>
+      </_MSBuildProjectReferenceExistent>
+
+      <!-- If the project has only one RID, assume it's compatible with the current project and don't pass this one along. -->
+      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(IsRidAgnostic)')' == 'true'">
+        <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');RuntimeIdentifier</UndefineProperties>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
-
-    <ItemGroup>
-      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.Identity)' == '%(Identity)' and '$(_ProjectReferenceTargetFrameworkProperties)' != ''">
-        <UndefineProperties Condition="$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectIsRidAgnostic=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);RuntimeIdentifier;ProjectIsRidAgnostic</UndefineProperties>
-        <!-- Unconditionally remove the property that was set as a marker to indicate that for this call we should remove RuntimeIdentifier -->
-        <UndefineProperties Condition="!$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectIsRidAgnostic=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);ProjectIsRidAgnostic</UndefineProperties>
-      </_MSBuildProjectReferenceExistent>
-    </ItemGroup>
-
-    <PropertyGroup>
-      <_ProjectReferenceTargetFrameworkProperties />
-    </PropertyGroup>
   </Target>
 
   <!--
@@ -1602,6 +1630,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     in as $(ReferringTargetFramework)
   -->
   <Target Name="GetTargetFrameworkProperties" />
+
+  <!--
+    ============================================================
+                                         IsCrossTargetingProject
+
+    Overrridden by cross-targeting projects to return "true" if
+    the project should have its GetTargetFrameworkProperties
+    target called with a ReferringTargetFramework. If "false",
+    the single output of the project is used.
+  -->
+  <Target Name="IsCrossTargetingProject" Returns="false" />
 
   <!--
     ============================================================

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1584,10 +1584,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceCrossTargeting)"
         Targets="GetReferenceProperties"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
+        Properties="%(_MSBuildProjectReferenceCrossTargeting.SetConfiguration); %(_MSBuildProjectReferenceCrossTargeting.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
-        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
+        RemoveProperties="%(_MSBuildProjectReferenceCrossTargeting.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
+        Condition="'%(_MSBuildProjectReferenceCrossTargeting.SkipGetTargetFrameworkProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1539,7 +1539,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);$(PropertiesToRemoveWhenQueryingForDesiredProperties)"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_MSBuildProjectReferenceCrossTargetingResults" />
@@ -1586,7 +1586,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceCrossTargeting.SetConfiguration); %(_MSBuildProjectReferenceCrossTargeting.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
-        RemoveProperties="%(_MSBuildProjectReferenceCrossTargeting.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
+        RemoveProperties="%(_MSBuildProjectReferenceCrossTargeting.GlobalPropertiesToRemove);$(PropertiesToRemoveWhenQueryingForDesiredProperties)"
         Condition="'%(_MSBuildProjectReferenceCrossTargeting.SkipGetTargetFrameworkProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkProperties" />

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1499,9 +1499,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ====================================================================================
-                                        _GetProjectReferencesThatCrossTarget
+                                        _GetProjectReferencesThatNeedProperties
 
-    Builds the IsCrossTargetingProject target of all existent project references,
+    Builds the ShouldQueryForProperties target of all existent project references,
     removing any TargetFramework and RuntimeIdentifier properties that are set as
     global properties in this project.
 
@@ -1510,7 +1510,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     ======================================================================================
   -->
-  <Target Name="_GetProjectReferencesThatCrossTarget">
+  <Target Name="_GetProjectReferencesThatNeedProperties">
     <!--
        Allow project references to specify which target framework properties to set and their values
        without consulting the referenced project. This has two use cases:
@@ -1520,27 +1520,27 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           there is also a .NETFramework implementation.
 
        2. As an escape hatch for cases where the compatibility check performed by 
-          GetTargetFrameworkProperties is faulty.
+          GetReferenceProperties is faulty.
     -->
     <ItemGroup>
       <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SetTargetFramework)' != ''">
-        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+        <SkipGetReferenceProperties>true</SkipGetReferenceProperties>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
 
     <!--
-      Honor SkipGetTargetFrameworkProperties=true metadata on project references
+      Honor SkipGetReferenceProperties=true metadata on project references
       to mean that the project reference is known not to target multiple frameworks
       and the mechanism here for selecting the best one can be skipped as an optimization.
     -->
     <MSBuild
         Projects="@(_MSBuildProjectReferenceExistent)"
-        Targets="IsCrossTargetingProject"
+        Targets="ShouldQueryForProperties"
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
-        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
+        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetReferenceProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_MSBuildProjectReferenceCrossTargetingResults" />
     </MSBuild>
@@ -1558,7 +1558,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ====================================================================================
                                         _GetProjectReferenceTargetFrameworkProperties
 
-    Builds the GetTargetFrameworkProperties target of all existent project references,
+    Builds the GetReferenceProperties target of all existent project references,
     passing $(TargetFrameworkMoniker) as $(ReferringTargetFramework) and sets the
     SetTargetFramework metadata of the project reference to the value that is returned.
 
@@ -1568,7 +1568,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ======================================================================================
   -->
   <Target Name="_GetProjectReferenceTargetFrameworkProperties"
-          DependsOnTargets="_GetProjectReferencesThatCrossTarget">
+          DependsOnTargets="_GetProjectReferencesThatNeedProperties">
     <!--
       Select the moniker to send to each project reference  if not already set. NugetTargetMoniker (NTM) is preferred by default over 
       TargetFrameworkMoniker (TFM) because it is required to disambiguate the UWP case where TFM is fixed at .NETCore,Version=v5.0 and 
@@ -1582,12 +1582,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <MSBuild
         Projects="@(_MSBuildProjectReferenceCrossTargeting)"
-        Targets="GetTargetFrameworkProperties"
+        Targets="GetReferenceProperties"
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
-        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
+        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetReferenceProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>
@@ -1619,7 +1619,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
-                                    GetTargetFrameworkProperties
+                                    GetReferenceProperties
 
     Overrridden by cross-targeting projects to return the set of
     properties (in the form "key1=value1;...keyN=valueN") needed
@@ -1629,18 +1629,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     The referring project's $(TargetFrameworkMoniker) is passed 
     in as $(ReferringTargetFramework)
   -->
-  <Target Name="GetTargetFrameworkProperties" />
+  <Target Name="GetReferenceProperties" />
 
   <!--
     ============================================================
-                                         IsCrossTargetingProject
+                                        ShouldQueryForProperties
 
     Overrridden by cross-targeting projects to return "true" if
-    the project should have its GetTargetFrameworkProperties
+    the project should have its GetReferenceProperties
     target called with a ReferringTargetFramework. If "false",
     the single output of the project is used.
   -->
-  <Target Name="IsCrossTargetingProject" Returns="false" />
+  <Target Name="ShouldQueryForProperties" Returns="false" />
 
   <!--
     ============================================================

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1546,11 +1546,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </MSBuild>
 
     <ItemGroup>
-      <_MSBuildProjectReferenceWithDesiredProperties Include="@(_MSBuildProjectReferenceWithDesiredPropertiesResults->'%(OriginalItemSpec)')"
-                                              Condition="'%(_MSBuildProjectReferenceWithDesiredPropertiesResults.Identity)' == 'true'" />
-      <_MSBuildProjectReferenceNoCrossTargeting Include="@(_MSBuildProjectReferenceExistent)"
-                                                Exclude="@(_MSBuildProjectReferenceWithDesiredProperties)" />
+      <!-- Transform the list so that its Identity correlates with that of _MSBuildProjectReferenceExistent. -->
+      <_MSBuildProjectReferenceWithDesiredProperties Include="@(_MSBuildProjectReferenceWithDesiredPropertiesResults->'%(OriginalItemSpec)')" />
 
+      <!-- Update refs to remove any properties that the reference knows (without the referring TF) it doesn't want. -->
+      <_MSBuildProjectReferenceExistent Condition="'@(_MSBuildProjectReferenceWithDesiredProperties)' == '%(Identity)' and '@(_MSBuildProjectReferenceWithDesiredProperties->'%(QueryForProperties)')' == 'false'">
+        <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');@(_MSBuildProjectReferenceWithDesiredProperties->'%(UndefineProperties)')</UndefineProperties>
+      </_MSBuildProjectReferenceExistent>
     </ItemGroup>
   </Target>
 
@@ -1587,7 +1589,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Properties="%(_MSBuildProjectReferenceWithDesiredProperties.SetConfiguration); %(_MSBuildProjectReferenceWithDesiredProperties.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceWithDesiredProperties.GlobalPropertiesToRemove);$(PropertiesToRemoveWhenQueryingForDesiredProperties)"
-        Condition="'%(_MSBuildProjectReferenceWithDesiredProperties.SkipGetTargetFrameworkProperties)' != 'true'">
+        Condition="'%(_MSBuildProjectReferenceWithDesiredProperties.SkipGetTargetFrameworkProperties)' != 'true' and '%(_MSBuildProjectReferenceWithDesiredProperties.QueryForProperties)' == 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>
@@ -1597,12 +1599,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_ProjectReferencesWithTargetFrameworkProperties Include="@(_ProjectReferenceTargetFrameworkProperties->'%(OriginalItemSpec)')" />
 
       <!-- Set the project's returned TargetFramework -->
-      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' != 'true'">
+      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(SetDesiredProperties)')' != ''">
         <SetDesiredProperties>@(_ProjectReferencesWithTargetFrameworkProperties->'%(SetDesiredProperties)')</SetDesiredProperties>
       </_MSBuildProjectReferenceExistent>
 
       <!-- Remove any properties that the reference didn't want. -->
-      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' == 'true'">
+      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(UndefineProperties)')' != ''">
         <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');@(_ProjectReferencesWithTargetFrameworkProperties->'%(UndefineProperties)')</UndefineProperties>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
@@ -1613,12 +1615,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                                     GetDesiredProperties
 
     Overrridden by cross-targeting projects to return the set of
-    properties (in the form "key1=value1;...keyN=valueN") needed
-    to build it with the best target for the referring project's
-    target framework.
+    properties (in the metadatum SetDesiredProperties` in the
+    form "key1=value1;...keyN=valueN") needed to build against
+    the target framework that best matches the referring
+    project's target framework.
 
-    The referring project's $(TargetFrameworkMoniker) is passed 
-    in as $(ReferringTargetFramework)
+    The referring project's $(TargetFrameworkMoniker) is passed
+    in as $(ReferringTargetFramework).
   -->
   <Target Name="GetDesiredProperties" />
 
@@ -1626,12 +1629,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
                                         ShouldQueryForProperties
 
-    Overrridden by cross-targeting projects to return "true" if
-    the project should have its GetDesiredProperties
-    target called with a ReferringTargetFramework. If "false",
-    the single output of the project is used.
+    Overrridden by cross-targeting projects to return an item
+    with QueryForProperties metadata that is a boolean set to
+    "true" if the project should have its GetDesiredProperties
+    target called with a ReferringTargetFramework.
+
+    If the returned QueryForProperties is false, the project
+    will be built with the returned UndefineProperties metadata
+    removed from its global properties.
   -->
-  <Target Name="ShouldQueryForProperties" Returns="false" />
+  <Target Name="ShouldQueryForProperties" />
 
   <!--
     ============================================================

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1520,7 +1520,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           there is also a .NETFramework implementation.
 
        2. As an escape hatch for cases where the compatibility check performed by 
-          GetReferenceProperties is faulty.
+          GetDesiredProperties is faulty.
     -->
     <ItemGroup>
       <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SetTargetFramework)' != ''">
@@ -1558,7 +1558,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ====================================================================================
                                         _GetProjectReferenceTargetFrameworkProperties
 
-    Builds the GetReferenceProperties target of all existent project references,
+    Builds the GetDesiredProperties target of all existent project references,
     passing $(TargetFrameworkMoniker) as $(ReferringTargetFramework) and sets the
     SetTargetFramework metadata of the project reference to the value that is returned.
 
@@ -1582,7 +1582,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <MSBuild
         Projects="@(_MSBuildProjectReferenceWithDesiredProperties)"
-        Targets="GetReferenceProperties"
+        Targets="GetDesiredProperties"
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceWithDesiredProperties.SetConfiguration); %(_MSBuildProjectReferenceWithDesiredProperties.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
@@ -1619,7 +1619,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
-                                    GetReferenceProperties
+                                    GetDesiredProperties
 
     Overrridden by cross-targeting projects to return the set of
     properties (in the form "key1=value1;...keyN=valueN") needed
@@ -1629,14 +1629,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     The referring project's $(TargetFrameworkMoniker) is passed 
     in as $(ReferringTargetFramework)
   -->
-  <Target Name="GetReferenceProperties" />
+  <Target Name="GetDesiredProperties" />
 
   <!--
     ============================================================
                                         ShouldQueryForProperties
 
     Overrridden by cross-targeting projects to return "true" if
-    the project should have its GetReferenceProperties
+    the project should have its GetDesiredProperties
     target called with a ReferringTargetFramework. If "false",
     the single output of the project is used.
   -->

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -899,7 +899,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="BuildGenerateSources"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework);"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties);"
         Condition="'$(BuildPassReferences)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != '' and '%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true'"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -924,7 +924,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="BuildCompile"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
         Condition="'$(BuildPassReferences)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''  and '%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true'"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -949,7 +949,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="BuildLink"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
         Condition="'$(BuildPassReferences)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '@(_MSBuildProjectReferenceExistent)' != ''  and '%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true'"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -1523,7 +1523,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           GetDesiredProperties is faulty.
     -->
     <ItemGroup>
-      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SetTargetFramework)' != ''">
+      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SetDesiredProperties)' != ''">
         <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
@@ -1560,7 +1560,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     Builds the GetDesiredProperties target of all existent project references,
     passing $(TargetFrameworkMoniker) as $(ReferringTargetFramework) and sets the
-    SetTargetFramework metadata of the project reference to the value that is returned.
+    SetDesiredProperties metadata of the project reference to the value that is returned.
 
     This allows a cross-targeting project to select how it should be configured to
     build against the most appropriate target for the referring target framework.
@@ -1595,24 +1595,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ItemGroup>
       <!-- Build an item that has Identity matching _MSBuildProjectReferenceExistent and metadata for properties to set. -->
       <_ProjectReferencesWithTargetFrameworkProperties Include="@(_ProjectReferenceTargetFrameworkProperties->'%(OriginalItemSpec)')" />
-      <_ProjectReferencesWithTargetFrameworkProperties Include="@(_MSBuildProjectReferenceNoCrossTargeting)">
-        <HasSingleTargetFramework>true</HasSingleTargetFramework>
-        <IsRidAgnostic>true</IsRidAgnostic>
-      </_ProjectReferencesWithTargetFrameworkProperties>
 
       <!-- Set the project's returned TargetFramework -->
       <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' != 'true'">
-        <SetTargetFramework>@(_ProjectReferencesWithTargetFrameworkProperties->'%(DesiredTargetFrameworkProperties)')</SetTargetFramework>
+        <SetDesiredProperties>@(_ProjectReferencesWithTargetFrameworkProperties->'%(SetDesiredProperties)')</SetDesiredProperties>
       </_MSBuildProjectReferenceExistent>
 
-      <!-- If the project has only one TF, don't specify it. It will go directly to the inner build anyway and we don't want to redundantly specify a global property, which can cause a race. -->
+      <!-- Remove any properties that the reference didn't want. -->
       <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' == 'true'">
-        <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');TargetFramework</UndefineProperties>
-      </_MSBuildProjectReferenceExistent>
-
-      <!-- If the project has only one RID, assume it's compatible with the current project and don't pass this one along. -->
-      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(IsRidAgnostic)')' == 'true'">
-        <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');RuntimeIdentifier</UndefineProperties>
+        <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');@(_ProjectReferencesWithTargetFrameworkProperties->'%(UndefineProperties)')</UndefineProperties>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
   </Target>
@@ -1653,8 +1644,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
         [OUT]
         @(ProjectReferenceWithConfiguration)   - Project references with apporpriate metadata
-        @(_MSBuildProjectReferenceExistent)    - Subset of @(ProjectReferenceWithConfiguration) that exist 
-                                                 with added SetTargetFramework metadata for cross-targeting
+        @(_MSBuildProjectReferenceExistent)    - Subset of @(ProjectReferenceWithConfiguration) that exist
+                                                 with added SetDesiredProperties metadata for cross-targeting
         @(_MSBuildProjectReferenceNonExistent) - Subset of  @(ProjectReferenceWithConfiguration) that do not exist
     ============================================================
   -->
@@ -1709,7 +1700,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="GetTargetPath"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
         Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildProjectReferences)' != 'true') and '$(VisualStudioVersion)' != '10.0' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -1736,7 +1727,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="%(_MSBuildProjectReferenceExistent.Targets);GetTargetPath"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
         Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and ('$(BuildingInsideVisualStudio)' == 'true' or '$(BuildProjectReferences)' != 'true') and '$(VisualStudioVersion)' == '10.0' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -1753,7 +1744,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="%(_MSBuildProjectReferenceExistent.Targets)"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform);  %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform);  %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
         Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '$(BuildingInsideVisualStudio)' != 'true' and '$(BuildProjectReferences)' == 'true' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="$(ContinueOnError)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -1770,7 +1761,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="GetNativeManifest"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
         Condition="'%(_MSBuildProjectReferenceExistent.BuildReference)' == 'true' and '@(ProjectReferenceWithConfiguration)' != '' and '$(BuildingProject)' == 'true' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="$(ContinueOnError)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -2300,7 +2291,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="GetReferenceTargetPlatformMonikers" DependsOnTargets="PrepareProjectReferences">
     <MSBuild
       Projects="@(_MSBuildProjectReferenceExistent)"
-      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
       Targets="GetTargetPathWithTargetPlatformMoniker"
       BuildInParallel="$(BuildInParallel)"
       ContinueOnError="!$(BuildingProject)"
@@ -4255,7 +4246,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="GetCopyToOutputDirectoryItems"
         BuildInParallel="$(BuildInParallel)"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
         Condition="'@(_MSBuildProjectReferenceExistent)' != '' and '$(_GetChildProjectCopyToOutputDirectoryItems)' == 'true' and '%(_MSBuildProjectReferenceExistent.Private)' != 'false' and '$(UseCommonOutputDirectory)' != 'true'"
         ContinueOnError="$(ContinueOnError)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
@@ -4817,7 +4808,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <MSBuild
         Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="Clean"
-        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetDesiredProperties)"
         BuildInParallel="$(BuildInParallel)"
         Condition="'$(BuildingInsideVisualStudio)' != 'true' and '$(BuildProjectReferences)' == 'true' and '@(_MSBuildProjectReferenceExistent)' != ''"
         ContinueOnError="$(ContinueOnError)"

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1524,12 +1524,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
     <ItemGroup>
       <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SetTargetFramework)' != ''">
-        <SkipGetReferenceProperties>true</SkipGetReferenceProperties>
+        <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
 
     <!--
-      Honor SkipGetReferenceProperties=true metadata on project references
+      Honor SkipGetTargetFrameworkProperties=true metadata on project references
       to mean that the project reference is known not to target multiple frameworks
       and the mechanism here for selecting the best one can be skipped as an optimization.
     -->
@@ -1540,7 +1540,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
-        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetReferenceProperties)' != 'true'">
+        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_MSBuildProjectReferenceCrossTargetingResults" />
     </MSBuild>
@@ -1587,7 +1587,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
         ContinueOnError="!$(BuildingProject)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
-        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetReferenceProperties)' != 'true'">
+        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
 
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>

--- a/src/XMakeTasks/Microsoft.Common.props
+++ b/src/XMakeTasks/Microsoft.Common.props
@@ -143,6 +143,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <WMSJSProjectDirectory Condition="'$(WMSJSProjectDirectory)' == ''">JavaScript</WMSJSProjectDirectory>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PropertiesToRemoveWhenQueryingForDesiredProperties Condition="'$(PropertiesToRemoveWhenQueryingForDesiredProperties)' == ''">TargetFramework;RuntimeIdentifier</PropertiesToRemoveWhenQueryingForDesiredProperties>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.VisualStudioVersion.v*.Common.props" Condition="'$(VisualStudioVersion)' == ''" />
 
   <!-- 


### PR DESCRIPTION
Before cross-targeting was implemented, a project had a single output
that was queried in ResolveProjectReferences by either `GetTargetPath`
(in single-project-build scenarios) or the default target (`Build`) in
command line builds.

A cross-targeting project doesn't have a single output--it has one for
each of its `TargetFrameworks`. A ProjectReference, then, has to first
figure out which output to ask for--the one that's the best fit for the
current project.

The initial implementation of this was simple: unconditionally call
`GetTargetFrameworkProperties` on every ProjectReference, passing a
`ReferringTargetFramework`. Then, if the project cross-targets, specify
the resulting TF on future calls to the ProjectReference. If the project
has a single TF, do not specify it to avoid building it once (from the
solution  build) and again (from a reference, explicitly specifying the
one TF).

Unfortunately, adding a global property for `ReferringTargetFramework`
will result in a separate evaluation for the project. This means that
almost _every_ project in a solution will be evaluated at least
twice--once directly, with no special global properties, and once for
each unique `ReferringTargetFramework` that refers to it. This can be
particularly onerous for C++ projects (.vcxproj), where evaluation time
is nontrivial and doubling it is noticeable. That was mitigated by
special-casing vcxproj in #1278, but that is inelegant and doesn't
address the root cause.

This change alters the calling pattern for `ProjectReference`s. Instead
of asking all references for the correct TF, it breaks the problem into
multiple phases:

* Ask all references whether they cross-target, and split into
cross-targeting and non-cross-targeting lists.
* Perform the `GetTargetFrameworkProperties` query only on projects that
reported that they cross-targeted.
* Update (in place) the existing `_MSBuildProjectReferenceExistent` item
to pass or undefine the relevant properties based on whether the
reference cross-targets (and what TF is the best match).

Fixes #1276 (when combined with an Sdk fix, forthcoming)