### PR TITLE
Mark public API in Conversion and Engine as Obsolete

### DIFF
--- a/ref/net46/Microsoft.Build.Conversion.Core/Microsoft.Build.Conversion.Core.cs
+++ b/ref/net46/Microsoft.Build.Conversion.Core/Microsoft.Build.Conversion.Core.cs
@@ -1,5 +1,6 @@
 namespace Microsoft.Build.Conversion
 {
+    [System.ObsoleteAttribute("The ProjectFileConverter class is deprecated.")]
     public sealed partial class ProjectFileConverter
     {
         public ProjectFileConverter() { }

--- a/ref/net46/Microsoft.Build.Engine/Microsoft.Build.Engine.cs
+++ b/ref/net46/Microsoft.Build.Engine/Microsoft.Build.Engine.cs
@@ -1,6 +1,7 @@
 namespace Microsoft.Build.BuildEngine
 {
     [System.Diagnostics.DebuggerDisplayAttribute("BuildItem (Name = { Name }, Include = { Include }, FinalItemSpec = { FinalItemSpec }, Condition = { Condition } )")]
+    [System.ObsoleteAttribute]
     public partial class BuildItem
     {
         public BuildItem(string itemName, Microsoft.Build.Framework.ITaskItem taskItem) { }
@@ -25,6 +26,7 @@ namespace Microsoft.Build.BuildEngine
         public void SetMetadata(string metadataName, string metadataValue, bool treatMetadataValueAsLiteral) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("BuildItemGroup (Count = { Count }, Condition = { Condition })")]
+    [System.ObsoleteAttribute]
     public partial class BuildItemGroup : System.Collections.IEnumerable
     {
         public BuildItemGroup() { }
@@ -41,6 +43,7 @@ namespace Microsoft.Build.BuildEngine
         public void RemoveItemAt(int index) { }
         public Microsoft.Build.BuildEngine.BuildItem[] ToArray() { throw null; }
     }
+    [System.ObsoleteAttribute]
     public partial class BuildItemGroupCollection : System.Collections.ICollection, System.Collections.IEnumerable
     {
         internal BuildItemGroupCollection() { }
@@ -51,6 +54,7 @@ namespace Microsoft.Build.BuildEngine
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("BuildProperty (Name = { Name }, Value = { Value }, FinalValue = { FinalValue }, Condition = { Condition })")]
+    [System.ObsoleteAttribute]
     public partial class BuildProperty
     {
         public BuildProperty(string propertyName, string propertyValue) { }
@@ -64,6 +68,7 @@ namespace Microsoft.Build.BuildEngine
         public override string ToString() { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("BuildPropertyGroup (Count = { Count }, Condition = { Condition })")]
+    [System.ObsoleteAttribute]
     public partial class BuildPropertyGroup : System.Collections.IEnumerable
     {
         public BuildPropertyGroup() { }
@@ -83,6 +88,7 @@ namespace Microsoft.Build.BuildEngine
         public void SetProperty(string propertyName, string propertyValue) { }
         public void SetProperty(string propertyName, string propertyValue, bool treatPropertyValueAsLiteral) { }
     }
+    [System.ObsoleteAttribute]
     public partial class BuildPropertyGroupCollection : System.Collections.ICollection, System.Collections.IEnumerable
     {
         internal BuildPropertyGroupCollection() { }
@@ -93,11 +99,13 @@ namespace Microsoft.Build.BuildEngine
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
     }
     [System.FlagsAttribute]
+    [System.ObsoleteAttribute]
     public enum BuildSettings
     {
         DoNotResetPreviouslyBuiltTargets = 1,
         None = 0,
     }
+    [System.ObsoleteAttribute]
     public partial class BuildTask
     {
         internal BuildTask() { }
@@ -114,8 +122,11 @@ namespace Microsoft.Build.BuildEngine
         public void SetParameterValue(string parameterName, string parameterValue) { }
         public void SetParameterValue(string parameterName, string parameterValue, bool treatParameterValueAsLiteral) { }
     }
+    [System.ObsoleteAttribute]
     public delegate void ColorResetter();
+    [System.ObsoleteAttribute]
     public delegate void ColorSetter(System.ConsoleColor color);
+    [System.ObsoleteAttribute]
     public partial class ConfigurableForwardingLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
     {
         public ConfigurableForwardingLogger() { }
@@ -128,6 +139,7 @@ namespace Microsoft.Build.BuildEngine
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
         public virtual void Shutdown() { }
     }
+    [System.ObsoleteAttribute]
     public partial class ConsoleLogger : Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
     {
         public ConsoleLogger() { }
@@ -155,6 +167,7 @@ namespace Microsoft.Build.BuildEngine
         public void TaskStartedHandler(object sender, Microsoft.Build.Framework.TaskStartedEventArgs e) { }
         public void WarningHandler(object sender, Microsoft.Build.Framework.BuildWarningEventArgs e) { }
     }
+    [System.ObsoleteAttribute]
     public partial class DistributedFileLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
     {
         public DistributedFileLogger() { }
@@ -208,6 +221,7 @@ namespace Microsoft.Build.BuildEngine
         public void UnloadProject(Microsoft.Build.BuildEngine.Project project) { }
         public void UnregisterAllLoggers() { }
     }
+    [System.ObsoleteAttribute]
     public partial class FileLogger : Microsoft.Build.BuildEngine.ConsoleLogger
     {
         public FileLogger() { }
@@ -215,6 +229,7 @@ namespace Microsoft.Build.BuildEngine
         public override void Initialize(Microsoft.Build.Framework.IEventSource eventSource, int nodeCount) { }
         public override void Shutdown() { }
     }
+    [System.ObsoleteAttribute]
     public partial class Import
     {
         internal Import() { }
@@ -223,6 +238,7 @@ namespace Microsoft.Build.BuildEngine
         public bool IsImported { get { throw null; } }
         public string ProjectPath { get { throw null; } set { } }
     }
+    [System.ObsoleteAttribute]
     public partial class ImportCollection : System.Collections.ICollection, System.Collections.IEnumerable
     {
         internal ImportCollection() { }
@@ -235,6 +251,7 @@ namespace Microsoft.Build.BuildEngine
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public void RemoveImport(Microsoft.Build.BuildEngine.Import importToRemove) { }
     }
+    [System.ObsoleteAttribute]
     public sealed partial class InternalLoggerException : System.Exception
     {
         public InternalLoggerException() { }
@@ -247,6 +264,7 @@ namespace Microsoft.Build.BuildEngine
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.ObsoleteAttribute]
     public sealed partial class InvalidProjectFileException : System.Exception
     {
         public InvalidProjectFileException() { }
@@ -267,6 +285,7 @@ namespace Microsoft.Build.BuildEngine
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.ObsoleteAttribute]
     public partial class InvalidToolsetDefinitionException : System.Exception
     {
         public InvalidToolsetDefinitionException() { }
@@ -279,11 +298,13 @@ namespace Microsoft.Build.BuildEngine
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.ObsoleteAttribute]
     public partial class LocalNode
     {
         internal LocalNode() { }
         public static void StartLocalNodeServer(int nodeNumber) { }
     }
+    [System.ObsoleteAttribute]
     public partial class LoggerDescription
     {
         public LoggerDescription(string loggerClassName, string loggerAssemblyName, string loggerAssemblyFile, string loggerSwitchParameters, Microsoft.Build.Framework.LoggerVerbosity verbosity) { }
@@ -367,27 +388,32 @@ namespace Microsoft.Build.BuildEngine
         public void SetProperty(string propertyName, string propertyValue, string condition, Microsoft.Build.BuildEngine.PropertyPosition position, bool treatPropertyValueAsLiteral) { }
     }
     [System.FlagsAttribute]
+    [System.ObsoleteAttribute]
     public enum ProjectLoadSettings
     {
         IgnoreMissingImports = 1,
         None = 0,
     }
+    [System.ObsoleteAttribute]
     public enum PropertyPosition
     {
         UseExistingOrCreateAfterLastImport = 1,
         UseExistingOrCreateAfterLastPropertyGroup = 0,
     }
+    [System.ObsoleteAttribute]
     public sealed partial class RemoteErrorException : System.Exception
     {
         internal RemoteErrorException() { }
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter=true)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.ObsoleteAttribute]
     public static partial class SolutionWrapperProject
     {
         public static string Generate(string solutionPath, string toolsVersionOverride, Microsoft.Build.Framework.BuildEventContext projectBuildEventContext) { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("Target (Name = { Name }, Condition = { Condition })")]
+    [System.ObsoleteAttribute]
     public partial class Target : System.Collections.IEnumerable
     {
         internal Target() { }
@@ -401,6 +427,7 @@ namespace Microsoft.Build.BuildEngine
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public void RemoveTask(Microsoft.Build.BuildEngine.BuildTask taskElement) { }
     }
+    [System.ObsoleteAttribute]
     public partial class TargetCollection : System.Collections.ICollection, System.Collections.IEnumerable
     {
         internal TargetCollection() { }
@@ -414,6 +441,7 @@ namespace Microsoft.Build.BuildEngine
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public void RemoveTarget(Microsoft.Build.BuildEngine.Target targetToRemove) { }
     }
+    [System.ObsoleteAttribute]
     public partial class Toolset
     {
         public Toolset(string toolsVersion, string toolsPath) { }
@@ -423,6 +451,7 @@ namespace Microsoft.Build.BuildEngine
         public string ToolsVersion { get { throw null; } }
         public Microsoft.Build.BuildEngine.Toolset Clone() { throw null; }
     }
+    [System.ObsoleteAttribute]
     public partial class ToolsetCollection : System.Collections.Generic.ICollection<Microsoft.Build.BuildEngine.Toolset>, System.Collections.Generic.IEnumerable<Microsoft.Build.BuildEngine.Toolset>, System.Collections.IEnumerable
     {
         internal ToolsetCollection() { }
@@ -440,12 +469,14 @@ namespace Microsoft.Build.BuildEngine
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }
     [System.FlagsAttribute]
+    [System.ObsoleteAttribute]
     public enum ToolsetDefinitionLocations
     {
         ConfigurationFile = 1,
         None = 0,
         Registry = 2,
     }
+    [System.ObsoleteAttribute]
     public partial class UsingTask
     {
         internal UsingTask() { }
@@ -455,6 +486,7 @@ namespace Microsoft.Build.BuildEngine
         public bool IsImported { get { throw null; } }
         public string TaskName { get { throw null; } }
     }
+    [System.ObsoleteAttribute]
     public partial class UsingTaskCollection : System.Collections.ICollection, System.Collections.IEnumerable
     {
         internal UsingTaskCollection() { }
@@ -465,9 +497,11 @@ namespace Microsoft.Build.BuildEngine
         public void CopyTo(System.Array array, int index) { }
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
     }
+    [System.ObsoleteAttribute]
     public static partial class Utilities
     {
         public static string Escape(string unescapedExpression) { throw null; }
     }
+    [System.ObsoleteAttribute]
     public delegate void WriteHandler(string message);
 }

--- a/src/Deprecated/Conversion/ProjectFileConverter.cs
+++ b/src/Deprecated/Conversion/ProjectFileConverter.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Build.Conversion
     /// .NET 2002 or 2003 to MSBuild format (for Whidbey).
     /// </summary>
     /// <owner>rgoel</owner>
+    [Obsolete("The ProjectFileConverter class is deprecated.")]
     public sealed class ProjectFileConverter
     {
         // The filename of the old VS7/Everett project file.

--- a/src/Deprecated/Engine/Engine/BuildTask.cs
+++ b/src/Deprecated/Engine/Engine/BuildTask.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class represents a single task.
     /// </summary>
     /// <owner>rgoel</owner>
+    [Obsolete]
     public class BuildTask
     {
         #region Member Data

--- a/src/Deprecated/Engine/Engine/Engine.cs
+++ b/src/Deprecated/Engine/Engine/Engine.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Build.BuildEngine
     /// <summary>
     /// Flags for controlling the build.
     /// </summary>
+    [Obsolete]
     [Flags]
     public enum BuildSettings
     {
@@ -50,6 +51,7 @@ namespace Microsoft.Build.BuildEngine
     /// <summary>
     /// Flags for controlling the project load.
     /// </summary>
+    [Obsolete]
     [Flags]
     public enum ProjectLoadSettings
     {
@@ -67,6 +69,7 @@ namespace Microsoft.Build.BuildEngine
     /// <summary>
     /// Flags for controlling the toolset initialization.
     /// </summary>
+    [Obsolete]
     [Flags]
     public enum ToolsetDefinitionLocations
     {

--- a/src/Deprecated/Engine/Engine/Import.cs
+++ b/src/Deprecated/Engine/Engine/Import.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class represents a single Import element in a project file
     /// </summary>
     /// <owner>LukaszG</owner>
+    [Obsolete]
     public class Import : IItemPropertyGrouping
     {
         #region Properties

--- a/src/Deprecated/Engine/Engine/ImportCollection.cs
+++ b/src/Deprecated/Engine/Engine/ImportCollection.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class represents a collection of all Import elements in a given project file
     /// </summary>
     /// <owner>LukaszG</owner>
+    [Obsolete]
     public class ImportCollection : IEnumerable, ICollection
     {
         #region Fields

--- a/src/Deprecated/Engine/Engine/Project.cs
+++ b/src/Deprecated/Engine/Engine/Project.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Build.BuildEngine
     /// <summary>
     /// The position of a property to be set inside a project file.
     /// </summary>
+    [Obsolete]
     public enum PropertyPosition
     {
         /// <summary>

--- a/src/Deprecated/Engine/Engine/Target.cs
+++ b/src/Deprecated/Engine/Engine/Target.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class represents a single target in its parent project.
     /// </summary>
     [DebuggerDisplay("Target (Name = { Name }, Condition = { Condition })")]
+    [Obsolete]
     public class Target : IEnumerable
     {
         #region Enums

--- a/src/Deprecated/Engine/Engine/TargetCollection.cs
+++ b/src/Deprecated/Engine/Engine/TargetCollection.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Build.BuildEngine
     /// all the imported Targets as well as the ones in the main project file.
     /// </summary>
     /// <owner>rgoel</owner>
+    [Obsolete]
     public class TargetCollection : IEnumerable, ICollection
     {
         #region Member Data

--- a/src/Deprecated/Engine/Engine/Toolset.cs
+++ b/src/Deprecated/Engine/Engine/Toolset.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Build.BuildEngine
     /// <summary>
     /// Aggregation of a toolset version (eg. "2.0"), tools path, and optional set of associated properties
     /// </summary>
+    [Obsolete]
     public class Toolset
     {
         // Name of the tools version

--- a/src/Deprecated/Engine/Engine/ToolsetCollection.cs
+++ b/src/Deprecated/Engine/Engine/ToolsetCollection.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Build.BuildEngine
     /// NOTE: This collection does not support ICollection&lt;Toolset&gt;'s
     /// Remove or Clear methods, and calls to these will generate exceptions.
     /// </summary>
+    [Obsolete]
     public class ToolsetCollection : ICollection<Toolset>
     {
         // the parent engine 

--- a/src/Deprecated/Engine/Engine/UsingTask.cs
+++ b/src/Deprecated/Engine/Engine/UsingTask.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class represents a single UsingTask element in a project file
     /// </summary>
     /// <owner>LukaszG</owner>
+    [Obsolete]
     public class UsingTask
     {
         #region Properties

--- a/src/Deprecated/Engine/Engine/UsingTaskCollection.cs
+++ b/src/Deprecated/Engine/Engine/UsingTaskCollection.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class represents a collection of all UsingTask elements in a given project file.
     /// </summary>
     /// <owner>LukaszG</owner>
+    [Obsolete]
     public class UsingTaskCollection : IEnumerable, ICollection
     {
         #region Properties

--- a/src/Deprecated/Engine/Engine/Utilities.cs
+++ b/src/Deprecated/Engine/Engine/Utilities.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class contains utility methods for the MSBuild engine.
     /// </summary>
     /// <owner>RGoel</owner>
+    [Obsolete]
     static public class Utilities
     {
         private readonly static Regex singlePropertyRegex = new Regex(@"^\$\(([^\$\(\)]*)\)$");

--- a/src/Deprecated/Engine/Errors/InternalLoggerException.cs
+++ b/src/Deprecated/Engine/Errors/InternalLoggerException.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Build.BuildEngine
     /// </remarks>
     /// <owner>SumedhK</owner>
     [Serializable]
+    [Obsolete]
     public sealed class InternalLoggerException : Exception
     {
         #region Unusable constructors

--- a/src/Deprecated/Engine/Errors/InvalidProjectFileException.cs
+++ b/src/Deprecated/Engine/Errors/InvalidProjectFileException.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Build.BuildEngine
     /// </remarks>
     /// <owner>RGoel</owner>
     [Serializable]
+    [Obsolete]
     public sealed class InvalidProjectFileException : Exception
     {
         #region Basic constructors

--- a/src/Deprecated/Engine/Errors/InvalidToolsetDefinitionException.cs
+++ b/src/Deprecated/Engine/Errors/InvalidToolsetDefinitionException.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.BuildEngine
     /// Exception subclass that ToolsetReaders should throw.
     /// </summary>
     [Serializable]
+    [Obsolete]
     public class InvalidToolsetDefinitionException : Exception
     {
         /// <summary>

--- a/src/Deprecated/Engine/Errors/RemoteErrorException.cs
+++ b/src/Deprecated/Engine/Errors/RemoteErrorException.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class is used to wrap exceptions that occur on a different node
     /// </summary>
     [Serializable]
+    [Obsolete]
     public sealed class RemoteErrorException : Exception
     {
         internal RemoteErrorException(string message, Exception innerException, BuildEventContext buildEventContext)

--- a/src/Deprecated/Engine/Items/BuildItem.cs
+++ b/src/Deprecated/Engine/Items/BuildItem.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Build.BuildEngine
     /// </summary>
     /// <owner>RGoel</owner>
     [DebuggerDisplay("BuildItem (Name = { Name }, Include = { Include }, FinalItemSpec = { FinalItemSpec }, Condition = { Condition } )")]
+    [Obsolete]
     public class BuildItem
     {
         #region Member Data

--- a/src/Deprecated/Engine/Items/BuildItemGroup.cs
+++ b/src/Deprecated/Engine/Items/BuildItemGroup.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Build.BuildEngine
     /// or it may just be a virtual BuildItemGroup (e.g., the evaluated items).
     /// </summary>
     [DebuggerDisplay("BuildItemGroup (Count = { Count }, Condition = { Condition })")]
+    [Obsolete]
     public class BuildItemGroup : IItemPropertyGrouping, IEnumerable
     {
         #region Member Data

--- a/src/Deprecated/Engine/Items/BuildItemGroupCollection.cs
+++ b/src/Deprecated/Engine/Items/BuildItemGroupCollection.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Build.BuildEngine
     /// doesn't maintain any BuildPropertyGroup state on its own.
     /// </summary>
     /// <owner>DavidLe</owner>
+    [Obsolete]
     public class BuildItemGroupCollection : IEnumerable, ICollection
     {
         #region Member Data

--- a/src/Deprecated/Engine/LocalProvider/LocalNode.cs
+++ b/src/Deprecated/Engine/LocalProvider/LocalNode.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Build.BuildEngine
     /// with the local node provider.
     /// Wraps a Node.
     /// </summary>
+    [Obsolete]
     public class LocalNode
     {
         #region Static Constructors

--- a/src/Deprecated/Engine/Logging/ConsoleLogger.cs
+++ b/src/Deprecated/Engine/Logging/ConsoleLogger.cs
@@ -20,17 +20,20 @@ namespace Microsoft.Build.BuildEngine
     /// the console window or the IDE build window.
     /// </summary>
     /// <param name="message"></param>
+    [Obsolete]
     public delegate void WriteHandler(string message);
 
     /// <summary>
     /// Type of delegate used to set console color.
     /// </summary>
     /// <param name="color">Text color</param>
+    [Obsolete]
     public delegate void ColorSetter(ConsoleColor color);
 
     /// <summary>
     /// Type of delegate used to reset console color.
     /// </summary>
+    [Obsolete]
     public delegate void ColorResetter();
 
     #endregion
@@ -42,6 +45,7 @@ namespace Microsoft.Build.BuildEngine
     /// either SerialConsoleLogger or ParallelConsoleLogger.
     /// </summary>
     /// <remarks>This class is not thread safe.</remarks>
+    [Obsolete]
     public class ConsoleLogger : INodeLogger
     {
         private BaseConsoleLogger consoleLogger;

--- a/src/Deprecated/Engine/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Deprecated/Engine/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Build.BuildEngine
     /// Logger that forwards events to a central logger (e.g ConsoleLogger)
     /// residing on the parent node.
     /// </summary>
+    [Obsolete]
     public class ConfigurableForwardingLogger: IForwardingLogger
     {
         #region Constructors

--- a/src/Deprecated/Engine/Logging/DistributedLoggers/DistributedFileLogger.cs
+++ b/src/Deprecated/Engine/Logging/DistributedLoggers/DistributedFileLogger.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Build.BuildEngine
     /// <summary>
     /// This class will create a text file which will contain the build log for that node
     /// </summary>
+    [Obsolete]
     public class DistributedFileLogger : IForwardingLogger
     {
         #region Constructors

--- a/src/Deprecated/Engine/Logging/FileLogger.cs
+++ b/src/Deprecated/Engine/Logging/FileLogger.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Build.BuildEngine
     /// complex -- for example, there is parameter parsing in this class, plus in BaseConsoleLogger. However we have
     /// to derive FileLogger from ConsoleLogger because it shipped that way in Whidbey.
     /// </remarks>
+    [Obsolete]
     public class FileLogger : ConsoleLogger
     {
         #region Constructors

--- a/src/Deprecated/Engine/Logging/LoggerDescription.cs
+++ b/src/Deprecated/Engine/Logging/LoggerDescription.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Build.BuildEngine
     /// can be used to instantiate the logger and can be serialized to be passed between different
     /// processes.
     /// </summary>
+    [Obsolete]
     public class LoggerDescription
     {
         #region Constructor

--- a/src/Deprecated/Engine/Microsoft.Build.Engine.csproj
+++ b/src/Deprecated/Engine/Microsoft.Build.Engine.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>Microsoft.Build.Engine</AssemblyName>
     <RootNamespace>Microsoft.Build.Engine</RootNamespace>
-    <NoWarn>$(NoWarn);618</NoWarn>
+    <NoWarn>$(NoWarn);618;612</NoWarn>
     <GenerateReferenceAssemblySources>true</GenerateReferenceAssemblySources>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
@@ -199,20 +199,16 @@
     <Compile Include="Shared\XMakeAttributes.cs" />
     <Compile Include="Shared\XMakeElements.cs" />
     <Compile Include="Shared\XmlUtilities.cs" />
-
     <!-- Resource Files -->
-
     <EmbeddedResource Include="Resources\Strings.resx">
       <LogicalName>$(AssemblyName).Strings.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-
     <EmbeddedResource Include="..\..\Shared\Resources\Strings.shared.resx">
       <Link>Resources\Strings.shared.resx</Link>
       <LogicalName>$(AssemblyName).Strings.shared.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    
     <!-- Assemblies Files we depend on -->
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Deprecated/Engine/Properties/BuildProperty.cs
+++ b/src/Deprecated/Engine/Properties/BuildProperty.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Build.BuildEngine
     /// </summary>
     /// <owner>rgoel</owner>
     [DebuggerDisplay("BuildProperty (Name = { Name }, Value = { Value }, FinalValue = { FinalValue }, Condition = { Condition })")]
+    [Obsolete]
     public class BuildProperty
     {
         #region Member Data

--- a/src/Deprecated/Engine/Properties/BuildPropertyGroup.cs
+++ b/src/Deprecated/Engine/Properties/BuildPropertyGroup.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Build.BuildEngine
     /// </summary>
     /// <owner>RGoel</owner>
     [DebuggerDisplay("BuildPropertyGroup (Count = { Count }, Condition = { Condition })")]
+    [Obsolete]
     public class BuildPropertyGroup : IItemPropertyGrouping, IEnumerable
     {
         #region Member Data

--- a/src/Deprecated/Engine/Properties/BuildPropertyGroupCollection.cs
+++ b/src/Deprecated/Engine/Properties/BuildPropertyGroupCollection.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Build.BuildEngine
     /// doesn't maintain any BuildPropertyGroup state on its own.
     /// </summary>
     /// <owner>DavidLe</owner>
+    [Obsolete]
     public class BuildPropertyGroupCollection : ICollection, IEnumerable
     {
         #region Member Data

--- a/src/Deprecated/Engine/Solution/SolutionWrapperProject.cs
+++ b/src/Deprecated/Engine/Solution/SolutionWrapperProject.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Build.BuildEngine
     /// This class is used to generate an MSBuild wrapper project for a solution file or standalone VC project.
     /// </summary>
     /// <owner>LukaszG, RGoel</owner>
+    [Obsolete]
     static public class SolutionWrapperProject
     {
         private const string webProjectOverrideFolder = "_PublishedWebsites";

--- a/src/MSBuild.sln
+++ b/src/MSBuild.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.0
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.Framework", "Framework\Microsoft.Build.Framework.csproj", "{571F09DB-A81A-4444-945C-6F7B530054CD}"
 EndProject
@@ -56,10 +56,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskWithDependency", "..\Sa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.LocalizationTasks", "..\build\LocalizationTasks\Microsoft.Build.LocalizationTasks.csproj", "{06347A6C-32A4-4218-A930-0A22699C726C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.Engine", "Deprecated\Engine\Microsoft.Build.Engine.csproj", "{D21C4BF9-E131-4ACB-8960-794797F19A39}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.Conversion", "Deprecated\Conversion\Microsoft.Build.Conversion.csproj", "{5274C277-F122-4A44-B7A0-00A1B3F39803}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGetPackages", "NuGetPackages", "{B3A6667F-80C1-4264-874B-60AF572F641F}"
 	ProjectSection(SolutionItems) = preProject
 		..\build\NuGetPackages\CreateNuGetPackages.proj = ..\build\NuGetPackages\CreateNuGetPackages.proj
@@ -71,8 +67,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGetPackages", "NuGetPacka
 		..\build\NuGetPackages\Microsoft.Build.Tasks.Core.nuspec = ..\build\NuGetPackages\Microsoft.Build.Tasks.Core.nuspec
 		..\build\NuGetPackages\Microsoft.Build.Utilities.Core.nuspec = ..\build\NuGetPackages\Microsoft.Build.Utilities.Core.nuspec
 	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deprecated", "Deprecated", "{64606C1B-CF86-49CA-8050-B66E7D5C7CB8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlFileLogger", "..\Samples\XmlFileLogger\XmlFileLogger.csproj", "{7D8BA0AA-B715-4646-A2F8-844DB2F15C81}"
 EndProject
@@ -781,82 +775,6 @@ Global
 		{06347A6C-32A4-4218-A930-0A22699C726C}.Release-NetCore|x64.Build.0 = Release-NetCore|Any CPU
 		{06347A6C-32A4-4218-A930-0A22699C726C}.Release-NetCore|x86.ActiveCfg = Release-NetCore|Any CPU
 		{06347A6C-32A4-4218-A930-0A22699C726C}.Release-NetCore|x86.Build.0 = Release-NetCore|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug|x64.ActiveCfg = Debug|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug|x64.Build.0 = Debug|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug|x86.ActiveCfg = Debug|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug|x86.Build.0 = Debug|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-MONO|Any CPU.ActiveCfg = Debug-MONO|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-MONO|Any CPU.Build.0 = Debug-MONO|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-MONO|x64.ActiveCfg = Debug-MONO|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-MONO|x64.Build.0 = Debug-MONO|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-MONO|x86.ActiveCfg = Debug-MONO|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-NetCore|Any CPU.ActiveCfg = Debug-NetCore|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-NetCore|Any CPU.Build.0 = Debug-NetCore|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-NetCore|x64.ActiveCfg = Debug-NetCore|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-NetCore|x64.Build.0 = Debug-NetCore|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Debug-NetCore|x86.ActiveCfg = Debug-NetCore|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Port-Progress|Any CPU.ActiveCfg = Port-Progress|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Port-Progress|Any CPU.Build.0 = Port-Progress|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Port-Progress|x64.ActiveCfg = Port-Progress|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Port-Progress|x64.Build.0 = Port-Progress|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Port-Progress|x86.ActiveCfg = Port-Progress|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Port-Progress|x86.Build.0 = Port-Progress|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release|x64.ActiveCfg = Release|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release|x64.Build.0 = Release|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release|x86.ActiveCfg = Release|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release|x86.Build.0 = Release|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-MONO|Any CPU.ActiveCfg = Release-MONO|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-MONO|Any CPU.Build.0 = Release-MONO|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-MONO|x64.ActiveCfg = Release-MONO|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-MONO|x64.Build.0 = Release-MONO|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-MONO|x86.ActiveCfg = Release-MONO|x86
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-NetCore|Any CPU.ActiveCfg = Release-NetCore|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-NetCore|Any CPU.Build.0 = Release-NetCore|Any CPU
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-NetCore|x64.ActiveCfg = Release-NetCore|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-NetCore|x64.Build.0 = Release-NetCore|x64
-		{D21C4BF9-E131-4ACB-8960-794797F19A39}.Release-NetCore|x86.ActiveCfg = Release-NetCore|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug|x64.ActiveCfg = Debug|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug|x64.Build.0 = Debug|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug|x86.ActiveCfg = Debug|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug|x86.Build.0 = Debug|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-MONO|Any CPU.ActiveCfg = Debug-MONO|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-MONO|Any CPU.Build.0 = Debug-MONO|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-MONO|x64.ActiveCfg = Debug-MONO|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-MONO|x64.Build.0 = Debug-MONO|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-MONO|x86.ActiveCfg = Debug-MONO|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-NetCore|Any CPU.ActiveCfg = Debug-NetCore|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-NetCore|Any CPU.Build.0 = Debug-NetCore|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-NetCore|x64.ActiveCfg = Debug-NetCore|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-NetCore|x64.Build.0 = Debug-NetCore|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Debug-NetCore|x86.ActiveCfg = Debug-NetCore|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Port-Progress|Any CPU.ActiveCfg = Port-Progress|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Port-Progress|Any CPU.Build.0 = Port-Progress|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Port-Progress|x64.ActiveCfg = Port-Progress|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Port-Progress|x64.Build.0 = Port-Progress|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Port-Progress|x86.ActiveCfg = Port-Progress|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Port-Progress|x86.Build.0 = Port-Progress|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release|x64.ActiveCfg = Release|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release|x64.Build.0 = Release|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release|x86.ActiveCfg = Release|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release|x86.Build.0 = Release|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-MONO|Any CPU.ActiveCfg = Release-MONO|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-MONO|Any CPU.Build.0 = Release-MONO|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-MONO|x64.ActiveCfg = Release-MONO|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-MONO|x64.Build.0 = Release-MONO|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-MONO|x86.ActiveCfg = Release-MONO|x86
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-NetCore|Any CPU.ActiveCfg = Release-NetCore|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-NetCore|Any CPU.Build.0 = Release-NetCore|Any CPU
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-NetCore|x64.ActiveCfg = Release-NetCore|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-NetCore|x64.Build.0 = Release-NetCore|x64
-		{5274C277-F122-4A44-B7A0-00A1B3F39803}.Release-NetCore|x86.ActiveCfg = Release-NetCore|x86
 		{7D8BA0AA-B715-4646-A2F8-844DB2F15C81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7D8BA0AA-B715-4646-A2F8-844DB2F15C81}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D8BA0AA-B715-4646-A2F8-844DB2F15C81}.Debug|x64.ActiveCfg = Debug|x64
@@ -909,8 +827,6 @@ Global
 		{11B5D53E-90E4-4BD5-9883-B5921F7DE854} = {760FF85D-8BEB-4992-8095-A9678F88FD47}
 		{9EAE36C3-50CD-49A6-9CA2-94649125DCD1} = {760FF85D-8BEB-4992-8095-A9678F88FD47}
 		{09EEB69D-817E-4B33-9F61-24FC9DA5B3D4} = {760FF85D-8BEB-4992-8095-A9678F88FD47}
-		{D21C4BF9-E131-4ACB-8960-794797F19A39} = {64606C1B-CF86-49CA-8050-B66E7D5C7CB8}
-		{5274C277-F122-4A44-B7A0-00A1B3F39803} = {64606C1B-CF86-49CA-8050-B66E7D5C7CB8}
 		{7D8BA0AA-B715-4646-A2F8-844DB2F15C81} = {760FF85D-8BEB-4992-8095-A9678F88FD47}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This marks every public type as Obsolete and removes Microsoft.Build.Conversion.Core and Microsoft.Build.Engine from our solution file.  This makes it so you don't see these deprecated types in VS.

In the next major release, we can look at not shipping these assemblies any more.

Closes #1651