### PR TITLE
Build failure on 64-bit MSBuild as could not load assembly " XamlBuildTask.dll”

### DIFF
--- a/src/XMakeCommandLine/app.amd64.config
+++ b/src/XMakeCommandLine/app.amd64.config
@@ -47,12 +47,10 @@
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
-          <codeBase version="15.0.0.0" href="..\Microsoft.Activities.Build.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
-          <codeBase version="15.0.0.0" href="..\XamlBuildTask.dll"/>
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -41,10 +41,12 @@
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+          <codeBase version="15.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+          <codeBase version="15.0.0.0" href=".\amd64\XamlBuildTask.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->

--- a/src/XMakeTasks/Microsoft.Xaml.targets
+++ b/src/XMakeTasks/Microsoft.Xaml.targets
@@ -13,7 +13,7 @@
         the .NET Framework directory and thus will no longer be the right answer. Override it to point
         to the correct .NET Framework location. --> 
    <PropertyGroup>
-      <XamlBuildTaskPath Condition="'$(XamlBuildTaskPath)' == ''">$(MSBuildThisFileDirectory)</XamlBuildTaskPath>
+      <XamlBuildTaskPath Condition="'$(XamlBuildTaskPath)' == ''">$(MSBuildToolsPath64)</XamlBuildTaskPath>
    </PropertyGroup>
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.Xaml.targets" Condition="Exists('$(MSBuildFrameworkToolsPath)\Microsoft.Xaml.targets')" />


### PR DESCRIPTION
The root cause of the issue is because MSBuild cannot find the XamlBuildTask.dll for X-platform build (I.e.: using x86 MSBuild to build x64 assembly). The fix requires 3 changes as below.

WF Team: First change is to drop XamlBuildTask.dll and Microsoft.Activitity.Build.dll to …\MSBuild\15.0\Bin\amd64 rather than MSBuild\15.0\Bin. Second change is to update the app base for 2nd app domain so that they can find XmlBuildTask.dll.

MSBuild Team: Another change is in Github to update the XmalBuildTaskPath to $(MSBuildToolsPath64) in "Microsoft.Xaml.Targets".
