### PR TITLE
Update DistributedLoggerBadPath to use Assert.Equals

### DIFF
--- a/src/Build.UnitTests/FileLogger_Tests.cs
+++ b/src/Build.UnitTests/FileLogger_Tests.cs
@@ -448,14 +448,14 @@ namespace Microsoft.Build.UnitTests
                                                           + "mylogfile.log");
 
                 fileLogger.Initialize(new EventSourceSink());
-                Assert.True(
-                              string.Compare(
-                                             fileLogger.InternalFilelogger.Parameters,
-                                             ";ShowCommandLine;logfile="
-                                             + Path.Combine(
-                                                            Directory.GetCurrentDirectory(),
-                                                            Path.DirectorySeparatorChar + "DONTEXIST" + Path.DirectorySeparatorChar + "mylogfile2.log"),
-                                             StringComparison.OrdinalIgnoreCase) == 0);
+
+                Assert.Equal(
+                    fileLogger.InternalFilelogger.Parameters,
+                    ";ShowCommandLine;logfile="
+                        + Path.Combine(
+                        Directory.GetCurrentDirectory(),
+                        Path.DirectorySeparatorChar + "DONTEXIST" + Path.DirectorySeparatorChar + "mylogfile2.log"), 
+                    StringComparer.OrdinalIgnoreCase);
             }
            );
         }


### PR DESCRIPTION
Assert.True() only tells you if the condition was false but Assert.Equals() will tell us why the strings were different.

FYI @patros