### PR TITLE
Add a capability to turn off importing CSharp\VisualBasic item schema files

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -48,7 +48,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(DefineCSharpItemSchemas)' == 'true' ">
         <PropertyPageSchema Include="$(CommonXamlResourcesDirectory)CSharp.ProjectItemsSchema.xaml;"/>
         <PropertyPageSchema Include="$(CommonXamlResourcesDirectory)CSharp.xaml;">
             <Context>File</Context>

--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -48,7 +48,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
     </PropertyGroup>
 
-    <ItemGroup Condition=" '$(DefineCSharpItemSchemas)' == 'true' ">
+    <ItemGroup Condition=" '$(DefineCSharpItemSchemas)' != 'false' ">
         <PropertyPageSchema Include="$(CommonXamlResourcesDirectory)CSharp.ProjectItemsSchema.xaml;"/>
         <PropertyPageSchema Include="$(CommonXamlResourcesDirectory)CSharp.xaml;">
             <Context>File</Context>

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -48,7 +48,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">My Project</AppDesignerFolder>
     </PropertyGroup>
 
-    <ItemGroup Condition=" '$(DefineVisualBasicItemSchemas)' == 'true' ">
+    <ItemGroup Condition=" '$(DefineVisualBasicItemSchemas)' != 'false' ">
         <PropertyPageSchema Include="$(CommonXamlResourcesDirectory)VisualBasic.ProjectItemsSchema.xaml;"/>
         <PropertyPageSchema Include="$(CommonXamlResourcesDirectory)VisualBasic.xaml;">
             <Context>File</Context>

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -48,7 +48,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">My Project</AppDesignerFolder>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(DefineVisualBasicItemSchemas)' == 'true' ">
         <PropertyPageSchema Include="$(CommonXamlResourcesDirectory)VisualBasic.ProjectItemsSchema.xaml;"/>
         <PropertyPageSchema Include="$(CommonXamlResourcesDirectory)VisualBasic.xaml;">
             <Context>File</Context>


### PR DESCRIPTION
The dotnet project system has it's own copy of these rules and these are being imported twice. This was benign before but we refactored one of the rules recently and this is now causing latest builds of wpt to be broken.

Introducing a property here that will be set by the project system to disable importing these rules.

@AndyGerlicher @cdmihai @rainersigwald 