### PR TITLE
Fix stackoverflow in preprocessor

### DIFF
--- a/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -937,5 +937,33 @@ namespace Microsoft.Build.UnitTests.Preprocessor
                 }
             }
         }
+
+        /// <summary>
+        /// Verifies that the Preprocessor works when the import graph contains unevaluated duplicates.  This can occur if two projects in 
+        /// two different folders both import "..\dir.props" or "$(Property)".  Those values will evaluate to different paths at run time
+        /// but the preprocessor builds a map of the imports.
+        /// </summary>
+        [Fact]
+        public void DuplicateUnevaluatedImports()
+        {
+            ProjectRootElement xml1 = ProjectRootElement.Create("p1");
+            ProjectRootElement xml2 = ProjectRootElement.Create("p2");
+            ProjectRootElement xml3 = ProjectRootElement.Create("p3");
+
+            xml1.AddProperty("Import", "p2");
+            xml2.AddProperty("Import", "p3");
+
+            // These imports are duplicates but for each project will evaluate to seperate projects.  We expect that to NOT break
+            // the preprocessor's internal mapping.
+            //
+            xml1.AddImport("$(Import)");
+            xml2.AddImport("$(Import)");
+
+            Project project = new Project(xml1);
+
+            StringWriter writer = new StringWriter();
+
+            project.SaveLogicalProject(writer);
+        }
     }
 }


### PR DESCRIPTION
When updating the pre-processor for the implicit imports, I changed the internal map from an XmlElement to a string.  However, the outer XML of imports can be duplicated because it can contain a property or a relative path.  This map could contain duplicates and the pre-processor would process the same import over and over until a stack overflow occurred.

This fix restores the mapping of XmlElements and adds the implicit imports to the mapping after their nodes are created.

I also added a unit test for this case.

Fixes #1893