### PR TITLE
PVS-Studio: fixed potential vulnerabilities

### DIFF
--- a/src/Deprecated/Engine/Engine/Utilities.cs
+++ b/src/Deprecated/Engine/Engine/Utilities.cs
@@ -237,11 +237,11 @@ namespace Microsoft.Build.BuildEngine
             BuildEventContext buildEventContext
         )
         {
-            ErrorUtilities.VerifyThrow((conditionAttribute != null) || (condition.Length == 0), 
+            ErrorUtilities.VerifyThrow((conditionAttribute != null) || (string.IsNullOrEmpty(condition)),
                 "If condition is non-empty, you must provide the XML node representing the condition.");
 
             // An empty condition is equivalent to a "true" condition.
-            if ((null == condition) || (condition.Length == 0))
+            if (string.IsNullOrEmpty(condition))
             {
                 return true;
             }

--- a/src/Tasks/AxReference.cs
+++ b/src/Tasks/AxReference.cs
@@ -77,7 +77,10 @@ namespace Microsoft.Build.Tasks
 
             var axImp = new ResolveComReference.AxImp();
 
-            axImp.ActiveXControlName = ReferenceInfo.strippedTypeLibPath;
+            if (ReferenceInfo != null)
+            {
+                axImp.ActiveXControlName = ReferenceInfo.strippedTypeLibPath;
+            }
 
             axImp.BuildEngine = BuildEngine;
             axImp.ToolPath = ToolPath;

--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -1433,7 +1433,8 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         continue;
                     }
 
-                    if ((packageFileSource != null) && (packageFileDestination != null))
+                    if ((packageFileSource != null) && (packageFileDestination != null) &&
+                        (packageFileName != null))
                     {
                         // Calculate the hash of this file and add it to the PackageFileNode
                         if (!AddVerificationInformation(packageFileNode, packageFileSource.Value, packageFileName.Value, builder, settings, _results))

--- a/src/Tasks/CommandLineBuilderExtension.cs
+++ b/src/Tasks/CommandLineBuilderExtension.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Build.Tasks
             ErrorUtilities.VerifyThrow
             (
                 treatAsFlags == null ||
-                (metadataNames.Length == treatAsFlags.Length),
+                (metadataNames != null && metadataNames.Length == treatAsFlags.Length),
                 "metadataNames and treatAsFlags should have the same length."
             );
 

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -2873,7 +2873,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         private static void ExtractSdkDiskRootsFromEnvironment(List<string> diskRoots, string directoryRoots)
         {
-            if (!String.IsNullOrEmpty(directoryRoots))
+            if (diskRoots != null && !String.IsNullOrEmpty(directoryRoots))
             {
                 string[] splitRoots = directoryRoots.Split(s_diskRootSplitChars, StringSplitOptions.RemoveEmptyEntries);
                 ErrorUtilities.DebugTraceMessage("ExtractSdkDiskRootsFromEnvironment", "DiskRoots from Registry '{0}'", String.Join(";", splitRoots));


### PR DESCRIPTION
[V3095](https://www.viva64.com/en/w/V3095/) The 'condition' object was used before it was verified against null. Check lines: 240, 244. Microsoft.Build.Engine Utilities.cs 240
[V3095](https://www.viva64.com/en/w/V3095/) The 'ReferenceInfo' object was used before it was verified against null. Check lines: 80, 90. Microsoft.Build.Tasks AxReference.cs 80
[V3095](https://www.viva64.com/en/w/V3095/) The 'packageFileName' object was used before it was verified against null. Check lines: 1439, 1448. Microsoft.Build.Tasks BootstrapperBuilder.cs 1439
[V3095](https://www.viva64.com/en/w/V3095/) The 'metadataNames' object was used before it was verified against null. Check lines: 243, 253. Microsoft.Build.Tasks CommandLineBuilderExtension.cs 243
[V3095](https://www.viva64.com/en/w/V3095/) The 'diskRoots' object was used before it was verified against null. Check lines: 2880, 2883. Microsoft.Build.Utilities ToolLocationHelper.cs 2880

V3095 -> CWE-476 (Medium) NULL Pointer Dereference