### PR TITLE
Revert "Enable RuntimeInformation intrinsic functions on all platform…

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -67,7 +67,6 @@
         <dependency id="Microsoft.Build.Utilities.Core" version="[$version$]" />
         <dependency id="System.Collections.Immutable" version="1.3.1" />
         <dependency id="System.Reflection.Metadata" version="1.3.0" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -53,7 +53,6 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -64,7 +64,6 @@
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
         <dependency id="System.Collections.Immutable" version="1.3.1" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/dir.props
+++ b/dir.props
@@ -368,6 +368,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_SETTERS</DefineConstants>
 
     <DefineConstants>$(DefineConstants);FEATURE_PROCESSSTARTINFO_ENVIRONMENT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEINFORMATION</DefineConstants>
     <DefineConstants>$(DefineConstants);USE_MSBUILD_DLL_EXTN</DefineConstants>
   </PropertyGroup>
 

--- a/setup/files.swr
+++ b/setup/files.swr
@@ -22,7 +22,6 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
@@ -150,7 +149,6 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -782,4 +782,19 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="!$(Configuration.EndsWith('MONO'))"/>
   -->
   <Import Project="..\dir.targets" />
+  <Target Name="CopyImmutableAndDataflowLocal" BeforeTargets="ResolveAssemblyReferences" AfterTargets="ResolveNuGetPackages">
+    <!-- The VSIX installer manifest references System.Collections.Immutable and System.Threading.Tasks.Dataflow
+         from the Output folder, but they won't be placed there by default because NuGet references come in as CopyLocal false.
+
+         Work around this by munging the references after NuGet emits them but before RAR.
+
+         TODO: this shouldn't be here. After moving to a better binplacing model (like "publish
+         msbuild.exe to a folder") it should be removed.
+    -->
+    <ItemGroup>
+      <Reference Condition="'%(Reference.NuGetPackageId)' == 'System.Collections.Immutable' or '%(Reference.NuGetPackageId)' == 'System.Threading.Tasks.Dataflow'">
+        <Private>true</Private>
+      </Reference>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -326,8 +326,10 @@ namespace Microsoft.Build.Internal
                     var environmentType = new Tuple<string, Type>(null, typeof(System.Environment));
                     var directoryType = new Tuple<string, Type>(null, typeof(System.IO.Directory));
                     var fileType = new Tuple<string, Type>(null, typeof(System.IO.File));
+#if FEATURE_RUNTIMEINFORMATION
                     var runtimeInformationType = new Tuple<string, Type>(null, typeof(System.Runtime.InteropServices.RuntimeInformation));
                     var osPlatformType = new Tuple<string, Type>(null, typeof(System.Runtime.InteropServices.OSPlatform));
+#endif
 
                     // Make specific static methods available (Assembly qualified type names are *NOT* supported, only null which means mscorlib):
                     TryAdd("System.Environment::ExpandEnvironmentVariables", environmentType);
@@ -419,8 +421,10 @@ namespace Microsoft.Build.Internal
                     TryAdd("System.UriBuilder", new Tuple<string, Type>(null, typeof(System.UriBuilder)));
                     TryAdd("System.Version", new Tuple<string, Type>(null, typeof(System.Version)));
                     TryAdd("Microsoft.Build.Utilities.ToolLocationHelper", new Tuple<string, Type>("Microsoft.Build.Utilities.ToolLocationHelper, Microsoft.Build.Utilities.Core, Version=" + MSBuildConstants.CurrentAssemblyVersion + ", Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", null));
+#if FEATURE_RUNTIMEINFORMATION
                     TryAdd("System.Runtime.InteropServices.RuntimeInformation", runtimeInformationType);
                     TryAdd("System.Runtime.InteropServices.OSPlatform", osPlatformType);
+#endif
                 }
             }
         }

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -1,7 +1,4 @@
 ﻿{
-  "dependencies": {
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/src/MSBuild/project.json
+++ b/src/MSBuild/project.json
@@ -1,7 +1,4 @@
 ﻿{
-  "dependencies": {
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -1,7 +1,4 @@
 ﻿{
-  "dependencies": {
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -1,7 +1,4 @@
 ﻿{
-  "dependencies": {
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -110,7 +110,7 @@
   <Target Name="DeployRuntime"
           DependsOnTargets="RestoreRuntimePackages"
           Outputs="%(RuntimeProjectJson.LockFile).IntentionallyDoesNotExistSoThisAlwaysRuns">
-    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="false"
                                          IncludeFrameworkReferences="false"
                                          NuGetPackagesDirectory="$(PackagesDir)"
                                          RuntimeIdentifier="$(NuGetRuntimeIdentifier)"
@@ -134,41 +134,6 @@
           DestinationFolder="$(OutputPath)"
           SkipUnchangedFiles="true"
           Condition=" '$(BuildingInsideVisualStudio)' == 'true' "
-          />
-    
-    
-    <Copy SourceFiles="@(ResolvedRuntimeFiles)"
-          DestinationFolder="$(OutputPath)"
-          SkipUnchangedFiles="true"
-          Condition=
-          "'%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Collections.Immutable' or
-          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Threading.Tasks.Dataflow' or
-          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Runtime.InteropServices.RuntimeInformation'"
-          />
-  </Target>
-
-  <!-- The VSIX installer manifest references
-        System.Collections.Immutable,
-        System.Threading.Tasks.Dataflow,
-        System.Runtime.InteropServices.RuntimeInformation
-        from the Output folder, but they won't be placed there
-        by default because NuGet references come in as CopyLocal false.
-
-        Work around this by manually copying them here.
-
-        TODO: this shouldn't be here. After moving to a better binplacing model (like "publish
-        msbuild.exe to a folder") it should be removed. This whole project file should be removed. :)
-  -->
-  <Target Name="CopyDependenciesFromNugetNeededByVsix"
-          AfterTargets="DeployRuntime">
-
-    <Copy SourceFiles="@(ResolvedRuntimeFiles)"
-          DestinationFolder="$(OutputPath)"
-          SkipUnchangedFiles="true"
-          Condition=
-          "'%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Collections.Immutable' or
-          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Threading.Tasks.Dataflow' or
-          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Runtime.InteropServices.RuntimeInformation'"
           />
   </Target>
 

--- a/targets/runtimeDependencies/project.json
+++ b/targets/runtimeDependencies/project.json
@@ -11,14 +11,14 @@
     "xunit": "2.1.0",
     "microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00629-09",
     "System.IO.FileSystem": "4.0.1",
-    "System.IO.Compression": "4.1.0",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "System.IO.Compression": "4.1.0"
   },
   "frameworks": {
     "net46": {
       "dependencies": {
         "xunit.runner.visualstudio": "2.1.0",
         "System.Collections.Immutable": "1.3.1",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Threading.Tasks.Dataflow": "4.5.24.0",
         "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01"
       }
@@ -32,6 +32,7 @@
         "Microsoft.NETCore.Platforms": "1.0.1",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Console": "4.0.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.IO.FileSystem.Watcher": "4.0.0",
         "System.IO.FileSystem.DriveInfo": "4.0.0",
         "System.IO.Pipes": "4.0.0",


### PR DESCRIPTION
…s (#1926)"

This reverts commit dba03f23b12e6eb9db52e66b65748b9aed6ce19f.

We broke VS with this change due to mysterious shared dependencies. Undoing temporarily to get VS rolling again.

@eerhardt :)