### PR TITLE
Revert "Revert "A better GetAllGlobs (#1871)" (#1946)"

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -500,10 +500,12 @@ namespace Microsoft.Build.Evaluation
 {
     public partial class GlobResult
     {
-        public GlobResult(Microsoft.Build.Construction.ProjectItemElement itemElement, string glob, System.Collections.Generic.IEnumerable<string> excludes) { }
+        internal GlobResult() { }
         public System.Collections.Generic.IEnumerable<string> Excludes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string Glob { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> IncludeGlobs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Construction.ProjectItemElement ItemElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Globbing.IMSBuildGlob MsBuildGlob { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.IEnumerable<string> Removes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     [System.FlagsAttribute]
     public enum NewProjectFileOptions

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -913,6 +913,7 @@ namespace Microsoft.Build.Execution
         public BuildManager() { }
         public BuildManager(string hostName) { }
         public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
+        public static bool WaitForDebugger { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
         public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
         public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -500,7 +500,7 @@ namespace Microsoft.Build.Evaluation
 {
     public partial class GlobResult
     {
-        internal GlobResult() { }
+        public GlobResult(Microsoft.Build.Construction.ProjectItemElement itemElement, System.Collections.Generic.IEnumerable<string> includeGlobStrings, Microsoft.Build.Globbing.IMSBuildGlob globWithGaps, System.Collections.Generic.IEnumerable<string> excludeFragmentStrings, System.Collections.Generic.IEnumerable<string> removeFragmentStrings) { }
         public System.Collections.Generic.IEnumerable<string> Excludes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Collections.Generic.IEnumerable<string> IncludeGlobs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Construction.ProjectItemElement ItemElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
@@ -913,7 +913,6 @@ namespace Microsoft.Build.Execution
         public BuildManager() { }
         public BuildManager(string hostName) { }
         public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
-        public static bool WaitForDebugger { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
         public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
         public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -488,10 +488,12 @@ namespace Microsoft.Build.Evaluation
 {
     public partial class GlobResult
     {
-        public GlobResult(Microsoft.Build.Construction.ProjectItemElement itemElement, string glob, System.Collections.Generic.IEnumerable<string> excludes) { }
+        internal GlobResult() { }
         public System.Collections.Generic.IEnumerable<string> Excludes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string Glob { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> IncludeGlobs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Construction.ProjectItemElement ItemElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Globbing.IMSBuildGlob MsBuildGlob { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Collections.Generic.IEnumerable<string> Removes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     [System.FlagsAttribute]
     public enum NewProjectFileOptions

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -488,7 +488,7 @@ namespace Microsoft.Build.Evaluation
 {
     public partial class GlobResult
     {
-        internal GlobResult() { }
+        public GlobResult(Microsoft.Build.Construction.ProjectItemElement itemElement, System.Collections.Generic.IEnumerable<string> includeGlobStrings, Microsoft.Build.Globbing.IMSBuildGlob globWithGaps, System.Collections.Generic.IEnumerable<string> excludeFragmentStrings, System.Collections.Generic.IEnumerable<string> removeFragmentStrings) { }
         public System.Collections.Generic.IEnumerable<string> Excludes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Collections.Generic.IEnumerable<string> IncludeGlobs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Construction.ProjectItemElement ItemElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }

--- a/src/Build.UnitTests/Evaluation/ItemSpec_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemSpec_Tests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Execution;
+using Microsoft.Build.UnitTests.BackEnd;
+using Xunit;
+using ProjectInstanceItemSpec =
+    Microsoft.Build.Evaluation.ItemSpec<Microsoft.Build.Execution.ProjectPropertyInstance, Microsoft.Build.Execution.ProjectItemInstance>;
+using ProjectInstanceExpander =
+    Microsoft.Build.Evaluation.Expander<Microsoft.Build.Execution.ProjectPropertyInstance, Microsoft.Build.Execution.ProjectItemInstance>;
+
+namespace Microsoft.Build.UnitTests.OM.Evaluation
+{
+    public class ItemSpec_Tests
+    {
+        [Fact]
+        public void EachFragmentTypeShouldContributeToItemSpecGlob()
+        {
+            var itemSpec = CreateItemSpecFrom("a;b*;c*;@(foo)", CreateExpander(new Dictionary<string, string[]> {{"foo", new[] {"d", "e"}}}));
+
+            var itemSpecGlob = itemSpec.ToMSBuildGlob();
+
+            Assert.True(itemSpecGlob.IsMatch("a"));
+            Assert.True(itemSpecGlob.IsMatch("bar"));
+            Assert.True(itemSpecGlob.IsMatch("car"));
+            Assert.True(itemSpecGlob.IsMatch("d"));
+            Assert.True(itemSpecGlob.IsMatch("e"));
+        }
+
+        [Fact]
+        public void FragmentGlobsWorkAfterStateIsPartiallyInitializedByOtherOperations()
+        {
+            var itemSpec = CreateItemSpecFrom("a;b*;c*;@(foo)", CreateExpander(new Dictionary<string, string[]> {{"foo", new[] {"d", "e"}}}));
+
+            int matches;
+            // cause partial Lazy state to initialize in the ItemExpressionFragment
+            itemSpec.FragmentsMatchingItem("e", out matches);
+
+            Assert.Equal(1, matches);
+
+            var itemSpecGlob = itemSpec.ToMSBuildGlob();
+
+            Assert.True(itemSpecGlob.IsMatch("a"));
+            Assert.True(itemSpecGlob.IsMatch("bar"));
+            Assert.True(itemSpecGlob.IsMatch("car"));
+            Assert.True(itemSpecGlob.IsMatch("d"));
+            Assert.True(itemSpecGlob.IsMatch("e"));
+        }
+
+        private ProjectInstanceItemSpec CreateItemSpecFrom(string itemSpec, ProjectInstanceExpander expander)
+        {
+            return new ProjectInstanceItemSpec(itemSpec, expander, MockElementLocation.Instance);
+        }
+
+        private ProjectInstanceExpander CreateExpander(Dictionary<string, string[]> items)
+        {
+            var itemDictionary = ToItemDictionary(items);
+
+            return new ProjectInstanceExpander(new PropertyDictionary<ProjectPropertyInstance>(), itemDictionary);
+        }
+
+        private static ItemDictionary<ProjectItemInstance> ToItemDictionary(Dictionary<string, string[]> itemTypes)
+        {
+            var itemDictionary = new ItemDictionary<ProjectItemInstance>();
+
+            var dummyProject = ProjectHelpers.CreateEmptyProjectInstance();
+
+            foreach (var itemType in itemTypes)
+            {
+                foreach (var item in itemType.Value)
+                {
+                    itemDictionary.Add(new ProjectItemInstance(dummyProject, itemType.Key, item, dummyProject.FullPath));
+                }
+            }
+
+            return itemDictionary;
+        }
+    }
+}

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Evaluation\ImportFromMSBuildExtensionsPath_Tests.cs" />
     <Compile Include="Evaluation\Preprocessor_Tests.cs" />
     <Compile Include="Evaluation\ProjectRootElementCache_Tests.cs" />
+    <Compile Include="Evaluation\ItemSpec_Tests.cs" />
     <Compile Include="Evaluation\ProjectStringCache_Tests.cs" />
     <Compile Include="EventArgsFormatting_Tests.cs" />
     <Compile Include="ExpressionTreeExpression_Tests.cs" />

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3721,7 +3721,10 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public IEnumerable<string> Removes { get; set; }
 
-        internal GlobResult(ProjectItemElement itemElement, IEnumerable<string> includeGlobStrings, IMSBuildGlob globWithGaps, IEnumerable<string> excludeFragmentStrings, IEnumerable<string> removeFragmentStrings)
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public GlobResult(ProjectItemElement itemElement, IEnumerable<string> includeGlobStrings, IMSBuildGlob globWithGaps, IEnumerable<string> excludeFragmentStrings, IEnumerable<string> removeFragmentStrings)
         {
             ItemElement = itemElement;
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -29,6 +30,9 @@ using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using ProjectItemFactory = Microsoft.Build.Evaluation.ProjectItem.ProjectItemFactory;
 using System.Globalization;
+using Microsoft.Build.Globbing;
+using EvaluationItemSpec = Microsoft.Build.Evaluation.ItemSpec<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
+using EvaluationItemExpressionFragment = Microsoft.Build.Evaluation.ItemExpressionFragment<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -1072,31 +1076,39 @@ namespace Microsoft.Build.Evaluation
         /// <code>
         ///<P>*.txt</P>
         /// 
+        ///<Bar Include="bar"/> (both outside and inside project cone)
         ///<Zar Include="C:\**\*.foo"/> (both outside and inside project cone)
-        ///<Foo Include="*.a" Exclude="3.a"/>
+        ///<Foo Include="*.a;*.b" Exclude="3.a"/>
+        ///<Foo Remove="2.a" />
         ///<Foo Include="**\*.b" Exclude="1.b;**\obj\*.b;**\bar\*.b"/>
         ///<Foo Include="$(P)"/> 
         ///<Foo Include="*.a;@(Bar);3.a"/> (If Bar has globs, they will have been included when querying Bar ProjectItems for globs)
-        ///<Foo Include="*.cs" Exclude="@(Bar)"/> (out of project cone glob)
+        ///<Foo Include="*.cs" Exclude="@(Bar)"/>
         ///</code>
         /// 
         ///Example result: 
         ///[
         ///GlobResult(glob: "C:\**\*.foo", exclude: []),
-        ///GlobResult(glob: "*.a", exclude=["3.a"]),
+        ///GlobResult(glob: ["*.a", "*.b"], exclude=["3.a"], remove=["2.a"]),
         ///GlobResult(glob: "**\*.b", exclude=["1.b, **\obj\*.b", **\bar\*.b"]),
         ///GlobResult(glob: "*.txt", exclude=[]),
         ///GlobResult(glob: "*.a", exclude=[]),
-        ///GlobResult(glob: "*.cs", exclude=[])
+        ///GlobResult(glob: "*.cs", exclude=["bar"])
         ///]
         /// </example>
         /// <remarks>
-        /// Sources of innacuracies: 
-        /// - <code>GlobResult.Excludes</code> does not contain information from item references (e.g. Exclude="@(Item)")
-        /// (it sees items as they are at the end of evaluation)
+        /// <see cref="GlobResult.MsBuildGlob"/> is a <see cref="IMSBuildGlob"/> that combines all globs in the include element and ignores
+        /// all the fragments in the exclude attribute and all the fragments in all Remove elements that apply to the include element.
+        /// 
+        /// Users can construct a composite glob that incorporates all the globs in the Project:
+        /// <code>
+        /// var uberGlob = new CompositeGlob(project.GetAllGlobs().Select(r => r.MSBuildGlob).ToArray());
+        /// uberGlob.IsMatch("foo.cs");
+        /// </code>
+        /// 
         /// </remarks>
         /// <returns>
-        /// List of <see cref="GlobResult"/>. Sorted in project evaluation order.
+        /// List of <see cref="GlobResult"/>.
         /// </returns>
         public List<GlobResult> GetAllGlobs()
         {
@@ -1117,33 +1129,169 @@ namespace Microsoft.Build.Evaluation
             return GetAllGlobs(GetItemElementsByType(GetEvaluatedItemElements(), itemType));
         }
 
-        private List<GlobResult> GetAllGlobs(List<ProjectItemElement> projectItemElements)
+        // represents cumulated remove information for a particular item type
+        private struct CumulativeRemoveElementData
         {
-            return projectItemElements
-                .AsParallel()
-                .AsOrdered()
-                .SelectMany(GetAllGlobs)
-                .ToList();
+            private ImmutableList<IMSBuildGlob>.Builder _globs;
+            private ImmutableHashSet<string>.Builder _fragmentStrings;
+
+            public IEnumerable<IMSBuildGlob> Globs => _globs.ToImmutable();
+            public IEnumerable<string> FragmentStrings => _fragmentStrings.ToImmutable();
+
+            public static CumulativeRemoveElementData Create()
+            {
+                return new CumulativeRemoveElementData
+                {
+                    _globs = ImmutableList.CreateBuilder<IMSBuildGlob>(),
+                    _fragmentStrings = ImmutableHashSet.CreateBuilder<string>()
+                };
+            }
+
+            public void AccumulateInformationFromRemoveItemSpec(EvaluationItemSpec removeSpec)
+            {
+                var removeSpecFragmentStrings = removeSpec.FlattenFragmentsAsStrings();
+                var removeGlob = removeSpec.ToMSBuildGlob();
+
+                _globs.Add(removeGlob);
+
+                foreach (var removeFragment in removeSpecFragmentStrings)
+                {
+                    _fragmentStrings.Add(removeFragment);
+                }
+            }
         }
 
-        private IEnumerable<GlobResult> GetAllGlobs(ProjectItemElement itemElement)
+        private List<GlobResult> GetAllGlobs(List<ProjectItemElement> projectItemElements)
         {
-            var includeItemspec = new ItemSpec<ProjectProperty, ProjectItem>(itemElement.Include, _data.Expander, itemElement.IncludeLocation);
-            var excludeItemspec = new ItemSpec<ProjectProperty, ProjectItem>(itemElement.Exclude, _data.Expander, itemElement.ExcludeLocation);
-
-            var excludeSet =
-                new Lazy<IEnumerable<string>>(
-                    () =>
-                        excludeItemspec.Fragments.Where(
-                            // take out item references, we can't reason about them
-                            f => !(f is ItemExpressionFragment<ProjectProperty, ProjectItem>))
-                            .Select(f => f.ItemSpecFragment)
-                            .ToImmutableHashSet());
-
-            foreach (var globFragment in includeItemspec.Fragments.Where(f => f is GlobFragment))
+            if (projectItemElements.Count == 0)
             {
-                yield return new GlobResult(itemElement, globFragment.ItemSpecFragment, excludeSet.Value);
+                return new List<GlobResult>();
             }
+
+            // Scan the project elements in reverse order and build globbing information for each include element.
+            // Based on the fact that relevant removes for a particular include element (xml element A) consist of:
+            // - all the removes seen by the next include statement of A's type (xml element B which appears after A in file order)
+            // - new removes between A and B (removes that apply to A but not to B. Spacially, these are placed between A's element and B's element)
+
+            // Example:
+            // 1. <I Include="A"/>
+            // 2. <I Remove="..."/> // this remove applies to the include at 1
+            // 3. <I Include="B"/>
+            // 4. <I Remove="..."/> // this remove applies to the includes at 1, 3
+            // 5. <I Include="C"/>
+            // 6. <I Remove="..."/> // this remove applies to the includes at 1, 3, 5
+            // So A's applicable removes are composed of:
+            // 
+            // The applicable removes for the element at position 1 (xml element A) are composed of:
+            // - all the removes seen by the next include statement of I's type (xml element B, position 3, which appears after A in file order). In this example that's Removes at positions 4 and 6.
+            // - new removes between A and B. In this example that's Remove 2.
+
+            // use immutable builders because there will be a lot of structural sharing between includes which share increasing subsets of corresponding remove elements
+            // item type -> aggregated information about all removes seen so far for that item type
+            var removeElementCache = new Dictionary<string, CumulativeRemoveElementData>(projectItemElements.Count);
+            var globResults = new List<GlobResult>(projectItemElements.Count);
+
+            for (var i = projectItemElements.Count - 1; i >= 0; i--)
+            {
+                var itemElement = projectItemElements[i];
+
+                if (!string.IsNullOrEmpty(itemElement.Include))
+                {
+                    var globResult = BuildGlobResultFromIncludeItem(itemElement, removeElementCache);
+
+                    if (globResult != null)
+                    {
+                        globResults.Add(globResult);
+                    }
+                }
+                else if (!string.IsNullOrEmpty(itemElement.Remove))
+                {
+                    CacheInformationFromRemoveItem(itemElement, removeElementCache);
+                }
+            }
+
+            globResults.TrimExcess();
+
+            return globResults;
+        }
+
+        private GlobResult BuildGlobResultFromIncludeItem(ProjectItemElement itemElement, IReadOnlyDictionary<string, CumulativeRemoveElementData> removeElementCache)
+        {
+            var includeItemspec = new EvaluationItemSpec(itemElement.Include, _data.Expander, itemElement.IncludeLocation);
+
+            var includeGlobFragments = includeItemspec.Fragments.Where(f => f is GlobFragment).ToImmutableArray();
+
+            if (includeGlobFragments.Length == 0)
+            {
+                return null;
+            }
+
+            var includeGlobStrings = includeGlobFragments.Select(f => f.ItemSpecFragment).ToImmutableArray();
+            var includeGlob = new CompositeGlob(includeGlobFragments.Select(f => f.ToMSBuildGlob()));
+
+            IEnumerable<string> excludeFragmentStrings = Enumerable.Empty<string>();
+            IMSBuildGlob excludeGlob = null;
+
+            if (!string.IsNullOrEmpty(itemElement.Exclude))
+            {
+                var excludeItemspec = new EvaluationItemSpec(itemElement.Exclude, _data.Expander, itemElement.ExcludeLocation);
+
+                excludeFragmentStrings = excludeItemspec.FlattenFragmentsAsStrings().ToImmutableHashSet();
+                excludeGlob = excludeItemspec.ToMSBuildGlob();
+            }
+
+            IEnumerable<string> removeFragmentStrings = Enumerable.Empty<string>();
+            IMSBuildGlob removeGlob = null;
+
+            if (removeElementCache.ContainsKey(itemElement.ItemType))
+            {
+                removeFragmentStrings = removeElementCache[itemElement.ItemType].FragmentStrings;
+                removeGlob = new CompositeGlob(removeElementCache[itemElement.ItemType].Globs);
+            }
+
+            var includeGlobWithGaps = CreateIncludeGlobWithGaps(includeGlob, excludeGlob, removeGlob);
+
+            return new GlobResult(itemElement, includeGlobStrings, includeGlobWithGaps, excludeFragmentStrings, removeFragmentStrings);
+        }
+
+        private static IMSBuildGlob CreateIncludeGlobWithGaps(IMSBuildGlob includeGlob, IMSBuildGlob excludeGlob, IMSBuildGlob removeGlob)
+        {
+            if (excludeGlob != null && removeGlob != null)
+            {
+                return new MSBuildGlobWithGaps(
+                    includeGlob,
+                    new CompositeGlob(
+                        excludeGlob,
+                        removeGlob
+                    ));
+            }
+
+            if (excludeGlob != null || removeGlob != null)
+            {
+                var gapGlob = excludeGlob ?? removeGlob;
+
+                return new MSBuildGlobWithGaps(
+                    includeGlob,
+                    gapGlob
+                );
+            }
+
+            return includeGlob;
+        }
+
+        private void CacheInformationFromRemoveItem(ProjectItemElement itemElement, Dictionary<string, CumulativeRemoveElementData> removeElementCache)
+        {
+            CumulativeRemoveElementData cumulativeRemoveElementData;
+            if (!removeElementCache.TryGetValue(itemElement.ItemType, out cumulativeRemoveElementData))
+            {
+                cumulativeRemoveElementData = CumulativeRemoveElementData.Create();
+
+                removeElementCache[itemElement.ItemType] = cumulativeRemoveElementData;
+            }
+
+            var removeSpec = new EvaluationItemSpec(itemElement.Remove, _data.Expander, itemElement.RemoveLocation);
+
+            cumulativeRemoveElementData.AccumulateInformationFromRemoveItemSpec(removeSpec);
         }
 
         /// <summary>
@@ -1245,7 +1393,7 @@ namespace Microsoft.Build.Evaluation
 
         private static IEnumerable<ProjectItemElement> GetItemElementsThatMightAffectItem(List<ProjectItemElement> evaluatedItemElements, ProjectItem item)
         {
-            var relevantElementsAfterInclude =  evaluatedItemElements
+            var relevantElementsAfterInclude = evaluatedItemElements
                 // Skip until we encounter the element that produced the item because
                 // there are no item operations that can affect future items
                 .SkipWhile((i => i != item.Xml))
@@ -1259,7 +1407,7 @@ namespace Microsoft.Build.Evaluation
                     itemElement.RemoveLocation == null);
 
             // add the include operation that created the project item element
-            return new[] {item.Xml}.Concat(relevantElementsAfterInclude);
+            return new[] { item.Xml }.Concat(relevantElementsAfterInclude);
         }
 
         private static List<ProjectItemElement> GetItemElementsByType(IEnumerable<ProjectItemElement> itemElements, string itemType)
@@ -1267,7 +1415,7 @@ namespace Microsoft.Build.Evaluation
             return itemElements.Where(i => i.ItemType.Equals(itemType)).ToList();
         }
 
-        private List<ProvenanceResult> GetItemProvenance(string itemToMatch, IEnumerable<ProjectItemElement> projectItemElements )
+        private List<ProvenanceResult> GetItemProvenance(string itemToMatch, IEnumerable<ProjectItemElement> projectItemElements)
         {
             if (string.IsNullOrEmpty(itemToMatch))
             {
@@ -1344,7 +1492,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             // expand the properties
-            var expandedItemSpec = new ItemSpec<ProjectProperty, ProjectItem>(itemSpec, expander, elementLocation, expandProperties: true);
+            var expandedItemSpec = new EvaluationItemSpec(itemSpec, expander, elementLocation, expandProperties: true);
             var numberOfMatches = ItemMatchesInItemSpec(itemToMatch, expandedItemSpec, out provenance);
 
             // Result is inconclusive if properties are present
@@ -1356,7 +1504,7 @@ namespace Microsoft.Build.Evaluation
             return numberOfMatches;
         }
 
-        private int ItemMatchesInItemSpec(string itemToMatch, ItemSpec<ProjectProperty, ProjectItem> itemSpec, out Provenance provenance)
+        private int ItemMatchesInItemSpec(string itemToMatch, EvaluationItemSpec itemSpec, out Provenance provenance)
         {
             provenance = Provenance.Undefined;
 
@@ -1373,7 +1521,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     provenance |= Provenance.Glob;
                 }
-                else if (fragment is ItemExpressionFragment<ProjectProperty, ProjectItem>)
+                else if (fragment is EvaluationItemExpressionFragment)
                 {
                     provenance |= Provenance.Inconclusive;
                 }
@@ -3543,34 +3691,45 @@ namespace Microsoft.Build.Evaluation
     }
     /// <summary>
     /// Data class representing a result from <see cref="Project.GetAllGlobs()"/> and its overloads.
-    /// This represents a glob found in an item include together with the item element it came from
-    /// and the excludes that were present on that item.
+    /// This represents all globs found in an item include together with the item element it came from,
+    /// the excludes that were present on that item, and all the Remove item elements pertaining to the Include item element.
     /// </summary>
     public class GlobResult
     {
         /// <summary>
-        /// Gets the original glob used to generate the result.
-        /// </summary>
-        public string Glob { get; private set; }
-
-        /// <summary>
-        /// Gets an <see cref="ISet{String}"/> containing paths that were excluded.
-        /// </summary>
-        public IEnumerable<string> Excludes{ get; private set; }
-
-        /// <summary>
-        /// Gets the original <see cref="ProjectItemElement"/> that contained the glob.
+        /// Gets the original <see cref="ProjectItemElement"/> that contained the globs.
         /// </summary>
         public ProjectItemElement ItemElement { get; private set; }
 
         /// <summary>
-        /// Initializes an instance of the GlobResult class.
+        /// Gets all the evaluated glob strings (properties expanded) from the include.
         /// </summary>
-        public GlobResult(ProjectItemElement itemElement, string glob, IEnumerable<string> excludes)
+        public IEnumerable<string> IncludeGlobs { get; private set; }
+
+        /// <summary>
+        /// A <see cref="IMSBuildGlob"/> representing the include globs. It also takes the excludes and relevant removes into consideration.
+        /// </summary>
+        public IMSBuildGlob MsBuildGlob { get; set; }
+
+        /// <summary>
+        /// Gets an <see cref="ISet{String}"/> containing strings that were excluded.
+        /// </summary>
+        public IEnumerable<string> Excludes { get; private set; }
+
+        /// <summary>
+        /// Gets an <see cref="ISet{String}"/> containing strings that were later removed via the Remove element.
+        /// </summary>
+        public IEnumerable<string> Removes { get; set; }
+
+        internal GlobResult(ProjectItemElement itemElement, IEnumerable<string> includeGlobStrings, IMSBuildGlob globWithGaps, IEnumerable<string> excludeFragmentStrings, IEnumerable<string> removeFragmentStrings)
         {
             ItemElement = itemElement;
-            Glob = glob;
-            Excludes = excludes;
+
+            IncludeGlobs = includeGlobStrings;
+            MsBuildGlob = globWithGaps;
+
+            Excludes = excludeFragmentStrings;
+            Removes = removeFragmentStrings;
         }
     }
 

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -4,6 +4,7 @@
 
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Microsoft.Build.Globbing
@@ -21,17 +22,23 @@ namespace Microsoft.Build.Globbing
         /// <summary>
         ///     Constructor
         /// </summary>
-        /// <param name="globs">Children globs</param>
+        /// <param name="globs">Children globs. Input gets shallow cloned</param>
         public CompositeGlob(IEnumerable<IMSBuildGlob> globs)
         {
-            Globs = globs;
+            // ImmutableArray also does this check, but copied it here just in case they remove it
+            if (globs is ImmutableArray<IMSBuildGlob>)
+            {
+                Globs = (ImmutableArray<IMSBuildGlob>)globs;
+            }
+
+            Globs = globs.ToImmutableArray();
         }
 
         /// <summary>
         ///     Constructor
         /// </summary>
-        /// <param name="globs">children globs</param>
-        public CompositeGlob(params IMSBuildGlob[] globs) : this(globs.AsEnumerable())
+        /// <param name="globs">Children globs. Input gets shallow cloned</param>
+        public CompositeGlob(params IMSBuildGlob[] globs) : this(globs.ToImmutableArray())
         {}
 
         /// <inheritdoc />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -660,6 +660,9 @@
     <Compile Include="..\Shared\ExceptionHandling.cs">
       <Link>SharedUtilities\ExceptionHandling.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\EscapingStringExtensions\EscapingStringExtensions.cs">
+      <Link>SharedUtilities\EscapingStringExtensions\EscapingStringExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\FileMatcher.cs">
       <Link>SharedUtilities\FileMatcher.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Shared/EscapingStringExtensions/EscapingStringExtensions.cs
+++ b/src/Shared/EscapingStringExtensions/EscapingStringExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Shared.EscapingStringExtensions
+{
+    internal static class EscapingStringExtensions
+    {
+        internal static string Unescape(this string escapedString)
+        {
+            return EscapingUtilities.UnescapeAll(escapedString);
+        }
+
+        internal static string Unescape
+        (
+            this string escapedString,
+            out bool escapingWasNecessary
+        )
+        {
+            return EscapingUtilities.UnescapeAll(escapedString, out escapingWasNecessary);
+        }
+
+        internal static string Escape(this string unescapedString)
+        {
+            return EscapingUtilities.Escape(unescapedString);
+        }
+
+        internal static bool ContainsEscapedWildcards(this string escapedString)
+        {
+            return EscapingUtilities.ContainsEscapedWildcards(escapedString);
+        }
+    }
+}

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -23,7 +23,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-MONO|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-MONO|AnyCPU'" />
-  <ItemGroup >
+  <ItemGroup>
     <Compile Condition="'$(NetCoreBuild)' == 'true'" Include="..\Shared\Compat\SafeHandleZeroOrMinusOneIsInvalid.cs">
       <Link>Compat\SafeHandleZeroOrMinusOneIsInvalid.cs</Link>
     </Compile>
@@ -88,6 +88,9 @@
     </Compile>
     <Compile Include="..\Shared\ExceptionHandling.cs">
       <Link>ExceptionHandling.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\EscapingStringExtensions\EscapingStringExtensions.cs">
+      <Link>EscapingStringExtensions\EscapingStringExtensions.cs</Link>
     </Compile>
     <Compile Include="..\Shared\FileUtilities.cs">
       <Link>FileUtilities.cs</Link>
@@ -253,7 +256,7 @@
       <LogicalName>$(AssemblyName).Strings.shared.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-    <!-- Assemblies Files we depend on -->
+  <!-- Assemblies Files we depend on -->
   <ItemGroup Condition="'$(NetCoreBuild)' != 'true'">
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
This reverts commit b98bc3ad486f5dac5eebf19e2d973fef4ab5e22e and brings back the new GetAllGlobs

Initial Revert PR: https://github.com/Microsoft/msbuild/pull/1946
Initial PR with the new GetAllGlobs.

I also made the GlobResult constructor public so API users can create mocks.

