### PR TITLE
Capture test output to Xunit MockEngine

### DIFF
--- a/src/Shared/UnitTests/MockEngine.cs
+++ b/src/Shared/UnitTests/MockEngine.cs
@@ -75,41 +75,41 @@ namespace Microsoft.Build.UnitTests
 
         public void LogErrorEvent(BuildErrorEventArgs eventArgs)
         {
+            string message = string.Empty;
+
             if (eventArgs.File != null && eventArgs.File.Length > 0)
             {
-                if (_logToConsole)
-                    Console.Write("{0}({1},{2}): ", eventArgs.File, eventArgs.LineNumber, eventArgs.ColumnNumber);
-                _log += String.Format("{0}({1},{2}): ", eventArgs.File, eventArgs.LineNumber, eventArgs.ColumnNumber);
+                message += String.Format("{0}({1},{2}): ", eventArgs.File, eventArgs.LineNumber, eventArgs.ColumnNumber);
             }
 
-            if (_logToConsole)
-                Console.Write("ERROR " + eventArgs.Code + ": ");
-            _log += "ERROR " + eventArgs.Code + ": ";
+            message += "ERROR " + eventArgs.Code + ": ";
             ++_errors;
 
+            message += eventArgs.Message;
+
             if (_logToConsole)
-                Console.WriteLine(eventArgs.Message);
-            _log += eventArgs.Message;
+                Console.WriteLine(message);
+            _log += message;
             _log += "\n";
         }
 
         public void LogWarningEvent(BuildWarningEventArgs eventArgs)
         {
+            string message = string.Empty;
+
             if (eventArgs.File != null && eventArgs.File.Length > 0)
             {
-                if (_logToConsole)
-                    Console.Write("{0}({1},{2}): ", eventArgs.File, eventArgs.LineNumber, eventArgs.ColumnNumber);
-                _log += String.Format("{0}({1},{2}): ", eventArgs.File, eventArgs.LineNumber, eventArgs.ColumnNumber);
+                message += String.Format("{0}({1},{2}): ", eventArgs.File, eventArgs.LineNumber, eventArgs.ColumnNumber);
             }
 
-            if (_logToConsole)
-                Console.Write("WARNING " + eventArgs.Code + ": ");
-            _log += "WARNING " + eventArgs.Code + ": ";
+            message += "WARNING " + eventArgs.Code + ": ";
             ++_warnings;
 
+            message += eventArgs.Message;
+
             if (_logToConsole)
-                Console.WriteLine(eventArgs.Message);
-            _log += eventArgs.Message;
+                Console.WriteLine(message);
+            _log += message;
             _log += "\n";
         }
 
@@ -132,22 +132,17 @@ namespace Microsoft.Build.UnitTests
 
         public void LogTelemetry(string eventName, IDictionary<string, string> properties)
         {
+            string message = $"Received telemetry event '{eventName}'{Environment.NewLine}";
+            foreach (string key in properties?.Keys)
+            {
+                message += $"  Property '{key}' = '{properties[key]}'{Environment.NewLine}";
+            }
+
             if (_logToConsole)
             {
-                Console.WriteLine($"Received telemetry event '{eventName}'");
+                Console.WriteLine(message);
             }
-            _log += $"Received telemetry event '{eventName}'{Environment.NewLine}";
-            if (properties != null)
-            {
-                foreach (string key in properties.Keys)
-                {
-                    if (_logToConsole)
-                    {
-                        Console.WriteLine($"  Property '{key}' = '{properties[key]}'{Environment.NewLine}");
-                    }
-                    _log += $"  Property '{key}' = '{properties[key]}'{Environment.NewLine}";
-                }
-            }
+            _log += message;
         }
 
         public bool ContinueOnError

--- a/src/Shared/UnitTests/MockEngine.cs
+++ b/src/Shared/UnitTests/MockEngine.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
@@ -29,6 +30,8 @@ namespace Microsoft.Build.UnitTests
      **************************************************************************/
     sealed internal class MockEngine : IBuildEngine5
     {
+        private readonly ITestOutputHelper _output;
+
         private bool _isRunningMultipleNodes;
         private int _messages = 0;
         private int _warnings = 0;
@@ -73,6 +76,12 @@ namespace Microsoft.Build.UnitTests
             _logToConsole = logToConsole;
         }
 
+        public MockEngine(ITestOutputHelper output)
+        {
+            _output = output;
+            _mockLogger = new MockLogger(output);
+            _logToConsole = false; // We have a better place to put it.
+        }
 
         public void LogErrorEvent(BuildErrorEventArgs eventArgs)
         {
@@ -90,6 +99,7 @@ namespace Microsoft.Build.UnitTests
 
             if (_logToConsole)
                 Console.WriteLine(message);
+            _output?.WriteLine(message);
             _log.AppendLine(message);
         }
 
@@ -109,6 +119,7 @@ namespace Microsoft.Build.UnitTests
 
             if (_logToConsole)
                 Console.WriteLine(message);
+            _output?.WriteLine(message);
             _log.AppendLine(message);
         }
 
@@ -116,6 +127,7 @@ namespace Microsoft.Build.UnitTests
         {
             if (_logToConsole)
                 Console.WriteLine(eventArgs.Message);
+            _output?.WriteLine(eventArgs.Message);
             _log.AppendLine(eventArgs.Message);
         }
 
@@ -123,6 +135,7 @@ namespace Microsoft.Build.UnitTests
         {
             if (_logToConsole)
                 Console.WriteLine(eventArgs.Message);
+            _output?.WriteLine(eventArgs.Message);
             _log.AppendLine(eventArgs.Message);
             ++_messages;
         }
@@ -139,6 +152,7 @@ namespace Microsoft.Build.UnitTests
             {
                 Console.WriteLine(message);
             }
+            _output?.WriteLine(message);
             _log.AppendLine(message);
         }
 
@@ -411,7 +425,11 @@ namespace Microsoft.Build.UnitTests
                 )
               )
             {
-                Console.WriteLine(_log);
+                if (_output == null)
+                {
+                    Console.WriteLine(_log.ToString());
+                }
+
                 _mockLogger.AssertLogContains(contains);
             }
         }
@@ -424,7 +442,10 @@ namespace Microsoft.Build.UnitTests
         /// <param name="contains"></param>
         internal void AssertLogDoesntContain(string contains)
         {
-            Console.WriteLine(_log);
+            if (_output == null)
+            {
+                Console.WriteLine(_log);
+            }
 
             if (_upperLog == null)
             {

--- a/src/Shared/UnitTests/MockEngine.cs
+++ b/src/Shared/UnitTests/MockEngine.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
@@ -32,7 +33,7 @@ namespace Microsoft.Build.UnitTests
         private int _messages = 0;
         private int _warnings = 0;
         private int _errors = 0;
-        private string _log = "";
+        private StringBuilder _log = new StringBuilder();
         private string _upperLog = null;
         private ProjectCollection _projectCollection = new ProjectCollection();
         private bool _logToConsole = false;
@@ -89,8 +90,7 @@ namespace Microsoft.Build.UnitTests
 
             if (_logToConsole)
                 Console.WriteLine(message);
-            _log += message;
-            _log += "\n";
+            _log.AppendLine(message);
         }
 
         public void LogWarningEvent(BuildWarningEventArgs eventArgs)
@@ -109,24 +109,21 @@ namespace Microsoft.Build.UnitTests
 
             if (_logToConsole)
                 Console.WriteLine(message);
-            _log += message;
-            _log += "\n";
+            _log.AppendLine(message);
         }
 
         public void LogCustomEvent(CustomBuildEventArgs eventArgs)
         {
             if (_logToConsole)
                 Console.WriteLine(eventArgs.Message);
-            _log += eventArgs.Message;
-            _log += "\n";
+            _log.AppendLine(eventArgs.Message);
         }
 
         public void LogMessageEvent(BuildMessageEventArgs eventArgs)
         {
             if (_logToConsole)
                 Console.WriteLine(eventArgs.Message);
-            _log += eventArgs.Message;
-            _log += "\n";
+            _log.AppendLine(eventArgs.Message);
             ++_messages;
         }
 
@@ -142,7 +139,7 @@ namespace Microsoft.Build.UnitTests
             {
                 Console.WriteLine(message);
             }
-            _log += message;
+            _log.AppendLine(message);
         }
 
         public bool ContinueOnError
@@ -179,8 +176,16 @@ namespace Microsoft.Build.UnitTests
 
         internal string Log
         {
-            set { _log = value; }
-            get { return _log; }
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentException("Expected log setter to be used only to reset the log to empty.");
+                }
+
+                _log.Clear();
+            }
+            get { return _log.ToString(); }
         }
 
         public bool IsRunningMultipleNodes
@@ -394,8 +399,7 @@ namespace Microsoft.Build.UnitTests
         {
             if (_upperLog == null)
             {
-                _upperLog = _log;
-                _upperLog = _upperLog.ToUpperInvariant();
+                _upperLog = _log.ToString().ToUpperInvariant();
             }
 
             // If we do not contain this string than pass it to
@@ -424,8 +428,7 @@ namespace Microsoft.Build.UnitTests
 
             if (_upperLog == null)
             {
-                _upperLog = _log;
-                _upperLog = _upperLog.ToUpperInvariant();
+                _upperLog = _log.ToString().ToUpperInvariant();
             }
 
             Assert.False(_upperLog.Contains

--- a/src/Tasks.UnitTests/GetSDKReference_Tests.cs
+++ b/src/Tasks.UnitTests/GetSDKReference_Tests.cs
@@ -20,6 +20,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
 {
@@ -187,6 +188,8 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
     /// </summary>
     public class GetSDKReferenceFilesTestFixture : IDisposable, IClassFixture<FakeSdkStructure>
     {
+        private readonly ITestOutputHelper _output;
+
         private readonly string _sdkDirectory;
         private readonly string _sdkDirectory2;
         private readonly MockEngine.GetStringDelegate _resourceDelegate;
@@ -194,8 +197,10 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         private readonly GetAssemblyRuntimeVersion _getAssemblyRuntimeVersion = GetImageRuntimeVersion;
         private readonly string _cacheDirectory = Path.Combine(Path.GetTempPath(), "GetSDKReferenceFiles");
 
-        public GetSDKReferenceFilesTestFixture(FakeSdkStructure fakeSdkStructure)
+        public GetSDKReferenceFilesTestFixture(FakeSdkStructure fakeSdkStructure, ITestOutputHelper output)
         {
+            _output = output;
+
             _sdkDirectory = fakeSdkStructure.SdkDirectory;
             _sdkDirectory2 = fakeSdkStructure.SdkDirectory2;
             _resourceDelegate = AssemblyResources.GetString;
@@ -222,7 +227,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Fact]
         public void PassReferenceWithNoReferenceDirectory()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             ITaskItem item = new TaskItem("C:\\SDKDoesNotExist");
@@ -313,7 +318,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Fact]
         public void PassNoSDKReferences()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -331,7 +336,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Fact]
         public void PassReferenceWithExpandFalse()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -356,7 +361,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Fact]
         public void PassReferenceWithCopyRedistFalse()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -383,7 +388,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void GetReferenceAssembliesWhenExpandTrueCopyLocalTrue()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -449,7 +454,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyNoCopyWhenReferenceOnlyIsTrue()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -507,7 +512,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-windows-failing")]
         public void GetReferenceAssembliesWhenExpandTrueCopyLocalFalse()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -560,7 +565,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Fact]
         public void VerifyCacheFileNames()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -627,7 +632,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyReferencesLogged()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -676,7 +681,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyReferencesLoggedFilterOutWinmd()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -722,7 +727,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogErrorWhenNoConfiguration()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -746,7 +751,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogErrorWhenNoArchitecture()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -772,7 +777,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void VerifyReferencesLoggedAmd64()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -824,7 +829,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyReferencesLoggedX64()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -876,7 +881,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyLogReferencesFalse()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -912,7 +917,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyRedistFilesLogRedistFalse()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -978,7 +983,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyRedistFilesLogRedistTrue()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1010,7 +1015,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyRedistFilesLogRedistTrueX64()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1043,7 +1048,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void VerifyRedistFilesLogRedistTrueAmd64()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1075,7 +1080,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogNoWarningForReferenceConflictWithinSDK()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1104,7 +1109,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogWarningForReferenceConflictWithinSDK()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1134,7 +1139,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogNoWarningForRedistConflictWithinSDK()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1162,7 +1167,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogWarningForRedistConflictWithinSDK()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1191,7 +1196,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogReferenceAndRedistConflictBetweenSdks()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1237,7 +1242,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogReferenceAndRedistConflictBetweenSdksDueToCustomTargetPath()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1280,7 +1285,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void LogReferenceAndRedistConflictBetweenSdksNowarning()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;
@@ -1328,7 +1333,7 @@ namespace Microsoft.Build.UnitTests.GetSDKReferenceFiles_Tests
         [Trait("Category", "mono-osx-failing")]
         public void TwoSDKSConflictRedistButDifferentTargetPaths()
         {
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             GetSDKReferenceFiles t = new GetSDKReferenceFiles();
             t.BuildEngine = engine;
             t.CacheFileFolderPath = _cacheDirectory;


### PR DESCRIPTION
https://ci2.dot.net/job/Microsoft_msbuild/job/master/job/_Windows_NT_Desktop_prtest/640/ had a mysterious failure in `LogReferenceAndRedistConflictBetweenSdks` which isn't known to be flaky. But the log just indicated that a task failed, which isn't helpful.

I added the ability to keep log information in xunit's style in MockEngine, switched its internal log capture to use StringBuilder instead of super allocatey concatenation all over the place, and opted the class that failed into the new logging.