### PR TITLE
Generate Portable PDBs and add SourceLink.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -176,6 +176,8 @@
   <!-- Set the host specific OS and Architecture variables -->
   <PropertyGroup>
     <Deterministic>true</Deterministic>
+    <DebugType>portable</DebugType>
+    <SourceLinkCreate>true</SourceLinkCreate>
 
     <!-- Possible Values: win7 / osx.10.10.  For linux, the value is calculated in cibuild.sh and passed at the command-line -->
     <RuntimeSystem Condition="'$(TargetPlatformIdentifier)' == 'Windows_NT'">win7</RuntimeSystem>

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -3,6 +3,7 @@
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
+        "SourceLink.Create.CommandLine": "2.1.0",
         "System.Collections.Immutable": "1.3.1",
         "System.Threading.Tasks.Dataflow": "4.5.24.0"
       }

--- a/src/Framework/project.json
+++ b/src/Framework/project.json
@@ -4,6 +4,7 @@
     "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "SourceLink.Create.CommandLine": "2.1.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Threading.Thread": "4.0.0"
       }

--- a/src/MSBuild/project.json
+++ b/src/MSBuild/project.json
@@ -8,6 +8,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": "1.0.1",
+        "SourceLink.Create.CommandLine": "2.1.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Diagnostics.FileVersionInfo": "4.0.0",
         "System.Diagnostics.Process": "4.1.0",

--- a/src/MSBuildTaskHost/project.json
+++ b/src/MSBuildTaskHost/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
+    "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5",
+    "SourceLink.Create.CommandLine": "2.1.0"
   },
   "frameworks": {
     "net35": { }

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -3,6 +3,7 @@
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
+        "SourceLink.Create.CommandLine": "2.1.0",
         "System.Collections.Immutable": "1.3.1",
         "System.Reflection.Metadata": "1.3.0"
       }

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -8,6 +8,7 @@
     "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "SourceLink.Create.CommandLine": "2.1.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TraceSource": "4.0.0",

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -111,5 +111,5 @@
 
   <!-- https://github.com/ctaggart/SourceLink - stamps the portable .pdbs with URLs to sources on GitHub 
   so that debugger can download the exact matching source files during debugging -->
-  <Import Project="$(PackagesDir)\sourcelink.create.commandline\2.1.0\build\SourceLink.Create.CommandLine.targets" Condition="'$(IsTestProject)' != 'true' And Exists('$(PackagesDir)\sourcelink.create.commandline\2.1.0\build\SourceLink.Create.CommandLine.targets')" />
+  <Import Project="$(PackagesDir)\sourcelink.create.commandline\2.1.0\build\SourceLink.Create.CommandLine.targets" Condition="'$(MSBuildRuntimeType)' == 'Full' And '$(IsTestProject)' != 'true' And Exists('$(PackagesDir)\sourcelink.create.commandline\2.1.0\build\SourceLink.Create.CommandLine.targets')" />
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -108,4 +108,8 @@
       </ReferencePath>
     </ItemGroup>
   </Target>
+
+  <!-- https://github.com/ctaggart/SourceLink - stamps the portable .pdbs with URLs to sources on GitHub 
+  so that debugger can download the exact matching source files during debugging -->
+  <Import Project="$(PackagesDir)\sourcelink.create.commandline\2.1.0\build\SourceLink.Create.CommandLine.targets" Condition="'$(IsTestProject)' != 'true' And Exists('$(PackagesDir)\sourcelink.create.commandline\2.1.0\build\SourceLink.Create.CommandLine.targets')" />
 </Project>


### PR DESCRIPTION
Switch to generating portable PDBs (instead of classic Windows PDBs). These are the future and since we're cross-platform as well it's good to switch.

Add https://github.com/ctaggart/SourceLink to the MSBuild repo. It injects a new target using `CompileDependsOn`. The `SourceLinkCreate` target determines the current git SHA, the origin remote URL and generates a `SourceLink.json` file that gets passed to `csc.exe` via the new `/sourcelink` switch. The file gets generated to: `C:\msbuild\bin\obj\Microsoft.Build.Framework\Debug\sourcelink.json`

Sample contents of the `SourceLink.json` file:

```
{"documents":{"C:\\msbuild\\*":"https://raw.githubusercontent.com/KirillOsenkov/msbuild/c57e0bd2d9014280d2f006826a1de85b6a32d481/*"}}
```

It will use the fork's URL for private builds but presumably it will take the official `https://github.com/Microsoft/MSBuild` for the CI server and official builds.