### PR TITLE
Remove ProjectConfigurationsInferredFromUsage capability from managed targets

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -62,7 +62,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <ItemGroup Condition=" '$(DefineCommonCapabilities)' == 'true' ">
       <ProjectCapability Include="ReferencesFolder;LanguageService" />
-      <ProjectCapability Include="ProjectConfigurationsInferredFromUsage" />
     </ItemGroup>
 
     <!--

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -62,7 +62,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <ItemGroup Condition=" '$(DefineCommonCapabilities)' == 'true' ">
       <ProjectCapability Include="ReferencesFolder;LanguageService" />
-      <ProjectCapability Include="ProjectConfigurationsInferredFromUsage" />
     </ItemGroup>
 
     <!--


### PR DESCRIPTION
The legacy project system works without it (since it's not CPS based) and there are changes in the pipeline to use a different capability to defined configurations differently. On the new project system the capability is defined by the project system (as a default). Additionally the capability was also defined in the design time targets so there is some redundancy. Having the old capabilities here conflicts with that and requires a workaround to add a remove statement elsewhere in the targets. 
