### PR TITLE
Update amd64 app.config to find XAML build tasks.

### DIFF
--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -47,10 +47,12 @@
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+          <codeBase version="15.0.0.0" href="..\Microsoft.Activities.Build.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+          <codeBase version="15.0.0.0" href="..\XamlBuildTask.dll"/>
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->


### PR DESCRIPTION
This change is part of an internal change to the XAML build tasks to
enable support for x64 builds. This was broken in Visual Studio 2017
because MSBuild assemblies are no longer in the GAC and any app domain
created by a task may not be able to find MSBuild assemblies correctly.

Closes #1943