### PR TITLE
Perf Regression: Stop using MSBuildNameIgnoreCaseComparer

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Evaluation
         // it's unneeded (at least by the 16.0 timeframe).
         private Dictionary<string, LazyItemList> _itemLists = Environment.GetEnvironmentVariable("MSBUILDUSECASESENSITIVEITEMNAMES") == "1" ?
             new Dictionary<string, LazyItemList>() :
-            new Dictionary<string, LazyItemList>(MSBuildNameIgnoreCaseComparer.Default);
+            new Dictionary<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
 
         public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, BuildEventContext buildEventContext, ILoggingService loggingService)
         {
@@ -377,7 +377,7 @@ namespace Microsoft.Build.Evaluation
 
             public ImmutableDictionary<string, LazyItemList>.Builder ReferencedItemLists { get; } = Environment.GetEnvironmentVariable("MSBUILDUSECASESENSITIVEITEMNAMES") == "1" ?
                 ImmutableDictionary.CreateBuilder<string, LazyItemList>() :
-                ImmutableDictionary.CreateBuilder<string, LazyItemList>(MSBuildNameIgnoreCaseComparer.Default);
+                ImmutableDictionary.CreateBuilder<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
 
             public bool ConditionResult { get; set; }
 


### PR DESCRIPTION
Fix for regression in performance caused by #1766. Port of #1929.

Internal Visual Studio perf tests discovered a small regression in 15.1 that appears to be due to using MSBuildNameIgnoreCaseComparer.Default for string comparison in the lazy evaluator. The change was originally made because of a behavior regression that caused item references to be case-sensitive. Using StringComparer.OrdinalIgnoreCase seems to resolve the performance issue and maintains the correct behavior from previous versions of MSBuild.