### PR TITLE
Differentiate version for RuntimeInformation and bring it back for property functions

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -67,7 +67,7 @@
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
         <dependency id="System.Collections.Immutable" version="1.3.1" />
         <dependency id="System.Reflection.Metadata" version="1.3.0" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -67,6 +67,7 @@
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
         <dependency id="System.Collections.Immutable" version="1.3.1" />
         <dependency id="System.Reflection.Metadata" version="1.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -53,6 +53,7 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -53,7 +53,7 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -64,7 +64,7 @@
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="System.Collections.Immutable" version="1.3.1" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -64,6 +64,7 @@
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="System.Collections.Immutable" version="1.3.1" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/dir.props
+++ b/dir.props
@@ -371,7 +371,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_SETTERS</DefineConstants>
 
     <DefineConstants>$(DefineConstants);FEATURE_PROCESSSTARTINFO_ENVIRONMENT</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEINFORMATION</DefineConstants>
     <DefineConstants>$(DefineConstants);USE_MSBUILD_DLL_EXTN</DefineConstants>
   </PropertyGroup>
 

--- a/setup/files.swr
+++ b/setup/files.swr
@@ -22,6 +22,7 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
@@ -149,6 +150,7 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks

--- a/src/Build.OM.UnitTests/project.json
+++ b/src/Build.OM.UnitTests/project.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5",
         "System.Collections.Immutable": "1.3.1",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
         "xunit.runner.visualstudio": "2.1.0"
       }
     },

--- a/src/Build.UnitTests/project.json
+++ b/src/Build.UnitTests/project.json
@@ -9,7 +9,8 @@
   "frameworks": {
     "net46": {
       "Microsoft.Net.Compilers": "2.0.0-beta3",
-      "System.Threading.Tasks.Dataflow": "4.5.24.0"
+      "System.Threading.Tasks.Dataflow": "4.5.24.0",
+      "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
     },
     "netstandard1.3": {
       "dependencies": {
@@ -22,6 +23,7 @@
         "System.Diagnostics.FileVersionInfo": "4.0.0",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TraceSource": "4.0.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Threading.Tasks.Dataflow": "4.6.0.0",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 using Microsoft.Build.Internal;
@@ -26,6 +28,14 @@ namespace Microsoft.Build.Evaluation
     /// </summary>
     internal static class IntrinsicFunctions
     {
+        private static Lazy<string> _validOsPlatforms = new Lazy<string>(
+            () => typeof(OSPlatform).GetTypeInfo()
+                .GetProperties(BindingFlags.Static | BindingFlags.Public)
+                .Where(pi => pi.PropertyType == typeof(OSPlatform))
+                .Select(pi => pi.Name)
+                .Aggregate("", (a, b) => string.IsNullOrEmpty(a) ? b : $"{a}, {b}"),
+            true);
+
         /// <summary>
         /// Add two doubles
         /// </summary>
@@ -416,6 +426,38 @@ namespace Microsoft.Build.Evaluation
         internal static string NormalizePath(params string[] path)
         {
             return FileUtilities.NormalizePath(Path.Combine(path));
+        }
+
+        /// <summary>
+        /// Specify whether the current OS platform is <paramref name="platformString"/>
+        /// </summary>
+        /// <param name="platformString">The platform string. Must be a member of <see cref="OSPlatform"/>. Case Insensitive</param>
+        /// <returns></returns>
+        internal static bool IsOsPlatform(string platformString)
+        {
+            var typeInfo = typeof(OSPlatform).GetTypeInfo();
+            var propertyInfo = typeInfo.GetProperty(platformString, BindingFlags.Static | BindingFlags.Public | BindingFlags.IgnoreCase);
+
+            if (propertyInfo == null || propertyInfo.PropertyType != typeof(OSPlatform))
+            {
+
+                ErrorUtilities.ThrowArgument("UnsupportedOSPlatformString", platformString, _validOsPlatforms.Value);
+
+                return false;
+            }
+
+            var platform = (OSPlatform) propertyInfo.GetValue(typeof(OSPlatform));
+
+            return RuntimeInformation.IsOSPlatform(platform);
+        }
+
+        /// <summary>
+        /// True if current OS is a Unix system.
+        /// </summary>
+        /// <returns></returns>
+        internal static bool IsOsUnixLike()
+        {
+            return NativeMethodsShared.IsUnixLike;
         }
 
         public static string GetCurrentToolsDirectory()

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -792,19 +792,4 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="!$(Configuration.EndsWith('MONO'))"/>
   -->
   <Import Project="..\dir.targets" />
-  <Target Name="CopyImmutableAndDataflowLocal" BeforeTargets="ResolveAssemblyReferences" AfterTargets="ResolveNuGetPackages">
-    <!-- The VSIX installer manifest references System.Collections.Immutable and System.Threading.Tasks.Dataflow
-         from the Output folder, but they won't be placed there by default because NuGet references come in as CopyLocal false.
-
-         Work around this by munging the references after NuGet emits them but before RAR.
-
-         TODO: this shouldn't be here. After moving to a better binplacing model (like "publish
-         msbuild.exe to a folder") it should be removed.
-    -->
-    <ItemGroup>
-      <Reference Condition="'%(Reference.NuGetPackageId)' == 'System.Collections.Immutable' or '%(Reference.NuGetPackageId)' == 'System.Threading.Tasks.Dataflow'">
-        <Private>true</Private>
-      </Reference>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -771,9 +771,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Runtime">
-      <HintPath>$(FrameworkPathOverride)\System.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="System.Threading.Tasks">
       <HintPath>$(FrameworkPathOverride)\System.Threading.Tasks.dll</HintPath>
     </Reference>

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -326,10 +326,8 @@ namespace Microsoft.Build.Internal
                     var environmentType = new Tuple<string, Type>(null, typeof(System.Environment));
                     var directoryType = new Tuple<string, Type>(null, typeof(System.IO.Directory));
                     var fileType = new Tuple<string, Type>(null, typeof(System.IO.File));
-#if FEATURE_RUNTIMEINFORMATION
                     var runtimeInformationType = new Tuple<string, Type>(null, typeof(System.Runtime.InteropServices.RuntimeInformation));
                     var osPlatformType = new Tuple<string, Type>(null, typeof(System.Runtime.InteropServices.OSPlatform));
-#endif
 
                     // Make specific static methods available (Assembly qualified type names are *NOT* supported, only null which means mscorlib):
                     TryAdd("System.Environment::ExpandEnvironmentVariables", environmentType);
@@ -421,10 +419,8 @@ namespace Microsoft.Build.Internal
                     TryAdd("System.UriBuilder", new Tuple<string, Type>(null, typeof(System.UriBuilder)));
                     TryAdd("System.Version", new Tuple<string, Type>(null, typeof(System.Version)));
                     TryAdd("Microsoft.Build.Utilities.ToolLocationHelper", new Tuple<string, Type>("Microsoft.Build.Utilities.ToolLocationHelper, Microsoft.Build.Utilities.Core, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null));
-#if FEATURE_RUNTIMEINFORMATION
                     TryAdd("System.Runtime.InteropServices.RuntimeInformation", runtimeInformationType);
                     TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
-#endif
                 }
             }
         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1603,13 +1603,19 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>MSB4231: ProjectRootElement can't reload if it contains unsaved changes.</value>
     <comment>{StrBegin="MSB4231: "}</comment>
   </data>
+
+  <data name="UnsupportedOSPlatformString">
+    <value>MSB4239: The provided argument {0} for [MSBuild]::IsOsPlatform is not supported. Supported values are: {1}</value>
+    <comment>{StrBegin="MSB4231: "} {0} is the name of an OS platform, like Windows, Linux, OSX; {1} is a comma separated enumeration of OS platforms</comment>
+  </data>
+
   <!--
         The engine message bucket is: MSB4001 - MSB4999
         
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4239.
+        Next message code should be MSB4240.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -1,4 +1,7 @@
 ﻿{
+  "dependencies": {
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -1,12 +1,10 @@
 ﻿{
-  "dependencies": {
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
         "System.Collections.Immutable": "1.3.1",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
         "System.Threading.Tasks.Dataflow": "4.5.24.0"
       }
     },
@@ -25,6 +23,7 @@
         "System.Reflection.Metadata": "1.3.0",
         "System.Reflection.TypeExtensions": "4.1.0",
         "System.Runtime": "4.1.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Runtime.Loader": "4.0.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Threading.Tasks.Dataflow": "4.6.0.0",

--- a/src/Framework.UnitTests/project.json
+++ b/src/Framework.UnitTests/project.json
@@ -6,7 +6,12 @@
     "xunit.assert": "2.1.0"
   },
   "frameworks": {
-    "net46": { },
+    "net46": {
+      "dependencies": {
+        "xunit.runner.visualstudio": "2.1.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
+      }
+    },
     "netstandard1.3": {
       "dependencies": {
         "System.Net.NetworkInformation": "4.1.0",
@@ -16,7 +21,8 @@
         "System.Console": "4.0.0",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
         "Microsoft.NETCore.TestHost": "1.0.0",
-        "Microsoft.Win32.Primitives": "4.0.1"
+        "Microsoft.Win32.Primitives": "4.0.1",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
       },
       "imports": [ "portable-net451+win81", "dnxcore50" ]
     }

--- a/src/MSBuild.UnitTests/project.json
+++ b/src/MSBuild.UnitTests/project.json
@@ -8,7 +8,8 @@
   "frameworks": {
     "net46": {
       "dependencies": {
-        "xunit.runner.visualstudio": "2.1.0"
+        "xunit.runner.visualstudio": "2.1.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },
     "netstandard1.3": {
@@ -25,7 +26,8 @@
         "Microsoft.Win32.Primitives":  "4.0.1",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
         "Microsoft.NETCore.TestHost": "1.0.0",
-        "System.Reflection.Metadata": "1.3.0"
+        "System.Reflection.Metadata": "1.3.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
       },
       "imports": [ "portable-net451+win81", "dnxcore50" ]
     }

--- a/src/MSBuild/project.json
+++ b/src/MSBuild/project.json
@@ -1,4 +1,7 @@
 ﻿{
+  "dependencies": {
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/src/MSBuild/project.json
+++ b/src/MSBuild/project.json
@@ -1,11 +1,9 @@
 ﻿{
-  "dependencies": {
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {
-        "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
+        "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },
     "netcoreapp1.0": {
@@ -19,6 +17,7 @@
         "System.Reflection.Metadata": "1.3.0",
         "System.Reflection.TypeExtensions": "4.1.0",
         "System.Runtime.Loader": "4.0.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10"
       }

--- a/src/Shared/UnitTests/App.config
+++ b/src/Shared/UnitTests/App.config
@@ -30,6 +30,15 @@
         <assemblyIdentity name="Microsoft.Build.Utilities.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
         <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0"/>
       </dependentAssembly>
+
+      <!-- RuntimeInformation is redirected because src/Build.UnitTests/project.json incorrectly resolves to 4.0.0.0 (package 4.0.0-rc3-24117-00) 
+      instead of 4.0.1.0 (package 4.3.0) for net4.6.
+           Remove the redirect once MSBuild is off of project.json.
+        -->
+      <dependentAssembly>
+          <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+        </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Xml;
 
@@ -1022,6 +1023,30 @@ namespace Microsoft.Build.UnitTests
     /// </summary>
     internal static partial class Helpers
     {
+        internal static string GetOSPlatformAsString()
+        {
+            var currentPlatformString = string.Empty;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                currentPlatformString = "Windows";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                currentPlatformString = "Linux";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                currentPlatformString = "OSX";
+            }
+            else
+            {
+                Assert.True(false, "unrecognized current platform");
+            }
+
+            return currentPlatformString;
+        }
+
         /// <summary>
         /// Returns the count of objects returned by an enumerator
         /// </summary>

--- a/src/Tasks.UnitTests/project.json
+++ b/src/Tasks.UnitTests/project.json
@@ -10,7 +10,8 @@
   "frameworks": {
     "net46": {
       "dependencies": {
-        "xunit.runner.visualstudio": "2.1.0"
+        "xunit.runner.visualstudio": "2.1.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },
     "netstandard1.3": {
@@ -30,7 +31,8 @@
         "Microsoft.Win32.Primitives": "4.0.1",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
         "Microsoft.NETCore.TestHost": "1.0.0",
-        "System.Reflection.Metadata": "1.3.0"
+        "System.Reflection.Metadata": "1.3.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
       },
       "imports": [
         "portable-net451+win81",

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -1,4 +1,7 @@
 ﻿{
+  "dependencies": {
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -1,13 +1,11 @@
 ﻿{
-  "dependencies": {
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
         "System.Collections.Immutable": "1.3.1",
-        "System.Reflection.Metadata": "1.3.0"
+        "System.Reflection.Metadata": "1.3.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },
     "netstandard1.3": {
@@ -23,6 +21,7 @@
         "System.Resources.Writer": "4.0.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Runtime.Serialization.Xml": "4.1.1",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Security.Cryptography.Algorithms": "4.2.0",
         "System.Threading.Thread": "4.0.0",
         "System.Xml.XmlDocument": "4.0.1",

--- a/src/Utilities.UnitTests/project.json
+++ b/src/Utilities.UnitTests/project.json
@@ -7,7 +7,11 @@
     "xunit.assert": "2.1.0"
   },
   "frameworks": {
-    "net46": { },
+    "net46": { 
+      "dependencies": {
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
+      }
+    },
     "netstandard1.3": {
       "dependencies": {
         "System.Net.NetworkInformation": "4.1.0",
@@ -21,7 +25,8 @@
         "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
         "Microsoft.NETCore.TestHost": "1.0.0",
         "System.Xml.XmlDocument": "4.0.1",
-        "System.Reflection.Metadata": "1.3.0"
+        "System.Reflection.Metadata": "1.3.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
       },
       "imports": [ "portable-net451+win81", "dnxcore50" ]
     }

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -1,4 +1,7 @@
 ﻿{
+  "dependencies": {
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -1,11 +1,9 @@
 ﻿{
-  "dependencies": {
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {
-        "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
+        "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },
     "netstandard1.3": {
@@ -17,6 +15,7 @@
         "System.Reflection.TypeExtensions": "4.1.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Runtime.Serialization.Xml": "4.1.1",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Security.Cryptography.X509Certificates": "4.1.0",
         "System.Threading.Thread": "4.0.0",
         "System.Xml.XmlDocument": "4.0.1"

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -110,7 +110,7 @@
   <Target Name="DeployRuntime"
           DependsOnTargets="RestoreRuntimePackages"
           Outputs="%(RuntimeProjectJson.LockFile).IntentionallyDoesNotExistSoThisAlwaysRuns">
-    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="false"
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
                                          IncludeFrameworkReferences="false"
                                          NuGetPackagesDirectory="$(PackagesDir)"
                                          RuntimeIdentifier="$(NuGetRuntimeIdentifier)"
@@ -134,6 +134,41 @@
           DestinationFolder="$(OutputPath)"
           SkipUnchangedFiles="true"
           Condition=" '$(BuildingInsideVisualStudio)' == 'true' "
+          />
+    
+    
+    <Copy SourceFiles="@(ResolvedRuntimeFiles)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true"
+          Condition=
+          "'%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Collections.Immutable' or
+          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Threading.Tasks.Dataflow' or
+          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Runtime.InteropServices.RuntimeInformation'"
+          />
+  </Target>
+
+  <!-- The VSIX installer manifest references
+        System.Collections.Immutable,
+        System.Threading.Tasks.Dataflow,
+        System.Runtime.InteropServices.RuntimeInformation
+        from the Output folder, but they won't be placed there
+        by default because NuGet references come in as CopyLocal false.
+
+        Work around this by manually copying them here.
+
+        TODO: this shouldn't be here. After moving to a better binplacing model (like "publish
+        msbuild.exe to a folder") it should be removed. This whole project file should be removed. :)
+  -->
+  <Target Name="CopyDependenciesFromNugetNeededByVsix"
+          AfterTargets="DeployRuntime">
+
+    <Copy SourceFiles="@(ResolvedRuntimeFiles)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true"
+          Condition=
+          "'%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Collections.Immutable' or
+          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Threading.Tasks.Dataflow' or
+          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Runtime.InteropServices.RuntimeInformation'"
           />
   </Target>
 

--- a/targets/runtimeDependencies/project.json
+++ b/targets/runtimeDependencies/project.json
@@ -11,14 +11,14 @@
     "xunit": "2.1.0",
     "microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00629-09",
     "System.IO.FileSystem": "4.0.1",
-    "System.IO.Compression": "4.1.0",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "System.IO.Compression": "4.1.0"
   },
   "frameworks": {
     "net46": {
       "dependencies": {
         "xunit.runner.visualstudio": "2.1.0",
         "System.Collections.Immutable": "1.3.1",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
         "System.Threading.Tasks.Dataflow": "4.5.24.0",
         "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01"
       }
@@ -44,6 +44,7 @@
         "System.Reflection": "4.1.0",
         "System.Reflection.Metadata": "1.3.0",
         "System.Runtime.Extensions": "4.1.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Runtime.Loader": "4.0.0",
         "System.Threading.Tasks.Dataflow": "4.6.0.0",
         "System.Xml.XmlDocument": "4.0.1",

--- a/targets/runtimeDependencies/project.json
+++ b/targets/runtimeDependencies/project.json
@@ -11,14 +11,14 @@
     "xunit": "2.1.0",
     "microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00629-09",
     "System.IO.FileSystem": "4.0.1",
-    "System.IO.Compression": "4.1.0"
+    "System.IO.Compression": "4.1.0",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
   },
   "frameworks": {
     "net46": {
       "dependencies": {
         "xunit.runner.visualstudio": "2.1.0",
         "System.Collections.Immutable": "1.3.1",
-        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Threading.Tasks.Dataflow": "4.5.24.0",
         "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01"
       }
@@ -32,7 +32,6 @@
         "Microsoft.NETCore.Platforms": "1.0.1",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Console": "4.0.0",
-        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.IO.FileSystem.Watcher": "4.0.0",
         "System.IO.FileSystem.DriveInfo": "4.0.0",
         "System.IO.Pipes": "4.0.0",


### PR DESCRIPTION
VS needs 4.0.1.0. If we use anything else, we won't get VS' ngened copy which then makes all of msbuild not be ngened.

This PR also brings back #1926 which got reverted in #1951