### PR TITLE
Fix metadata reference in a property function, in an item metadata

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -730,6 +730,26 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Assert.Equal(0, items[5].Metadata.Count());
         }
 
+        [Fact]
+        public void ExpandItemMetadataWithPropertyFunctionReferencingItemMetadata()
+        {
+            string content = @"
+ <Project DefaultTargets=`t` xmlns=`http://schemas.microsoft.com/developer/msbuild/2003`>
+        <ItemGroup>
+            <Item Include='dir\itemFoo'>
+              <MD>$([System.String]::new('%(RelativeDir)').TrimEnd('\'))</MD>
+            </Item>
+        </ItemGroup>
+        <Target Name='t'>
+                <Message Text='MD: %(Item.MD)' />
+        </Target>
+</Project>";
+
+            MockLogger log = Helpers.BuildProjectWithNewOMExpectSuccess(content);
+
+            log.AssertLogContains("MD: dir");
+        }
+
         /// <summary>
         /// Creates an expander populated with some ProjectPropertyInstances and ProjectPropertyItems.
         /// </summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Evaluation
 
             readonly ImmutableList<string> _excludes;
 
-            readonly ImmutableList<PartiallyEvaluatedMetadata> _metadata;
+            readonly ImmutableList<ProjectMetadataElement> _metadata;
 
             public IncludeOperation(IncludeOperationBuilder builder, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
                 : base(builder, lazyEvaluator)

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Evaluation
     {
         class UpdateOperation : LazyItemOperation
         {
-            private readonly ImmutableList<PartiallyEvaluatedMetadata> _metadata;
+            private readonly ImmutableList<ProjectMetadataElement> _metadata;
 
             public UpdateOperation(OperationBuilderWithMetadata builder, LazyItemEvaluator<P, I, M, D> lazyEvaluator)
                 : base(builder, lazyEvaluator)

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Build.Evaluation
 
         private class OperationBuilderWithMetadata : OperationBuilder
         {
-            public ImmutableList<PartiallyEvaluatedMetadata>.Builder Metadata = ImmutableList.CreateBuilder<PartiallyEvaluatedMetadata>();
+            public ImmutableList<ProjectMetadataElement>.Builder Metadata = ImmutableList.CreateBuilder<ProjectMetadataElement>();
 
             public OperationBuilderWithMetadata(ProjectItemElement itemElement, bool conditionResult) : base(itemElement, conditionResult)
             {
@@ -521,6 +521,8 @@ namespace Microsoft.Build.Evaluation
         {
             if (itemElement.HasMetadata)
             {
+                operationBuilder.Metadata.AddRange(itemElement.Metadata);
+
                 var values = new List<string>(itemElement.Metadata.Count * 2);
 
                 // Expand properties here, because a property may have a value which is an item reference (ie "@(Bar)"), and
@@ -536,14 +538,6 @@ namespace Microsoft.Build.Evaluation
                         metadatumElement.Condition,
                         ExpanderOptions.ExpandProperties,
                         metadatumElement.ConditionLocation);
-
-                    operationBuilder.Metadata.Add(
-                        new PartiallyEvaluatedMetadata
-                        {
-                            ValueWithPropertiesExpanded = valueWithPropertiesExpanded,
-                            ConditionWithPropertiesExpanded = conditionWithPropertiesExpanded,
-                            Element = metadatumElement
-                        });
 
                     values.Add(valueWithPropertiesExpanded);
                     values.Add(conditionWithPropertiesExpanded);
@@ -601,14 +595,6 @@ namespace Microsoft.Build.Evaluation
                     AddReferencedItemLists(operationBuilder, subMatch);
                 }
             }
-        }
-
-        // todo: replace with value tuples when we move to C# 7
-        private struct PartiallyEvaluatedMetadata
-        {
-            public ProjectMetadataElement Element { get; set; }
-            public string ConditionWithPropertiesExpanded { get; set; }
-            public string ValueWithPropertiesExpanded { get; set; }
         }
     }
 }


### PR DESCRIPTION
Fixes #1932.

This partially reverts 816d37362bc34a6dd754607cad8c601ae8f13000,
specifically the part (quoted from the commit message):

` Side effect change: if metadata properties are evalauted early,
there's no use for operation application to expand them yet again, so
cache the property expansion during operation construction and use the
cached values during operation application. This should also be a perf
improvement when metadata references are present within metadata, as
that triggers the re-evaluation of all metadata elements for each item
instance.`

We can't use the metadata expanded at operation construction time as we
didn't expand referenced item metadata at that time. This breaks a case
where the item metadata has a value like:

`<MD>$([System.String]::new('%(RelativeDir)').TrimEnd('\'))</MD>`

So, we need to expand the original metadata string at operation
application time.