### PR TITLE
Switch to producing portable PDBs instead of classic PDBs.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -176,6 +176,7 @@
   <!-- Set the host specific OS and Architecture variables -->
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <DebugType>portable</DebugType>
 
     <!-- Possible Values: win7 / osx.10.10.  For linux, the value is calculated in cibuild.sh and passed at the command-line -->
     <RuntimeSystem Condition="'$(TargetPlatformIdentifier)' == 'Windows_NT'">win7</RuntimeSystem>

--- a/dir.targets
+++ b/dir.targets
@@ -131,6 +131,16 @@
     </PropertyGroup>
   </Target>
 
+  <!-- The C# compiler supports the new EmbeddedFiles item for files to embed into the portable .pdb
+  http://source.roslyn.io/#MSBuildItem=EmbeddedFiles -->
+  <Target Name="PopulateEmbeddedFiles"
+          AfterTargets="BeforeCompile"
+          BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <EmbeddedFiles Include="@(Compile)" />
+    </ItemGroup>
+  </Target>
+
   <!-- We want this target to be incremental, but editbin affects the file in place, as does
        OpenSourceSign. So run this target when the assembly has been updated since the last
        time it was signed. Signing will run immediately after this, flipping another bit and


### PR DESCRIPTION
Embed all source files directly into the PDBs.