### PR TITLE
FixFilePath for %(Filename) item modifier

### DIFF
--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Build.Shared
                         }
                         else
                         {
-                            modifiedItemSpec = Path.GetFileNameWithoutExtension(itemSpec);
+                            modifiedItemSpec = Path.GetFileNameWithoutExtension(FixFilePath(itemSpec));
                         }
                     }
                     else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.Extension, StringComparison.OrdinalIgnoreCase) == 0)


### PR DESCRIPTION
This manifested as a bug when building any project with Xamarin Studio
on OSX.  The debug file from `obj/x86/Debug/Console009.pdb` would end up
in `bin/Debug/obj/x86/Debug/Console009.pdb`, instead of
`bin/Debug/Console009.pdb`. A subsequent build worked correctly though!
And it would build correctly on the command line.

Looking at the logs, one of the differences was that in the first build
we had ..

    BaseIntermediateOutputPath     = obj\

.. and the second one had

    BaseIntermediateOutputPath     = obj/

This also affected `_DebugSymbolsIntermediatePath` which ended up with
backslashes, `obj\x86\Debug\Console009.pdb`.

    <_DebugSymbolsOutputPath Include="@(_DebugSymbolsIntermediatePath->'$(OutDir)%(Filename)%(Extension)')" />

So, when `_DebugSymbolsOutputPath` tried to get `%(Filename)` in the
transform, it ended up with `obj\x86\Debug\Console009` as the filename,
because of the backlashes.

Investigating, it turns out that we do try to convert the path to unix
style for `BaseIntermediateOutputPath` via `MaybeFileAdjustPath`, but it
gets rejected by `LooksLikeUnixPath`, because `obj` directory does *not*
exist at this point. But after the first build, that directory does
exist, so a subsequent build gets the path converted and works fine.

Also, it turns out that we are fixing up paths for other file related
item modifiers, but seem to have missed it for `%(Filename)`. It makes
sense to always convert (on !windows) the path here, since the item is
expected to be a file path at this point.

In case of the command line builds, a different code path was executed
as it immediately starts the build, which caused the paths to be
converted with `FixFilePath`:

  at Microsoft.Build.Shared.FileUtilities.FixFilePath (System.String path) [0x0002b] in /Users/ankit/dev/msbuild/src/Shared/FileUtilities.cs:397
  at Microsoft.Build.Execution.ProjectItemInstance+TaskItem..ctor (System.String includeEscaped, System.String includeBeforeWildcardExpansionEscaped, Microsoft.Build.Collections.CopyOnWritePropertyDictionary`1[T] directMetadata, System.Collections.Generic.List`1[T] itemDefinitions, System.String projectDirectory, System.Boolean immutable, System.String definingFileEscaped) [0x00020] in /Users/ankit/dev/msbuild/src/Build/Instance/ProjectItemInstance.cs:811
  at Microsoft.Build.Execution.ProjectItemInstance.CommonConstructor (Microsoft.Build.Execution.ProjectInstance projectToUse, System.String itemTypeToUse, System.String includeEscaped, System.String includeBeforeWildcardExpansionEscaped, Microsoft.Build.Collections.CopyOnWritePropertyDictionary`1[T] directMetadata, System.Collections.Generic.List`1[T] itemDefinitions, System.String definingFileEscaped) [0x0007e] in /Users/ankit/dev/msbuild/src/Build/Instance/ProjectItemInstance.cs:711
  at Microsoft.Build.Execution.ProjectItemInstance..ctor (Microsoft.Build.Execution.ProjectInstance project, System.String itemType, System.String includeEscaped, System.String includeBeforeWildcardExpansionEscaped, Microsoft.Build.Collections.CopyOnWritePropertyDictionary`1[T] directMetadata, System.Collections.Generic.List`1[T] itemDefinitions, System.String definingFileEscaped) [0x00008] in /Users/ankit/dev/msbuild/src/Build/Instance/ProjectItemInstance.cs:94
  at Microsoft.Build.Execution.ProjectItemInstance..ctor (Microsoft.Build.Execution.ProjectInstance project, System.String itemType, System.String includeEscaped, System.String includeBeforeWildcardExpansionEscaped, System.String definingFileEscaped) [0x00000] in /Users/ankit/dev/msbuild/src/Build/Instance/ProjectItemInstance.cs:75

Bug: https://bugzilla.xamarin.com/show_bug.cgi?id=53019