### PR TITLE
Improve running of tests in VS

### DIFF
--- a/src/dir.targets
+++ b/src/dir.targets
@@ -77,7 +77,7 @@
 
   <!-- TODO: enable for all runtime hosts https://github.com/Microsoft/msbuild/issues/694 -->
   <Import Project="$(GitVersioningDir)dotnet\Nerdbank.GitVersioning.targets"
-          Condition="'$(MSBuildRuntimeType)' == 'Full'" />
+          Condition="'$(MSBuildRuntimeType)' == 'Full' And '$(IsTestProject)' != 'true' " />
   <PropertyGroup Condition="'$(MSBuildRuntimeType)' != 'Full'">
     <DefineConstants>$(DefineConstants);STATIC_VERSION_NUMBER</DefineConstants>
   </PropertyGroup>

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -129,6 +129,12 @@
           DestinationFolder="@(RuntimeProjectJson->'%(TestDeploymentDir)')"
           SkipUnchangedFiles="true"
           />
+
+    <Copy SourceFiles="@(ResolvedRuntimeFiles)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true"
+          Condition=" '$(BuildingInsideVisualStudio)' == 'true' "
+          />
   </Target>
 
   <Target Name="SetUnixPermissions"


### PR DESCRIPTION
Don't version test assemblies.  When building with MSBuild 15.0. MSBuildRuntimeType wasn't set so our assemblies weren't being versioned.  With the move to MSBuild 15.0, we get errors when trying to debug the tests in Visual Studio.

Copy XUnit dependencies to VS output path when building in VS.  