### PR TITLE
New VS path under Microbuild

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -160,6 +160,11 @@
       -->
       <EditBinCommand Condition="'$(VSINSTALLDIR)' != ''">call &quot;$(VSINSTALLDIR)\Common7\Tools\VsDevCmd.bat&quot; &amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)</EditBinCommand>
       <EditBinCommand Condition="'$(VsInstallRoot)' != '' and '$(EditBinCommand)' == ''">call &quot;$(VsInstallRoot)\Common7\Tools\VsDevCmd.bat&quot; &amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)</EditBinCommand>
+
+      <!--
+        But sometimes, on Microbuild, VS140COMNTOOLS is defined instead of VsInstallRoot.
+      -->
+      <EditBinCommand Condition="'$(VS140COMNTOOLS)' != '' and '$(EditBinCommand)' == ''">call &quot;$(VsInstallRoot)\VsDevCmd.bat&quot; &amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)</EditBinCommand>
     </PropertyGroup>
 
     <Exec Condition="'$(EditBinFlags)'!=''"


### PR DESCRIPTION
Recent builds failed with Visual Studio not being found on the Microbuild machines, thus making the editbin target fail.

This is a preemptive PR. Maybe the failing build that experienced the missing VS environment property was just a flaky run. Looking at the failed build log, the VS relevant properties are:

```
                   VCTargetsPath = C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\
                   VCTargetsPath10 = C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\
                   VCTargetsPath11 = C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V110\
                   VCTargetsPath12 = C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\
                   VCTargetsPath14 = C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\
                   Version = 1.0.0.0
                   VisualStudioVersion = 14.0
                   VS110COMNTOOLS = C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\Tools\
                   VS120COMNTOOLS = C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools\
                   VS140COMNTOOLS = C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\
                   VSSDK140Install = C:\Program Files (x86)\Microsoft Visual Studio 14.0\VSSDK\
```