### PR TITLE
Perf Regression: Stop using MSBuildNameIgnoreCaseComparer

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/LazyItemEvaluator.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Evaluation
         // it's unneeded (at least by the 16.0 timeframe).
         private Dictionary<string, LazyItemList> _itemLists = Environment.GetEnvironmentVariable("MSBUILDUSECASESENSITIVEITEMNAMES") == "1" ?
             new Dictionary<string, LazyItemList>() :
-            new Dictionary<string, LazyItemList>(MSBuildNameIgnoreCaseComparer.Default);
+            new Dictionary<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
 
         public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, BuildEventContext buildEventContext, ILoggingService loggingService)
         {
@@ -373,7 +373,7 @@ namespace Microsoft.Build.Evaluation
 
             public ImmutableDictionary<string, LazyItemList>.Builder ReferencedItemLists { get; } = Environment.GetEnvironmentVariable("MSBUILDUSECASESENSITIVEITEMNAMES") == "1" ?
                 ImmutableDictionary.CreateBuilder<string, LazyItemList>() :
-                ImmutableDictionary.CreateBuilder<string, LazyItemList>(MSBuildNameIgnoreCaseComparer.Default);
+                ImmutableDictionary.CreateBuilder<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
 
             public bool ConditionResult { get; set; }
 


### PR DESCRIPTION
Fix for regression in performance caused by #1766.

Internal Visual Studio perf tests discovered a small regression in 15.1 that appears to be due to using `MSBuildNameIgnoreCaseComparer.Default` for string comparison in the lazy evaluator. The change was originally made because of a behavior regression that caused item references to be case-sensitive. Using `StringComparer.OrdinalIgnoreCase` seems to resolve the performance issue and maintains the correct behavior from previous versions of MSBuild.