### PR TITLE
PVS-Studio: fixed vulnerabilities

### DIFF
--- a/src/MSBuild/InitializationException.cs
+++ b/src/MSBuild/InitializationException.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Build.CommandLine
 
             ErrorUtilities.VerifyThrow(errorMessage != null, "The resource string must exist.");
 
-            if (showStackTrace)
+            if (showStackTrace && e != null)
             {
                 errorMessage += Environment.NewLine + e.ToString();
             }

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -167,13 +167,16 @@ namespace Microsoft.Build.Tasks
             ResolutionSearchLocation searchLocation
         )
         {
-            searchLocation.FileNameAttempted = pathToCandidateAssembly;
+            if (searchLocation != null)
+            {
+                searchLocation.FileNameAttempted = pathToCandidateAssembly;
+            }
 
             // Base name of the target file has to match the Name from the assemblyName
             if (!allowMismatchBetweenFusionNameAndFileName)
             {
                 string candidateBaseName = Path.GetFileNameWithoutExtension(pathToCandidateAssembly);
-                if (String.Compare(assemblyName.Name, candidateBaseName, StringComparison.CurrentCultureIgnoreCase) != 0)
+                if (String.Compare(assemblyName?.Name, candidateBaseName, StringComparison.CurrentCultureIgnoreCase) != 0)
                 {
                     if (searchLocation != null)
                     {
@@ -246,7 +249,10 @@ namespace Microsoft.Build.Tasks
                               && (targetProcessorArchitecture != ProcessorArchitecture.MSIL && targetAssemblyName.AssemblyName.ProcessorArchitecture != ProcessorArchitecture.MSIL) /*The assembly is not MSIL*/
                            )
                         {
-                            searchLocation.Reason = NoMatchReason.ProcessorArchitectureDoesNotMatch;
+                            if (searchLocation != null)
+                            {
+                                searchLocation.Reason = NoMatchReason.ProcessorArchitectureDoesNotMatch;
+                            }
                             return false;
                         }
                     }


### PR DESCRIPTION
[V3095](https://www.viva64.com/en/w/V3095/) The 'searchLocation' object was used before it was verified against null. Check lines: 170, 178. Microsoft.Build.Tasks Resolver.cs 170
[V3095](https://www.viva64.com/en/w/V3095/) The 'searchLocation' object was used before it was verified against null. Check lines: 249, 264. Microsoft.Build.Tasks Resolver.cs 249
[V3095](https://www.viva64.com/en/w/V3095/) The 'assemblyName' object was used before it was verified against null. Check lines: 176, 194. Microsoft.Build.Tasks Resolver.cs 176
[V3095](https://www.viva64.com/en/w/V3095/) The 'e' object was used before it was verified against null. Check lines: 165, 170. MSBuild InitializationException.cs 165

V3095  ->  CWE-476 (Medium) NULL Pointer Dereference