### PR TITLE
Fix for MSBuild command parser confused by Fully Qualified Path to proj files in Linux root #1894

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -464,6 +464,12 @@ namespace Microsoft.Build.Shared
                 return true;
             }
 
+            // Check for actual files or directories under / that get missed by the above logic
+            if (firstSlash == 0 && value[0] == '/' && (Directory.Exists(value) || File.Exists(value)))
+            {
+                return true;
+            }
+
             return false;
         }
 

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -833,7 +833,11 @@ namespace Microsoft.Build.UnitTests
         [PlatformSpecific(Xunit.PlatformID.AnyUnix)]
         public void AbsolutePathLooksLikeUnixPathOnUnix()
         {
+            var secondSlash = SystemSpecificAbsolutePath.Substring(1).IndexOf(Path.DirectorySeparatorChar) + 1;
+            var rootLevelPath = SystemSpecificAbsolutePath.Substring(0, secondSlash);
+
             Assert.True(FileUtilities.LooksLikeUnixFilePath(SystemSpecificAbsolutePath));
+            Assert.True(FileUtilities.LooksLikeUnixFilePath(rootLevelPath));
         }
 
         [Fact]
@@ -842,6 +846,7 @@ namespace Microsoft.Build.UnitTests
         {
             Assert.False(FileUtilities.LooksLikeUnixFilePath(SystemSpecificAbsolutePath));
             Assert.False(FileUtilities.LooksLikeUnixFilePath("/path/that/looks/unixy"));
+            Assert.False(FileUtilities.LooksLikeUnixFilePath("/root"));
         }
 
         private static string SystemSpecificAbsolutePath => FileUtilities.ExecutingAssemblyPath;


### PR DESCRIPTION
The FileUtilities.LooksLikeLinuxPath() only returns true if the first path
segment is a directory. This can't be true for files in the root directory
on *nix systems. This commit adds an additional check to determine if the
parameter is a file.