### PR TITLE
Attempt to fix a race condition in TestBinaryLogRoundtrip.

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -434,8 +434,9 @@ namespace Microsoft.Build.Logging
             }
 
             var entries = items.OfType<DictionaryEntry>()
-                .Where(e => e.Key is string && e.Value is ITaskItem);
-            Write(entries.Count());
+                .Where(e => e.Key is string && e.Value is ITaskItem)
+                .ToArray();
+            Write(entries.Length);
 
             foreach (DictionaryEntry entry in entries)
             {
@@ -467,9 +468,13 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            Write(properties.Cast<object>().Count());
+            // there are no guarantees that the properties iterator won't change, so 
+            // take a snapshot and work with the readonly copy
+            var propertiesArray = properties.OfType<DictionaryEntry>().ToArray();
 
-            foreach (DictionaryEntry entry in properties)
+            Write(propertiesArray.Length);
+
+            foreach (DictionaryEntry entry in propertiesArray)
             {
                 if (entry.Key is string && entry.Value is string)
                 {


### PR DESCRIPTION
My hypothesis is that when serializing properties of a ProjectStartedEventArgs we were iterating over the properties twice, first to establish count and the second time to actually write the items.

By inspecting the binary stream I've found that the log expected to find 166 property name/value pairs, but in the stream there's actually a 167th:

"SBuildLastTaskResult\u0004true\u0001\bTestItem\u0004Test\0\v5#Building with tools version \"15.0"

So I'm guessing is that the MSBuildLastTaskResult property is being set to true right after we grab the property count, but before we iterate over the properties. At least that would explain the extra property in the stream that we don't expect.

In any case the change seems good and I'd like to get this in (I'm 60% positive this will fix it).