### PR TITLE
Implement importing a list of files

### DIFF
--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -1056,7 +1056,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 directory2 = Path.Combine(Path.GetTempPath(), "fol$der" + Path.DirectorySeparatorChar + "fol$der2");
                 Directory.CreateDirectory(directory2);
 
-                string importPathRelativeEscaped = Path.Combine("fol$(x)$der2", "Escap%3beab$(x)leChar$ac;tersInI*tPa?h");
+                string importPathRelativeEscaped = Path.Combine("fol$(x)$der2", "Escap%3beab$(x)leChar$ac%3BtersInI*tPa?h");
                 string importRelative1 = Path.Combine("fol$der2", "Escap;eableChar$ac;tersInImportPath");
                 string importRelative2 = Path.Combine("fol$der2", "Escap;eableChar$ac;tersInI_XXXX_tPath");
                 importPath1 = Path.Combine(directory, importRelative1);

--- a/src/Build.UnitTests/ExpressionTreeExpression_Tests.cs
+++ b/src/Build.UnitTests/ExpressionTreeExpression_Tests.cs
@@ -336,11 +336,6 @@ namespace Microsoft.Build.UnitTests
             "existsX",
             "!",
             "nonexistentfunction('xyz')",
-            "exists('a;b')", /* non scalar */
-            "exists(@(z))",
-            "exists('@(z)')",
-            "exists($(a_semi_b))",
-            "exists('$(a_semi_b)')",
             "exists(@(v)x)",
             "exists(@(v)$(nonexistent))",
             "exists('@(v)$(a)')",

--- a/src/Build.UnitTests/ExpressionTreeExpression_Tests.cs
+++ b/src/Build.UnitTests/ExpressionTreeExpression_Tests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.UnitTests
         private readonly ITestOutputHelper output;
 
 
-        private static readonly string[] FilesWithExistenceChecks = { "a", "a;b", "a'b", ";", "'" };
+        private static readonly string[] FilesWithExistenceChecks = { "a", "c", "a;b", "a'b", ";", "'" };
 
         private readonly Expander<ProjectPropertyInstance, ProjectItemInstance> _expander;
 
@@ -137,6 +137,8 @@ namespace Microsoft.Build.UnitTests
             "exists(a)",
             "exists('a%3bb')", /* semicolon */
             "exists('a%27b')", /* apostrophe */
+            "exists('a;c')", /* items */
+            "exists($(a_semi_c))",
             "exists($(a_escapedsemi_b))",
             "exists('$(a_escapedsemi_b)')",
             "exists($(a_escapedapos_b))",
@@ -192,6 +194,11 @@ namespace Microsoft.Build.UnitTests
             "exists('@(u)')",
             "exists('$(foo_apos_foo)')",
             "!exists('a')",
+            "!exists('a;c')",
+            "!exists('$(a_semi_c)')",
+            "exists('a;b;c')", /* a and c exist but b does not */
+            "exists('b;c;a')",
+            "exists('$(a_semi_c);b')",
             "!!!exists(a)",
             "exists('|||||')",
             @"hastrailingslash('foo')",
@@ -377,7 +384,7 @@ namespace Microsoft.Build.UnitTests
             propertyBag.Set(ProjectPropertyInstance.Create("e", "xxx"));
             propertyBag.Set(ProjectPropertyInstance.Create("f", "1.9.5"));
             propertyBag.Set(ProjectPropertyInstance.Create("and", "and"));
-            propertyBag.Set(ProjectPropertyInstance.Create("a_semi_b", "a;b"));
+            propertyBag.Set(ProjectPropertyInstance.Create("a_semi_c", "a;c"));
             propertyBag.Set(ProjectPropertyInstance.Create("a_apos_b", "a'b"));
             propertyBag.Set(ProjectPropertyInstance.Create("foo_apos_foo", "foo'foo"));
             propertyBag.Set(ProjectPropertyInstance.Create("a_escapedsemi_b", "a%3bb"));

--- a/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
@@ -40,9 +40,12 @@ namespace Microsoft.Build.Evaluation
 
                 try
                 {
-                    return !ExpandArgumentAsFileList((GenericExpressionNode) _arguments[0], state)
+                    // Expand the items and use DefaultIfEmpty in case there is nothing returned
+                    // Then check if everything is not null (because the list was empty), not
+                    // already loaded into the cache, and exists
+                    return ExpandArgumentAsFileList((GenericExpressionNode) _arguments[0], state)
                         .DefaultIfEmpty()
-                        .Any(i => i == null || state.LoadedProjectsCache?.TryGet(i) == null && !FileUtilities.FileOrDirectoryExistsNoThrow(i));
+                        .All(i => i != null && (state.LoadedProjectsCache?.TryGet(i) != null || FileUtilities.FileOrDirectoryExistsNoThrow(i)));
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {

--- a/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-
+using System.Linq;
 using Microsoft.Build.Shared;
 
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
@@ -38,20 +38,11 @@ namespace Microsoft.Build.Evaluation
                 // Check we only have one argument
                 VerifyArgumentCount(1, state);
 
-                // Expand properties and items, and verify the result is an appropriate scalar
-                string expandedValue = ExpandArgumentForScalarParameter("exists", (GenericExpressionNode)_arguments[0], state);
-
-                if (String.IsNullOrEmpty(expandedValue))
-                {
-                    return false;
-                }
-
                 try
                 {
-                    if (state.EvaluationDirectory != null && !Path.IsPathRooted(expandedValue))
-                    {
-                        expandedValue = Path.GetFullPath(Path.Combine(state.EvaluationDirectory, expandedValue));
-                    }
+                    return !ExpandArgumentAsFileList((GenericExpressionNode) _arguments[0], state)
+                        .DefaultIfEmpty()
+                        .Any(i => i == null || state.LoadedProjectsCache?.TryGet(i) == null && !FileUtilities.FileOrDirectoryExistsNoThrow(i));
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {
@@ -64,15 +55,6 @@ namespace Microsoft.Build.Evaluation
 
                     return false;
                 }
-
-                if (state.LoadedProjectsCache != null && state.LoadedProjectsCache.TryGet(expandedValue) != null)
-                {
-                    return true;
-                }
-
-                bool exists = FileUtilities.FileOrDirectoryExistsNoThrow(expandedValue);
-
-                return exists;
             }
             else if (String.Compare(_functionName, "HasTrailingSlash", StringComparison.OrdinalIgnoreCase) == 0)
             {
@@ -128,9 +110,7 @@ namespace Microsoft.Build.Evaluation
                 argument = FileUtilities.FixFilePath(argument);
             }
 
-            IList<TaskItem> items;
-
-            items = state.ExpandIntoTaskItems(argument);
+            IList<TaskItem> items = state.ExpandIntoTaskItems(argument);
 
             string expandedValue = String.Empty;
 
@@ -152,6 +132,23 @@ namespace Microsoft.Build.Evaluation
             }
 
             return expandedValue;
+        }
+
+        private IEnumerable<string> ExpandArgumentAsFileList(GenericExpressionNode argumentNode, ConditionEvaluator.IConditionEvaluationState state, bool isFilePath = true)
+        {
+            string argument = argumentNode.GetUnexpandedValue(state);
+
+            // Fix path before expansion
+            if (isFilePath)
+            {
+                argument = FileUtilities.FixFilePath(argument);
+            }
+
+            return state.ExpandIntoTaskItems(argument)
+                .Select(i =>
+                    state.EvaluationDirectory != null && !Path.IsPathRooted(i.ItemSpec)
+                        ? Path.GetFullPath(Path.Combine(state.EvaluationDirectory, i.ItemSpec))
+                        : i.ItemSpec);
         }
 
         /// <summary>


### PR DESCRIPTION
Allows `<Import Project="import1.props;import2.props" />` to work.  This also updates `Exists` so that this will work:

```xml
<Import Project="import1.props;import2.props"
   Condition="Exists('import1.props;import2.props')" />
```

It also works with properties:

```xml
<Project>

  <PropertyGroup>
    <Imports>import1.props</Imports>
    <Imports>$(Imports);import2.props</Imports>
  </PropertyGroup>

  <Import Project="$(Imports)" Condition=" '$(Imports)' != '' And Exists($(Imports))" />
</Project>
```
**It does not work with items** because items are not available when evaluating `<Import />` elements.

Closes #890 