### PR TITLE
Document the ProjectReference protocol

### DIFF
--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -45,6 +45,8 @@ These targets should exist in a project to be compatible with the common targets
 
 These targets are all defined in `Microsoft.Common.targets` and are defined in Microsoft SDKs. You should only have to implement them yourself if you require custom behavior or are authoring a project that doesn't import the common targets.
 
+If implementing a project with an “outer” (determine what properties to pass to the real build) and “inner” (fully specified) build, only `GetTargetFrameworkProperties` is required in the “outer” build. The other targets listed can be “inner” build only.
+
 <!--* `BuildGenerateSources` is run
   * **Conditions**: only if `'$(BuildPassReferences)' == 'true'`.
   * Rare in managed projects but common in C++ scenarios (for example, using IDL to generate header code).-->
@@ -52,7 +54,6 @@ These targets are all defined in `Microsoft.Common.targets` and are defined in M
   * **New** for MSBuild 15/Visual Studio 2017. Supports the cross-targeting feature allowing a project to have multiple `TargetFrameworks`.
   * **Conditions**: only when metadata `SkipGetTargetFrameworkProperties` for each reference is not true.
   * Skipped for `*.vcxproj` by default.
-  * This target must be present in a build request that does not specify a `TargetFramework`—the “outer” build. It is not required in a fully-specified (“inner”) build.
 * `GetTargetPath` should the path of the project's output, but _not_ build that output.
   * **Conditions**: this is used for builds inside Visual Studio, but not on the command line.
   * It's also used when the property `BuildProjectReferences` is `false`, manually indicating that all `ProjectReferences` are up to date and shouldn't be (re)built.

--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -52,6 +52,7 @@ These targets are all defined in `Microsoft.Common.targets` and are defined in M
   * **New** for MSBuild 15/Visual Studio 2017. Supports the cross-targeting feature allowing a project to have multiple `TargetFrameworks`.
   * **Conditions**: only when metadata `SkipGetTargetFrameworkProperties` for each reference is not true.
   * Skipped for `*.vcxproj` by default.
+  * This target must be present in a build request that does not specify a `TargetFramework`—the “outer” build. It is not required in a fully-specified (“inner”) build.
 * `GetTargetPath` should the path of the project's output, but _not_ build that output.
   * **Conditions**: this is used for builds inside Visual Studio, but not on the command line.
   * It's also used when the property `BuildProjectReferences` is `false`, manually indicating that all `ProjectReferences` are up to date and shouldn't be (re)built.

--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -67,3 +67,5 @@ These targets are all defined in `Microsoft.Common.targets` and are defined in M
 As with all MSBuild logic, targets can be added to do other work with `ProjectReference`s.
 
 In particular, NuGet depends on being able to identify referenced projects' package dependencies, and calls some targets that are imported through `Microsoft.Common.targets` to do so. At the time of writing this this is in [`NuGet.targets`](https://github.com/NuGet/NuGet.Client/blob/79264a74262354c1a8f899c2c9ddcaff58afaf62/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets).
+
+XAML targets add a dependency on the target `GetPackagingOutputs`.

--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -1,0 +1,69 @@
+# The `ProjectReference` Protocol
+
+The MSBuild engine doesn't have a notion of a “project reference”—it only provides the [`MSBuild` task](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-task) to allow cross-project communication.
+
+That's a powerful tool, but no one would want to have to specify how to build every single reference in every single project. The common targets introduce an item, `ProjectReference`, and a default process for building references declared via that item.
+
+## Projects that have references
+
+In its simplest form, a project need only specify the path to another project in a `ProjectReference` item. For example,
+
+```csproj
+<ItemGroup>
+  <ProjectReference Include="..\..\some\other\project.csproj" />
+</ItemGroup>
+```
+
+Including `Microsoft.Common.targets` includes logic that consumes these items and transforms them into compile-time references before the compiler runs. 
+
+## Who this document is for
+
+This document describes that process, including what is required of a project to be referenceable through a `ProjectReference`. It is intended for for MSBuild SDK maintainers, and those who have created a completely custom project type that needs to interoperate with other projects. It may also be of interest if you'd like to see the implementation details of references. Understanding the details should not be necessary to _use_ `ProjectReferences` in your project.
+
+## Targets related to consuming a reference
+
+The bulk of the work of transforming `ProjectReference` items into something suitable to feed the compiler is done by tasks listed in the `ResolveReferencesDependsOn` property defined in `Microsoft.Common.CurrentVersion.targets`.
+
+There are empty hooks in the default targets for
+
+* `BeforeResolveReferences`—run before the primary work of resolving references.
+* `AfterResolveReferences`—run after the primary work of resolving references.
+
+`AssignProjectConfiguration` runs when building in a solution context, and ensures that the right `Configuration` and `Platform` are assigned to each reference. For example, if a solution specifies (using the Solution Build Manager) that for a given solution configuration, a project should always be built `Release`, that is applied inside MSBuild in this target.
+
+`PrepareProjectReferences` then runs, ensuring that each referenced project exists (creating the item `@(_MSBuildProjectReferenceExistent)`) and asking it for the closest matching `TargetFramework` to build.
+
+`ResolveProjectReferences` does the bulk of the work, building the referenced projects and collecting their outputs.
+
+After the compiler is invoked, `GetCopyToOutputDirectoryItems` pulls child-project outputs into the current project to be copied to its output directory.
+
+When `Clean`ing the output of a project, `CleanReferencedProjects` ensures that referenced projects also clean.
+
+## Targets required to be referenceable
+
+These targets should exist in a project to be compatible with the common targets' `ProjectReference`. Some are called only conditionally.
+
+These targets are all defined in `Microsoft.Common.targets` and are defined in Microsoft SDKs. You should only have to implement them yourself if you require custom behavior or are authoring a project that doesn't import the common targets.
+
+<!--* `BuildGenerateSources` is run
+  * **Conditions**: only if `'$(BuildPassReferences)' == 'true'`.
+  * Rare in managed projects but common in C++ scenarios (for example, using IDL to generate header code).-->
+* `GetTargetFrameworkProperties` determines what properties should be passed to the main get-build-output target.
+  * **New** for MSBuild 15/Visual Studio 2017. Supports the cross-targeting feature allowing a project to have multiple `TargetFrameworks`.
+  * **Conditions**: only when metadata `SkipGetTargetFrameworkProperties` for each reference is not true.
+  * Skipped for `*.vcxproj` by default.
+* `GetTargetPath` should the path of the project's output, but _not_ build that output.
+  * **Conditions**: this is used for builds inside Visual Studio, but not on the command line.
+  * It's also used when the property `BuildProjectReferences` is `false`, manually indicating that all `ProjectReferences` are up to date and shouldn't be (re)built.
+* Default/explicitly specified targets do the full build and return an assembly to be referenced.
+  * If the `ProjectReference` defines the `Targets` metadata, it is used. If not, no target is passed, and the default target of the reference (usually `Build`) is built.
+* `GetNativeManifest` should return a manifest suitable for passing to the `ResolveNativeReferences` target.
+* `GetCopyToOutputDirectoryItems` should return the outputs of a project that should be copied to the output of a referencing project.
+* `Clean` should delete all outputs of the project.
+  * It is not called during a normal build, only during "Clean" and "Rebuild".
+
+## Other protocol requirements
+
+As with all MSBuild logic, targets can be added to do other work with `ProjectReference`s.
+
+In particular, NuGet depends on being able to identify referenced projects' package dependencies, and calls some targets that are imported through `Microsoft.Common.targets` to do so. At the time of writing this this is in [`NuGet.targets`](https://github.com/NuGet/NuGet.Client/blob/79264a74262354c1a8f899c2c9ddcaff58afaf62/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets).

--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -1,4 +1,4 @@
-# The `ProjectReference` Protocol
+﻿# The `ProjectReference` Protocol
 
 The MSBuild engine doesn't have a notion of a “project reference”—it only provides the [`MSBuild` task](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-task) to allow cross-project communication.
 
@@ -69,4 +69,4 @@ As with all MSBuild logic, targets can be added to do other work with `ProjectRe
 
 In particular, NuGet depends on being able to identify referenced projects' package dependencies, and calls some targets that are imported through `Microsoft.Common.targets` to do so. At the time of writing this this is in [`NuGet.targets`](https://github.com/NuGet/NuGet.Client/blob/79264a74262354c1a8f899c2c9ddcaff58afaf62/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets).
 
-XAML targets add a dependency on the target `GetPackagingOutputs`.
+`Microsoft.AppxPackage.targets` adds a dependency on the target `GetPackagingOutputs`.


### PR DESCRIPTION
Wrote a document explaining what ProjectReferences do behind the scenes
and how to make a green-field project that doesn't import the machinery
of Common.targets compatibile with using them.