### PR TITLE
Allow StreamReader to detect file Encoding w/o BOM.

### DIFF
--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Build.Internal
                 // load.
                 _stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
                 _streamReader = new StreamReader(_stream, s_utf8NoBom, detectEncodingFromByteOrderMarks: true);
-
-                Reader = GetXmlReader(_streamReader, out var detectedEncoding);
+                Encoding detectedEncoding;
+                Reader = GetXmlReader(_streamReader, out detectedEncoding);
 
                 // Override detected encoding if an XML encoding attribute is specified and that encoding is sufficiently
                 // different from the detected encoding.


### PR DESCRIPTION
Thanks @davkean 

Passing in UTF8 w/o BOM Encoding object to StreamReader will allow the
StreamReader class to correctly detect encoding when a BOM exists in
the file. Using the default (UTF8 with BOM) will cause issues when the
file is UTF8 encoded without a BOM (added on save).

The overall issue was fixed in 8e3adba by reading the Stream. This
change allows for that behavior without needing to check the preamble
again.

#1898, #1768

Note: I'm not reverting my other change since part of it still necessary and the unit tests still need to read the preamble to verify the fix and we still need other aspects of that change to ensure that UTF8 and UTF8 w/o BOM are treated the same in some cases.