### PR TITLE
Implement ability for project properties to suppress and elevate warnings

### DIFF
--- a/src/Build.UnitTests/BackEnd/EventSourceSink_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/EventSourceSink_Tests.cs
@@ -288,6 +288,10 @@ namespace Microsoft.Build.UnitTests.Logging
             Assert.Equal(expectedBuildEvent.BuildEventContext, actualBuildEvent.BuildEventContext);
             Assert.Equal(expectedBuildEvent.ThreadId, actualBuildEvent.ThreadId);
             Assert.Equal(expectedBuildEvent.Timestamp, actualBuildEvent.Timestamp);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.ProjectFinished);
+
+            Assert.Equal(0, eventSourceSink.WarningsAsErrorsByProject.Keys.Count);
         }
 
         /// <summary>
@@ -426,6 +430,10 @@ namespace Microsoft.Build.UnitTests.Logging
             Assert.Equal(expectedBuildEvent.Subcategory, actualBuildEvent.Subcategory);
             Assert.Equal(expectedBuildEvent.ThreadId, actualBuildEvent.ThreadId);
             Assert.Equal(expectedBuildEvent.Timestamp, actualBuildEvent.Timestamp);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.ProjectFinished);
+
+            Assert.Equal(0, eventSourceSink.WarningsAsMessagesByProject.Keys.Count);
         }
 
         /// <summary>
@@ -1178,7 +1186,10 @@ namespace Microsoft.Build.UnitTests.Logging
             /// <summary>
             /// Project Finished Event
             /// </summary>
-            private static ProjectFinishedEventArgs s_projectFinished = new ProjectFinishedEventArgs("message", "help", "ProjectFile", true);
+            private static ProjectFinishedEventArgs s_projectFinished = new ProjectFinishedEventArgs("message", "help", "ProjectFile", true)
+            {
+                BuildEventContext = s_buildWarning.BuildEventContext
+            };
 
             /// <summary>
             /// External Project Started Event

--- a/src/Build.UnitTests/BackEnd/EventSourceSink_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/EventSourceSink_Tests.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.BackEnd.Logging;
@@ -170,6 +171,7 @@ namespace Microsoft.Build.UnitTests.Logging
             Assert.IsType<BuildErrorEventArgs>(eventHandlerHelper.RaisedEvent);
         }
 
+
         /// <summary>
         /// Verifies that a warning is logged as a low importance message when it's warning code is specified.
         /// </summary>
@@ -229,6 +231,256 @@ namespace Microsoft.Build.UnitTests.Logging
                     "123",
                     "ABC",
                 },
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.Equal(expectedBuildEvent, eventHandlerHelper.RaisedEvent);
+        }
+
+        /// <summary>
+        /// Verifies that warnings are treated as an error for a particular project when codes are specified.
+        /// </summary>
+        [Fact]
+        public void TreatWarningsAsErrorByProjectWhenSpecified()
+        {
+            BuildWarningEventArgs expectedBuildEvent = RaiseEventHelper.Warning;
+
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsErrorsByProject = new Dictionary<int, ISet<string>>
+                {
+                    {
+                        RaiseEventHelper.Warning.BuildEventContext.ProjectInstanceId,
+                        new HashSet<string>
+                        {
+                            "123",
+                            expectedBuildEvent.Code,
+                            "ABC"
+                        }
+                    }
+                }
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.IsType<BuildErrorEventArgs>(eventHandlerHelper.RaisedEvent);
+
+            BuildErrorEventArgs actualBuildEvent = (BuildErrorEventArgs)eventHandlerHelper.RaisedEvent;
+
+            Assert.Equal(expectedBuildEvent.Code, actualBuildEvent.Code);
+            Assert.Equal(expectedBuildEvent.File, actualBuildEvent.File);
+            Assert.Equal(expectedBuildEvent.ProjectFile, actualBuildEvent.ProjectFile);
+            Assert.Equal(expectedBuildEvent.Subcategory, actualBuildEvent.Subcategory);
+            Assert.Equal(expectedBuildEvent.HelpKeyword, actualBuildEvent.HelpKeyword);
+            Assert.Equal(expectedBuildEvent.Message, actualBuildEvent.Message);
+            Assert.Equal(expectedBuildEvent.SenderName, actualBuildEvent.SenderName);
+            Assert.Equal(expectedBuildEvent.ColumnNumber, actualBuildEvent.ColumnNumber);
+            Assert.Equal(expectedBuildEvent.EndColumnNumber, actualBuildEvent.EndColumnNumber);
+            Assert.Equal(expectedBuildEvent.EndLineNumber, actualBuildEvent.EndLineNumber);
+            Assert.Equal(expectedBuildEvent.LineNumber, actualBuildEvent.LineNumber);
+            Assert.Equal(expectedBuildEvent.BuildEventContext, actualBuildEvent.BuildEventContext);
+            Assert.Equal(expectedBuildEvent.ThreadId, actualBuildEvent.ThreadId);
+            Assert.Equal(expectedBuildEvent.Timestamp, actualBuildEvent.Timestamp);
+        }
+
+        /// <summary>
+        /// Verifies that warnings are not treated as errors for a particular project even though a matching code was added for another project.
+        /// </summary>
+        [Fact]
+        public void NotTreatWarningsAsErrorByProjectWhenProjectNotSpecified()
+        {
+            BuildWarningEventArgs expectedBuildEvent = RaiseEventHelper.Warning;
+
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsErrorsByProject = new Dictionary<int, ISet<string>>
+                {
+                    {
+                        expectedBuildEvent.BuildEventContext.ProjectInstanceId + 100,
+                        new HashSet<string>
+                        {
+                            "123",
+                            expectedBuildEvent.Code,
+                            "ABC"
+                        }
+                    }
+                }
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.Equal(expectedBuildEvent, eventHandlerHelper.RaisedEvent);
+        }
+
+        /// <summary>
+        /// Verifies that warnings are not treated as errors for a particular project when a code does not match.
+        /// </summary>
+        [Fact]
+        public void NotTreatWarningsAsErrorByProjectWhenCodeNotSpecified()
+        {
+            BuildWarningEventArgs expectedBuildEvent = RaiseEventHelper.Warning;
+
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsErrorsByProject = new Dictionary<int, ISet<string>>
+                {
+                    {
+                        expectedBuildEvent.BuildEventContext.ProjectInstanceId,
+                        new HashSet<string>
+                        {
+                            "123",
+                            "ABC"
+                        }
+                    }
+                }
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.Equal(expectedBuildEvent, eventHandlerHelper.RaisedEvent);
+        }
+
+        /// <summary>
+        /// Verifies that all warnings are treated as errors for a particular project.
+        /// </summary>
+        [Fact]
+        public void TreatWarningsAsErrorByProjectWhenAllSpecified()
+        {
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsErrorsByProject = new Dictionary<int, ISet<string>>
+                {
+                    {
+                        RaiseEventHelper.Warning.BuildEventContext.ProjectInstanceId,
+                        new HashSet<string>()
+                    }
+                }
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.IsType<BuildErrorEventArgs>(eventHandlerHelper.RaisedEvent);
+        }
+
+        /// <summary>
+        /// Verifies that warnings are treated as messages for a particular project.
+        /// </summary>
+        [Fact]
+        public void TreatWarningsAsMessagesByProjectWhenSpecified()
+        {
+            BuildWarningEventArgs expectedBuildEvent = RaiseEventHelper.Warning;
+
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsMessagesByProject = new Dictionary<int, ISet<string>>
+                {
+                    {
+                        expectedBuildEvent.BuildEventContext.ProjectInstanceId,
+                        new HashSet<string>
+                        {
+                            "FOO",
+                            expectedBuildEvent.Code,
+                            "BAR"
+                        }
+                    }
+                }
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.IsType<BuildMessageEventArgs>(eventHandlerHelper.RaisedEvent);
+
+            BuildMessageEventArgs actualBuildEvent = (BuildMessageEventArgs)eventHandlerHelper.RaisedEvent;
+
+            Assert.Equal(expectedBuildEvent.BuildEventContext, actualBuildEvent.BuildEventContext);
+            Assert.Equal(expectedBuildEvent.Code, actualBuildEvent.Code);
+            Assert.Equal(expectedBuildEvent.ColumnNumber, actualBuildEvent.ColumnNumber);
+            Assert.Equal(expectedBuildEvent.EndColumnNumber, actualBuildEvent.EndColumnNumber);
+            Assert.Equal(expectedBuildEvent.EndLineNumber, actualBuildEvent.EndLineNumber);
+            Assert.Equal(expectedBuildEvent.File, actualBuildEvent.File);
+            Assert.Equal(expectedBuildEvent.HelpKeyword, actualBuildEvent.HelpKeyword);
+            Assert.Equal(MessageImportance.Low, actualBuildEvent.Importance);
+            Assert.Equal(expectedBuildEvent.LineNumber, actualBuildEvent.LineNumber);
+            Assert.Equal(expectedBuildEvent.Message, actualBuildEvent.Message);
+            Assert.Equal(expectedBuildEvent.ProjectFile, actualBuildEvent.ProjectFile);
+            Assert.Equal(expectedBuildEvent.SenderName, actualBuildEvent.SenderName);
+            Assert.Equal(expectedBuildEvent.Subcategory, actualBuildEvent.Subcategory);
+            Assert.Equal(expectedBuildEvent.ThreadId, actualBuildEvent.ThreadId);
+            Assert.Equal(expectedBuildEvent.Timestamp, actualBuildEvent.Timestamp);
+        }
+
+        /// <summary>
+        /// Verifies that warnings are not treated as messages for a particular project when a code does not match.
+        /// </summary>
+        [Fact]
+        public void NotTreatWarningsAsMessagesByProjectWhenCodeNotSpecified()
+        {
+            BuildWarningEventArgs expectedBuildEvent = RaiseEventHelper.Warning;
+
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsMessagesByProject = new Dictionary<int, ISet<string>>
+                {
+                    {
+                        expectedBuildEvent.BuildEventContext.ProjectInstanceId,
+                        new HashSet<string>
+                        {
+                            "FOO",
+                            "BAR"
+                        }
+                    }
+                }
+            };
+
+            RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
+            EventHandlerHelper eventHandlerHelper = new EventHandlerHelper(eventSourceSink, null);
+
+            raiseEventHelper.RaiseBuildEvent(RaiseEventHelper.Warning);
+
+            Assert.Equal(expectedBuildEvent, eventHandlerHelper.RaisedEvent);
+        }
+
+        /// <summary>
+        /// Verifies that warnings are not treated as messages for a particular project even though a matching code was added for another project.
+        /// </summary>
+        [Fact]
+        public void NotTreatWarningsAsMessagesByProjectWhenProjectNotSpecified()
+        {
+            BuildWarningEventArgs expectedBuildEvent = RaiseEventHelper.Warning;
+
+            EventSourceSink eventSourceSink = new EventSourceSink()
+            {
+                WarningsAsMessagesByProject = new Dictionary<int, ISet<string>>
+                {
+                    {
+                        expectedBuildEvent.BuildEventContext.ProjectInstanceId + 100, // Ensures that the project instance ID doesn't match
+                        new HashSet<string>
+                        {
+                            "FOO",
+                            expectedBuildEvent.Code,
+                            "BAR"
+                        }
+                    }
+                }
             };
 
             RaiseEventHelper raiseEventHelper = new RaiseEventHelper(eventSourceSink);
@@ -898,7 +1150,10 @@ namespace Microsoft.Build.UnitTests.Logging
             /// <summary>
             /// Build Warning Event
             /// </summary>
-            private static BuildWarningEventArgs s_buildWarning = new BuildWarningEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender");
+            private static BuildWarningEventArgs s_buildWarning = new BuildWarningEventArgs("SubCategoryForSchemaValidationErrors", "MSB4000", "file", 1, 2, 3, 4, "message", "help", "sender")
+            {
+                BuildEventContext = new BuildEventContext(1, 2, 3, 4, 5, 6)
+            };
 
             /// <summary>
             /// Build Error Event

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -183,6 +183,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
             set;
         }
 
+        public void AddWarningsAsMessages(int projectInstanceId, ISet<string> codes)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddWarningsAsErrors(int projectInstanceId, ISet<string> codes)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Registers a distributed logger.
         /// </summary>

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -190,6 +190,7 @@
     <Compile Include="TargetsFile_Test.cs" />
     <Compile Include="TestUtilities.cs" />
     <Compile Include="Utilities_Tests.cs" />
+    <Compile Include="WarningsAsMessagesAndErrors_Tests.cs" />
     <None Include="..\Shared\UnitTests\App.config">
       <Link>App.config</Link>
       <SubType>Designer</SubType>

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.UnitTests;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests
+{
+    public sealed class WarningsAsMessagesAndErrorsTests
+    {
+        private const string ExpectedEventMessage = "03767942CDB147B98D0ECDBDE1436DA3";
+        private const string ExpectedEventCode = "0BF68998";
+
+        [Fact]
+        public void TreatAllWarningsAsErrors()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(GetTestProject(treatAllWarningsAsErrors: true));
+
+            VerifyBuildErrorEvent(logger);
+
+            ObjectModelHelpers.BuildProjectExpectSuccess(GetTestProject(treatAllWarningsAsErrors: false));
+        }
+
+        [Fact]
+        public void TreatWarningsAsErrorsWhenSpecified()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(GetTestProject(warningsAsErrors: ExpectedEventCode));
+
+            VerifyBuildErrorEvent(logger);
+        }
+
+        [Fact]
+        public void TreatWarningsAsErrorsWhenSpecifiedIndirectly()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(
+                GetTestProject(
+                    customProperties: new Dictionary<string, string>
+                    {
+                        {"Foo", "true"},
+                        {"MSBuildTreatWarningsAsErrors", "$(Foo)"}
+                    }));
+
+            VerifyBuildErrorEvent(logger);
+        }
+
+        [Fact]
+        public void TreatWarningsAsErrorsWhenSpecifiedThroughAdditiveProperty()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(
+                GetTestProject(
+                    customProperties: new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", "123"),
+                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", $@"$(MSBuildWarningsAsErrors);
+                                                                                       {ExpectedEventCode.ToLowerInvariant()}"),
+                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", "$(MSBuildWarningsAsErrors);ABC")
+                    }));
+
+            VerifyBuildErrorEvent(logger);
+        }
+
+        [Fact]
+        public void NotTreatWarningsAsErrorsWhenCodeNotSpecified()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(
+                GetTestProject(
+                    customProperties: new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", "123"),
+                        new KeyValuePair<string, string>("MSBuildWarningsAsErrors", "$(MSBuildWarningsAsErrors);ABC")
+                    }));
+
+            VerifyBuildWarningEvent(logger);
+        }
+
+        [Fact]
+        public void TreatWarningsAsMessagesWhenSpecified()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(GetTestProject(warningsAsMessages: ExpectedEventCode));
+
+            VerifyBuildMessageEvent(logger);
+        }
+
+        [Fact]
+        public void TreatWarningsAsMessagesWhenSpecifiedIndirectly()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(
+                GetTestProject(
+                    customProperties: new Dictionary<string, string>
+                    {
+                        {"Foo", ExpectedEventCode},
+                    },
+                    warningsAsMessages: "$(Foo)"
+                )
+            );
+
+            VerifyBuildMessageEvent(logger);
+        }
+
+        [Fact]
+        public void TreatWarningsAsMessagesWhenSpecifiedThroughAdditiveProperty()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(
+                GetTestProject(
+                    customProperties: new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "123"),
+                        new KeyValuePair<string, string>("MSBuildWarningsAsMessages", $@"$(MSBuildWarningsAsMessages);
+                                                                                       {ExpectedEventCode.ToLowerInvariant()}"),
+                        new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "$(MSBuildWarningsAsMessages);ABC")
+                    }));
+
+            VerifyBuildMessageEvent(logger);
+        }
+
+        [Fact]
+        public void NotTreatWarningsAsMessagesWhenCodeNotSpecified()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(
+                GetTestProject(
+                    customProperties: new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "123"),
+                        new KeyValuePair<string, string>("MSBuildWarningsAsMessages", "$(MSBuildWarningsAsMessages);ABC")
+                    }));
+
+            VerifyBuildWarningEvent(logger);
+        }
+
+        [Fact]
+        public void TreatWarningAsMessageOverridesTreatingItAsError()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(
+                GetTestProject(
+                    warningsAsMessages: ExpectedEventCode,
+                    warningsAsErrors: ExpectedEventCode
+                    ));
+
+            VerifyBuildMessageEvent(logger);
+        }
+
+        private void VerifyBuildErrorEvent(MockLogger logger)
+        {
+            BuildErrorEventArgs actualEvent = logger.Errors.FirstOrDefault();
+
+            Assert.NotNull(actualEvent);
+
+            Assert.Equal(ExpectedEventMessage, actualEvent.Message);
+            Assert.Equal(ExpectedEventCode, actualEvent.Code);
+
+            logger.AssertNoWarnings();
+        }
+
+        private void VerifyBuildWarningEvent(MockLogger logger)
+        {
+            BuildWarningEventArgs actualEvent = logger.Warnings.FirstOrDefault();
+
+            Assert.NotNull(actualEvent);
+
+            Assert.Equal(ExpectedEventMessage, actualEvent.Message);
+            Assert.Equal(ExpectedEventCode, actualEvent.Code);
+
+            logger.AssertNoErrors();
+        }
+
+        private void VerifyBuildMessageEvent(MockLogger logger)
+        {
+            BuildMessageEventArgs actualEvent = logger.BuildMessageEvents.FirstOrDefault(i => i.Message.Equals(ExpectedEventMessage));
+
+            Assert.NotNull(actualEvent);
+
+            Assert.Equal(ExpectedEventCode, actualEvent.Code);
+
+            logger.AssertNoErrors();
+            logger.AssertNoWarnings();
+        }
+
+        private string GetTestProject(bool? treatAllWarningsAsErrors = null, string warningsAsErrors = null, string warningsAsMessages = null, ICollection<KeyValuePair<string, string>> customProperties = null)
+        {
+            return $@"
+            <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
+                <PropertyGroup>
+                    {(customProperties != null ? String.Join(Environment.NewLine, customProperties.Select(i => $"<{i.Key}>{i.Value}</{i.Key}>")) : "")}
+                    {(treatAllWarningsAsErrors.HasValue ? $"<MSBuildTreatWarningsAsErrors>{treatAllWarningsAsErrors.Value}</MSBuildTreatWarningsAsErrors>" : "")}
+                    {(warningsAsErrors != null ? $"<MSBuildWarningsAsErrors>{warningsAsErrors}</MSBuildWarningsAsErrors>" : "")}
+                    {(warningsAsMessages != null ? $"<MSBuildWarningsAsMessages>{warningsAsMessages}</MSBuildWarningsAsMessages>" : "")}
+                </PropertyGroup>
+                <Target Name='Build'>
+                    <Message Text=""MSBuildTreatWarningsAsErrors: '$(MSBuildTreatWarningsAsErrors)' "" />
+                    <Message Text=""MSBuildWarningsAsErrors: '$(MSBuildWarningsAsErrors)' "" />
+                    <Message Text=""MSBuildWarningsAsMessages: '$(MSBuildWarningsAsMessages)' "" />
+                    <Warning Text=""{ExpectedEventMessage}"" Code=""{ExpectedEventCode}"" />
+                </Target>
+            </Project>";
+        }
+    }
+}

--- a/src/Build/BackEnd/Components/Logging/BuildEventArgTransportSink.cs
+++ b/src/Build/BackEnd/Components/Logging/BuildEventArgTransportSink.cs
@@ -91,9 +91,27 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
+        /// This property is ignored by this event sink and relies on the receiver to treat warnings as errors.
+        /// </summary>
+        public IDictionary<int, ISet<string>> WarningsAsErrorsByProject
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// This property is ignored by this event sink and relies on the receiver to treat warnings as low importance messages.
         /// </summary>
         public ISet<string> WarningsAsMessages
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// This property is ignored by this event sink and relies on the receiver to treat warnings as low importance messages.
+        /// </summary>
+        public IDictionary<int, ISet<string>> WarningsAsMessagesByProject
         {
             get;
             set;

--- a/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
@@ -228,6 +228,12 @@ namespace Microsoft.Build.BackEnd.Logging
             else if (buildEvent is ProjectFinishedEventArgs)
             {
                 this.RaiseProjectFinishedEvent(null, (ProjectFinishedEventArgs)buildEvent);
+
+                if (buildEvent.BuildEventContext != null && buildEvent.BuildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
+                {
+                    WarningsAsErrorsByProject?.Remove(buildEvent.BuildEventContext.ProjectInstanceId);
+                    WarningsAsMessagesByProject?.Remove(buildEvent.BuildEventContext.ProjectInstanceId);
+                }
             }
             else if (buildEvent is BuildStartedEventArgs)
             {

--- a/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
@@ -141,9 +141,27 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
+        /// A list of warnings to treat as errors for an associated <see cref="BuildEventContext.ProjectInstanceId"/>.  If the set associated with a ProjectInstanceId is null, nothing is treated as an error.  If an empty set, all warnings are treated as errors.
+        /// </summary>
+        public IDictionary<int, ISet<string>> WarningsAsErrorsByProject
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// A list of warnings to treat as low importance messages.
         /// </summary>
         public ISet<string> WarningsAsMessages
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// A list of warnings to treat as low importance messages for an associated <see cref="BuildEventContext.ProjectInstanceId"/>.
+        /// </summary>
+        public IDictionary<int, ISet<string>> WarningsAsMessagesByProject
         {
             get;
             set;
@@ -233,7 +251,7 @@ namespace Microsoft.Build.BackEnd.Logging
             {
                 BuildWarningEventArgs warningEvent = (BuildWarningEventArgs) buildEvent;
 
-                if (WarningsAsMessages != null && WarningsAsMessages.Contains(warningEvent.Code))
+                if (ShouldTreatWarningAsMessage(warningEvent))
                 {
                     // Treat this warning as a message with low importance if its in the list
                     BuildMessageEventArgs errorEvent = new BuildMessageEventArgs(
@@ -257,7 +275,7 @@ namespace Microsoft.Build.BackEnd.Logging
                     this.RaiseMessageEvent(null, errorEvent);
 
                 }
-                else if (WarningsAsErrors != null && (WarningsAsErrors.Count == 0 || WarningsAsErrors.Contains(warningEvent.Code)))
+                else if (ShouldTreatWarningAsError(warningEvent))
                 {
                     // Treat this warning as an error if an empty set of warnings was specified or this code was specified
                     BuildErrorEventArgs errorEvent = new BuildErrorEventArgs(
@@ -968,6 +986,75 @@ namespace Microsoft.Build.BackEnd.Logging
                     InternalLoggerException.Throw(exception, buildEvent, "FatalErrorWhileLogging", false);
                 }
             }
+        }
+
+        /// <summary>
+        /// Determines if the specified warning should be treated as an error.
+        /// </summary>
+        /// <param name="warningEvent">A <see cref="BuildWarningEventArgs"/> that specifies the warning.</param>
+        /// <returns><code>true</code> if the warning should be treated as an error, otherwise <code>false</code>.</returns>
+        private bool ShouldTreatWarningAsError(BuildWarningEventArgs warningEvent)
+        {
+            // This only applies if the user specified /warnaserror from the command-line or added an empty set through the object model
+            //
+            if (WarningsAsErrors != null)
+            {
+                // Global warnings as errors apply to all projects.  If the list is empty or contains the code, the warning should be treated as an error
+                //
+                if (WarningsAsErrors.Count == 0 || WarningsAsErrors.Contains(warningEvent.Code))
+                {
+                    return true;
+                }
+            }
+
+            // This only applies if the user specified <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors or <MSBuildWarningsAsErrors />
+            // and there is a valid ProjectInstanceId for the warning.
+            //
+            if (WarningsAsErrorsByProject != null && warningEvent.BuildEventContext != null && warningEvent.BuildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
+            {
+                ISet<string> codesByProject;
+
+                // Attempt to get the list of warnings to treat as errors for the current project
+                //
+                if (WarningsAsErrorsByProject.TryGetValue(warningEvent.BuildEventContext.ProjectInstanceId, out codesByProject) && codesByProject != null)
+                {
+                    // We create an empty set if all warnings should be treated as errors so that should be checked first.
+                    // If the set is not empty, check the specific code.
+                    //
+                    return codesByProject.Count == 0 || codesByProject.Contains(warningEvent.Code);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if the specified warning should be treated as a low importance message.
+        /// </summary>
+        /// <param name="warningEvent">A <see cref="BuildWarningEventArgs"/> that specifies the warning.</param>
+        /// <returns><code>true</code> if the warning should be treated as a low importance message, otherwise <code>false</code>.</returns>
+        private bool ShouldTreatWarningAsMessage(BuildWarningEventArgs warningEvent)
+        {
+            // This only applies if the user specified /nowarn at the command-line or added the warning code through the object model
+            //
+            if (WarningsAsMessages != null && WarningsAsMessages.Contains(warningEvent.Code))
+            {
+                return true;
+            }
+
+            // This only applies if the user specified <MSBuildWarningsAsMessages /> and there is a valid ProjectInstanceId
+            //
+            if (WarningsAsMessagesByProject != null && warningEvent.BuildEventContext != null && warningEvent.BuildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
+            {
+                ISet<string> codesByProject;
+
+                if (WarningsAsMessagesByProject.TryGetValue(warningEvent.BuildEventContext.ProjectInstanceId, out codesByProject) && codesByProject != null)
+                {
+                    return codesByProject.Contains(warningEvent.Code);
+                }
+            }
+
+            return false;
         }
 
         #endregion

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -174,6 +174,20 @@ namespace Microsoft.Build.BackEnd.Logging
         #endregion
 
         /// <summary>
+        /// Adds a set of warning codes to treat as low importance messages for the specified project instance ID.
+        /// </summary>
+        /// <param name="projectInstanceId">A <see cref="BuildEventContext.ProjectInstanceId"/> to associate with the list of warning codes.</param>
+        /// <param name="codes">The list of warning codes to treat as low importance messsages.</param>
+        void AddWarningsAsMessages(int projectInstanceId, ISet<string> codes);
+
+        /// <summary>
+        /// Adds a set of warning codes to treat as errors for the specified project instance ID.
+        /// </summary>
+        /// <param name="projectInstanceId">A <see cref="BuildEventContext.ProjectInstanceId"/> to associate with the list of warning codes.</param>
+        /// <param name="codes">The list of warning codes to treat as errors.</param>
+        void AddWarningsAsErrors(int projectInstanceId, ISet<string> codes);
+
+        /// <summary>
         /// Determines if the specified submission has logged an errors.
         /// </summary>
         /// <param name="submissionId">The ID of the build submission.  A value of "0" means that an error was logged outside of any build submission.</param>
@@ -482,9 +496,27 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
+        /// A list of warnings to treat as errors for an associated <see cref="BuildEventContext.ProjectInstanceId"/>.
+        /// </summary>
+        IDictionary<int, ISet<string>> WarningsAsErrorsByProject
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// A list of warnings to treat as low importance messages.
         /// </summary>
         ISet<string> WarningsAsMessages
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// A list of warnings to treat as low importance messages for an associated <see cref="BuildEventContext.ProjectInstanceId"/>.
+        /// </summary>
+        IDictionary<int, ISet<string>> WarningsAsMessagesByProject
         {
             get;
             set;

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1298,12 +1298,8 @@ namespace Microsoft.Build.BackEnd
             {
                 return null;
             }
-
-            return new HashSet<string>(
-                warnings.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Where(i => !String.IsNullOrWhiteSpace(i))
-                    .Select(i => i.Trim()),
-                StringComparer.OrdinalIgnoreCase);
+            
+            return new HashSet<string>(ExpressionShredder.SplitSemiColonSeparatedList(warnings), StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Globalization;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
@@ -1079,6 +1080,10 @@ namespace Microsoft.Build.BackEnd
 
             _projectLoggingContext = _nodeLoggingContext.LogProjectStarted(_requestEntry);
 
+            // Now that the project has started, parse a few known properties which indicate warning codes to treat as errors or messages
+            //
+            ConfigureWarningsAsErrorsAndMessages();
+
             // See comment on ProjectItemInstance.Initialize for full details
             // We have been asked to build with a tools verison that we don't know about
             // so we'll report that we're building as if the project had been marked with a known toolsversion instead
@@ -1245,6 +1250,60 @@ namespace Microsoft.Build.BackEnd
         private void VerifyIsNotZombie()
         {
             ErrorUtilities.VerifyThrow(!_isZombie, "RequestBuilder has been zombied.");
+        }
+
+        /// <summary>
+        /// Configure warnings as messages and errors based on properties defined in the project.
+        /// </summary>
+        private void ConfigureWarningsAsErrorsAndMessages()
+        {
+            // Gather needed objects
+            //
+            ProjectInstance project = _requestEntry?.RequestConfiguration?.Project;
+            BuildEventContext buildEventContext = _projectLoggingContext?.BuildEventContext;
+            ILoggingService loggingService = _projectLoggingContext?.LoggingService;
+
+            // Ensure everything that is required is available at this time
+            //
+            if (project != null && buildEventContext != null && loggingService != null && buildEventContext.ProjectInstanceId != BuildEventContext.InvalidProjectInstanceId)
+            {
+                if (String.Equals(project.GetPropertyValue(MSBuildConstants.TreatWarningsAsErrors)?.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    // If <MSBuildTreatWarningsAsErrors was specified then an empty ISet<string> signals the IEventSourceSink to treat all warnings as errors
+                    //
+                    loggingService.AddWarningsAsErrors(buildEventContext.ProjectInstanceId, new HashSet<string>());
+                }
+                else
+                {
+                    ISet<string> warningsAsErrors = ParseWarningCodes(project.GetPropertyValue(MSBuildConstants.WarningsAsErrors));
+
+                    if (warningsAsErrors?.Count > 0)
+                    {
+                        loggingService.AddWarningsAsErrors(buildEventContext.ProjectInstanceId, warningsAsErrors);
+                    }
+                }
+
+                ISet<string> warningsAsMessages = ParseWarningCodes(project.GetPropertyValue(MSBuildConstants.WarningsAsMessages));
+
+                if (warningsAsMessages?.Count > 0)
+                {
+                    loggingService.AddWarningsAsMessages(buildEventContext.ProjectInstanceId, warningsAsMessages);
+                }
+            }
+        }
+
+        private ISet<string> ParseWarningCodes(string warnings)
+        {
+            if (String.IsNullOrWhiteSpace(warnings))
+            {
+                return null;
+            }
+
+            return new HashSet<string>(
+                warnings.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Where(i => !String.IsNullOrWhiteSpace(i))
+                    .Select(i => i.Trim()),
+                StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1474,6 +1474,21 @@ elementFormDefault="qualified">
     </xs:element>
     <xs:element name="MyType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="MSBuildAllProjects" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="MSBuildTreatWarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="MSBuildTreatWarningsAsErrors" _locComment="" -->Indicates whether to treat all warnings as errors when building a project.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="MSBuildWarningsAsMessages" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="MSBuildWarningsAsMessages" _locComment="" -->Indicates a semicolon delimited list of warnings to treat as low importance messages when building a project.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="MSBuildWarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_text="MSBuildWarningsAsErrors" _locComment="" -->Indicates a semicolon delimited list of warnings to treat as errors when building a project.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="NoConfig" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>    
     <xs:element name="NoStandardLibraries" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="NoStdLib" type="msb:StringPropertyType" substitutionGroup="msb:Property">

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -32,6 +32,21 @@ namespace Microsoft.Build.Shared
         internal const string SdksPath = "MSBuildSDKsPath";
 
         /// <summary>
+        /// Name of the property that indicates that all warnings should be treated as errors.
+        /// </summary>
+        internal const string TreatWarningsAsErrors = "MSBuildTreatWarningsAsErrors";
+
+        /// <summary>
+        /// Name of the property that indicates a list of warnings to treat as errors.
+        /// </summary>
+        internal const string WarningsAsErrors = "MSBuildWarningsAsErrors";
+
+        /// <summary>
+        /// Name of the property that indicates the list of warnings to treat as messages.
+        /// </summary>
+        internal const string WarningsAsMessages = "MSBuildWarningsAsMessages";
+
+        /// <summary>
         /// The most current Visual Studio Version known to this version of MSBuild. 
         /// </summary>
 #if STANDALONEBUILD


### PR DESCRIPTION
Introduce `MSBuildTreatWarningsAsErrors` property that when set to true will treat all warnings as errors when building a project.
Introduce `MSBuildWarningsAsErrors` property which is a semicolon delmited list of warning codes to treat as errors when building a project.
Introduce `MSBuildWarningsAsMessages` property which is a semicolon delimited list of warning codes to treat as low importance messages.

This allows users to control warnings at the project level via standard MSBuild properties.  They can be set in a project, an import, or from the command-line.

The limitation here is that the warnings can only include ones that occur during a build.  This is because the properties are not read until after parsing so warnings generated during parse/evaluation happen too soon.  For these warnings, users will only be able to treat them as errors/messages with the `/WarnAsError` and `/WarnAsMessage` command-line arguments.

Closes #1886