### PR TITLE
Fix issue importing an SDK via Import element.

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -90,10 +90,12 @@ namespace Microsoft.Build.Construction
     {
         internal ProjectImportElement() { }
         public Microsoft.Build.Construction.ImplicitImportLocation ImplicitImportLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string MinimumVersion { get { throw null; } set { } }
         public string Project { get { throw null; } set { } }
         public Microsoft.Build.Construction.ElementLocation ProjectLocation { get { throw null; } }
         public string Sdk { get { throw null; } set { } }
         public Microsoft.Build.Construction.ElementLocation SdkLocation { get { throw null; } }
+        public string Version { get { throw null; } set { } }
         protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("#Imports={Count} Condition={Condition} Label={Label}")]

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -90,10 +90,12 @@ namespace Microsoft.Build.Construction
     {
         internal ProjectImportElement() { }
         public Microsoft.Build.Construction.ImplicitImportLocation ImplicitImportLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string MinimumVersion { get { throw null; } set { } }
         public string Project { get { throw null; } set { } }
         public Microsoft.Build.Construction.ElementLocation ProjectLocation { get { throw null; } }
         public string Sdk { get { throw null; } set { } }
         public Microsoft.Build.Construction.ElementLocation SdkLocation { get { throw null; } }
+        public string Version { get { throw null; } set { } }
         protected override Microsoft.Build.Construction.ProjectElement CreateNewInstance(Microsoft.Build.Construction.ProjectRootElement owner) { throw null; }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("#Imports={Count} Condition={Condition} Label={Label}")]

--- a/src/Build.OM.UnitTests/Construction/ConstructionEditing_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ConstructionEditing_Tests.cs
@@ -16,6 +16,7 @@ using System.Xml;
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -3255,6 +3256,30 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             }
         }
 
+        public void UpdateSdkImportProperty()
+        {
+            ProjectRootElement project = ProjectRootElement.Create();
+            ProjectImportElement import = project.AddImport("file");
+
+            // Add properties and assert that the SdkReference is updated accordingly.
+            import.Sdk = "Name";
+            AssertSdkEquals(import, "Name", null, null);
+
+            import.Version = "Version";
+            AssertSdkEquals(import, "Name", "Version", null);
+
+            import.MinimumVersion = "Min";
+            AssertSdkEquals(import, "Name", "Version", "Min");
+
+            import.MinimumVersion = null;
+            AssertSdkEquals(import, "Name", "Version", null);
+
+            import.Version = null;
+            AssertSdkEquals(import, "Name", "Version", null);
+
+            Assert.Throws<ArgumentException>(() => import.Sdk = null);
+        }
+
         private static string AdjustSpacesForItem(string expectedItem)
         {
             Assert.False(string.IsNullOrEmpty(expectedItem));
@@ -3287,6 +3312,17 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             expectedItem = sb.ToString();
             return expectedItem;
+        }
+
+        private void AssertSdkEquals(ProjectImportElement importElement, string name, string version, string minimumVersion)
+        {
+            // Use reflection to verify the value. The property is not public and we do not have InternalsVisibleTo (by design).
+            PropertyInfo pi = importElement.GetType().GetProperty("ParsedSdkReference");
+
+            var expected = new SdkReference(name, version, minimumVersion);
+            var actual = (SdkReference) pi.GetValue(importElement);
+
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/Build.OM.UnitTests/Construction/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectSdkImplicitImport_Tests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
   <ItemGroup>
     <PackageReference Include=""Microsoft.NETCore.App"" Version=""1.0.1"" />
   </ItemGroup>";
-            File.WriteAllText(_sdkPropsPath, " < Project />");
+            File.WriteAllText(_sdkPropsPath, "<Project />");
             File.WriteAllText(_sdkTargetsPath, "<Project />");
 
             using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))
@@ -231,7 +231,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
   <ItemGroup>
     <PackageReference Include=""Microsoft.NETCore.App"" Version=""1.0.1"" />
   </ItemGroup>";
-            File.WriteAllText(_sdkPropsPath, " < Project />");
+            File.WriteAllText(_sdkPropsPath, " <Project />");
             File.WriteAllText(_sdkTargetsPath, "<Project />");
 
             using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))

--- a/src/Build.OM.UnitTests/Construction/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectSdkImplicitImport_Tests.cs
@@ -20,6 +20,24 @@ namespace Microsoft.Build.UnitTests.OM.Construction
     /// </summary>
     public class ProjectSdkImplicitImport_Tests : IDisposable
     {
+        private const string ProjectTemplateSdkAsAttribute = @"
+<Project Sdk=""{0}"">
+  {1}
+</Project>";
+
+        private const string ProjectTemplateSdkAsElement = @"
+<Project>
+  <Sdk Name=""{0}"" />
+  {1}
+</Project>";
+
+        private const string ProjectTemplateSdkAsExplicitImport = @"
+<Project>
+  <Import Project=""Sdk.props"" Sdk=""{0}"" />
+  {1}
+  <Import Project=""Sdk.targets"" Sdk=""{0}"" />
+</Project>";
+
         private const string SdkName = "MSBuildUnitTestSdk";
         private readonly string _testSdkRoot;
         private readonly string _testSdkDirectory;
@@ -37,29 +55,18 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         }
 
         [Theory]
-        [InlineData(@"
-<Project Sdk=""{0}"">
-  <PropertyGroup>
-    <UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <Sdk Name=""{0}"" />
-  <PropertyGroup>
-    <UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation>
-  </PropertyGroup>
-</Project>
-")]
-        public void SdkImportsAreInLogicalProject(string projectFormatString)
+        [InlineData(ProjectTemplateSdkAsAttribute, false)]
+        [InlineData(ProjectTemplateSdkAsElement, true)]
+        [InlineData(ProjectTemplateSdkAsExplicitImport, false)]
+        public void SdkImportsAreInLogicalProject(string projectFormatString, bool expectImportInLogicalProject)
         {
+            string projectInnerContents = @"<PropertyGroup><UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation></PropertyGroup>";
             File.WriteAllText(_sdkPropsPath, "<Project><PropertyGroup><InitialImportProperty>Hello</InitialImportProperty></PropertyGroup></Project>");
             File.WriteAllText(_sdkTargetsPath, "<Project><PropertyGroup><FinalImportProperty>World</FinalImportProperty></PropertyGroup></Project>");
 
             using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))
             {
-                string content = string.Format(projectFormatString, SdkName);
+                string content = string.Format(projectFormatString, SdkName, projectInnerContents);
 
                 ProjectRootElement projectRootElement = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
 
@@ -68,42 +75,30 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 IList<ProjectElement> children = project.GetLogicalProject().ToList();
 
                 // <Sdk> style will have an extra ProjectElment.
-                var expected = projectFormatString.Contains("Sdk=") ? 6 : 7;
-                Assert.Equal(expected, children.Count);
+                Assert.Equal(expectImportInLogicalProject ? 7 : 6, children.Count);
             }
         }
 
         [Theory]
-        [InlineData(@"
-<Project Sdk=""{0}"">
-  <PropertyGroup>
-    <UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <Sdk Name=""{0}"" />
-  <PropertyGroup>
-    <UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation>
-  </PropertyGroup>
-</Project>
-")]
-        public void SdkImportsAreInImportList(string projectFormatString)
+        [InlineData(ProjectTemplateSdkAsAttribute, false)]
+        [InlineData(ProjectTemplateSdkAsElement, false)]
+        [InlineData(ProjectTemplateSdkAsExplicitImport, true)]
+        public void SdkImportsAreInImportList(string projectFormatString, bool expectImportInLogicalProject)
         {
+            string projectInnerContents = @"<PropertyGroup><UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation></PropertyGroup>";
             File.WriteAllText(_sdkPropsPath, "<Project><PropertyGroup><InitialImportProperty>Hello</InitialImportProperty></PropertyGroup></Project>");
             File.WriteAllText(_sdkTargetsPath, "<Project><PropertyGroup><FinalImportProperty>World</FinalImportProperty></PropertyGroup></Project>");
 
             using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))
             {
-                string content = string.Format(projectFormatString, SdkName);
+                string content = string.Format(projectFormatString, SdkName, projectInnerContents);
 
                 ProjectRootElement projectRootElement = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
 
                 var project = new Project(projectRootElement);
 
-                // The XML representation of the project should indicate there are no imports
-                Assert.Equal(0, projectRootElement.Imports.Count);
+                // The XML representation of the project should only indicate an import if they are not implicit.
+                Assert.Equal(expectImportInLogicalProject ? 2 : 0, projectRootElement.Imports.Count);
 
                 // The project representation should have imports
                 Assert.Equal(2, project.Imports.Count);
@@ -128,14 +123,24 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         [Theory]
         [InlineData(@"
 <Project Sdk=""{0};{1};{2}"">
-</Project >")]
+</Project >", false)]
         [InlineData(@"
 <Project>
   <Sdk Name=""{0}"" />
   <Sdk Name=""{1}"" />
   <Sdk Name=""{2}"" />
-</Project>")]
-        public void SdkSupportsMultiple(string projectFormatString)
+</Project>", false)]
+        [InlineData(@"
+<Project>
+  <Import Project=""Sdk.props"" Sdk=""{0}"" />
+  <Import Project=""Sdk.props"" Sdk=""{1}"" />
+  <Import Project=""Sdk.props"" Sdk=""{2}"" />
+
+  <Import Project=""Sdk.targets"" Sdk=""{0}"" />
+  <Import Project=""Sdk.targets"" Sdk=""{1}"" />
+  <Import Project=""Sdk.targets"" Sdk=""{2}"" />
+</Project>", true)]
+        public void SdkSupportsMultiple(string projectFormatString, bool expectImportInLogicalProject)
         {
             IList<string> sdkNames = new List<string>
             {
@@ -161,7 +166,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 Project project = new Project(projectRootElement);
 
                 // The XML representation of the project should indicate there are no imports
-                Assert.Equal(0, projectRootElement.Imports.Count);
+                Assert.Equal(expectImportInLogicalProject ? 6 : 0, projectRootElement.Imports.Count);
 
                 // The project representation should have twice as many imports as SDKs
                 Assert.Equal(sdkNames.Count * 2, project.Imports.Count);
@@ -173,21 +178,12 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         }
 
         [Theory]
-        [InlineData(@"<Project Sdk=""{0}"" ToolsVersion=""15.0"">
-")]
-        [InlineData(@"<Project ToolsVersion=""15.0"">
-  <Sdk Name=""{0}"" />
-")]
-        public void ProjectWithSdkImportsIsCloneable(string projectFileFirstLineFormat)
+        [InlineData(ProjectTemplateSdkAsAttribute)]
+        [InlineData(ProjectTemplateSdkAsElement)]
+        [InlineData(ProjectTemplateSdkAsExplicitImport)]
+        public void ProjectWithSdkImportsIsCloneable(string projectFormatString)
         {
-            File.WriteAllText(_sdkPropsPath, "<Project />");
-            File.WriteAllText(_sdkTargetsPath, "<Project />");
-
-            using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))
-            {
-                // Based on the new-console-project CLI template (but not matching exactly
-                // should not be a deal-breaker).
-                string content = $@"{string.Format(projectFileFirstLineFormat, SdkName)}
+            string projectInnerContents = @"
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -200,10 +196,15 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
   <ItemGroup>
     <PackageReference Include=""Microsoft.NETCore.App"" Version=""1.0.1"" />
-  </ItemGroup>
+  </ItemGroup>";
+            File.WriteAllText(_sdkPropsPath, " < Project />");
+            File.WriteAllText(_sdkTargetsPath, "<Project />");
 
-</Project>";
-
+            using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))
+            {
+                // Based on the new-console-project CLI template (but not matching exactly
+                // should not be a deal-breaker).
+                string content = string.Format(projectFormatString, SdkName, projectInnerContents);
                 ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
 
                 project.DeepClone();
@@ -211,21 +212,12 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         }
 
         [Theory]
-        [InlineData(@"<Project Sdk=""{0}"" ToolsVersion=""15.0"">
-")]
-        [InlineData(@"<Project ToolsVersion=""15.0"">
-  <Sdk Name=""{0}"" />
-")]
-        public void ProjectWithSdkImportsIsRemoveable(string projectFileFirstLineFormat)
+        [InlineData(ProjectTemplateSdkAsAttribute)]
+        [InlineData(ProjectTemplateSdkAsElement)]
+        [InlineData(ProjectTemplateSdkAsExplicitImport)]
+        public void ProjectWithSdkImportsIsRemoveable(string projectFormatString)
         {
-            File.WriteAllText(_sdkPropsPath, "<Project />");
-            File.WriteAllText(_sdkTargetsPath, "<Project />");
-
-            using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))
-            {
-                // Based on the new-console-project CLI template (but not matching exactly
-                // should not be a deal-breaker).
-                string content = $@"{string.Format(projectFileFirstLineFormat, SdkName)}
+            string projectInnerContents = @"
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -238,10 +230,15 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
   <ItemGroup>
     <PackageReference Include=""Microsoft.NETCore.App"" Version=""1.0.1"" />
-  </ItemGroup>
+  </ItemGroup>";
+            File.WriteAllText(_sdkPropsPath, " < Project />");
+            File.WriteAllText(_sdkTargetsPath, "<Project />");
 
-</Project>";
-
+            using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))
+            {
+                // Based on the new-console-project CLI template (but not matching exactly
+                // should not be a deal-breaker).
+                string content = string.Format(projectFormatString, SdkName, projectInnerContents);
                 ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
                 ProjectRootElement clone = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
 
@@ -280,21 +277,28 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// <summary>
         /// Verifies that an empty SDK attribute works and nothing is imported.
         /// </summary>
-        [Fact]
-        public void ProjectWithEmptySdkName()
+        [Theory]
+        [InlineData(ProjectTemplateSdkAsAttribute, false)]
+        [InlineData(ProjectTemplateSdkAsElement, true)]
+        [InlineData(ProjectTemplateSdkAsExplicitImport, true)]
+        public void ProjectWithEmptySdkName(string projectFormatString, bool throwsOnEvaluate)
         {
+            string projectInnerContents =
+                @"<PropertyGroup><UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation></PropertyGroup>";
+
             using (new Helpers.TemporaryEnvironment("MSBuildSDKsPath", _testSdkRoot))
             {
-                string content = @"
-                    <Project Sdk="""">
-                        <PropertyGroup>
-                            <UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation>
-                        </PropertyGroup>
-                    </Project>";
-
-                Project project = new Project(ProjectRootElement.Create(XmlReader.Create(new StringReader(content))));
-
-                Assert.Equal(0, project.Imports.Count);
+                string content = string.Format(projectFormatString, string.Empty, projectInnerContents);
+                if (throwsOnEvaluate)
+                {
+                    Assert.Throws<InvalidProjectFileException>(
+                        () => new Project(ProjectRootElement.Create(XmlReader.Create(new StringReader(content)))));
+                }
+                else
+                {
+                    var project = new Project(ProjectRootElement.Create(XmlReader.Create(new StringReader(content))));
+                    Assert.Equal(0, project.Imports.Count);
+                }
             }
         }
 

--- a/src/Build/Construction/ProjectImportElement.cs
+++ b/src/Build/Construction/ProjectImportElement.cs
@@ -169,6 +169,11 @@ namespace Microsoft.Build.Construction
             return owner.CreateImportElement(this.Project);
         }
 
+        /// <summary>
+        /// Helper method to extract attribute values and update the ParsedSdkReference property if
+        /// necessary (update only when changed).
+        /// </summary>
+        /// <returns>True if the ParsedSdkReference was updated, otherwise false (no update necessary).</returns>
         private bool CheckUpdatedSdk()
         {
 

--- a/src/Build/Construction/ProjectImportElement.cs
+++ b/src/Build/Construction/ProjectImportElement.cs
@@ -22,10 +22,11 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Initialize a parented ProjectImportElement
         /// </summary>
-        internal ProjectImportElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
+        internal ProjectImportElement(XmlElementWithLocation xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject, SdkReference sdkReference = null)
             : base(xmlElement, parent, containingProject)
         {
             ErrorUtilities.VerifyThrowArgumentNull(parent, "parent");
+            ParsedSdkReference = sdkReference;
         }
 
         /// <summary>
@@ -75,9 +76,37 @@ namespace Microsoft.Build.Construction
             set
             {
                 ErrorUtilities.VerifyThrowArgumentLength(value, XMakeAttributes.sdk);
-
+                if (!CheckUpdatedSdk()) return;
                 ProjectXmlUtilities.SetOrRemoveAttribute(XmlElement, XMakeAttributes.sdk, value);
                 MarkDirty("Set Import Sdk {0}", value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the version associated with this SDK import
+        /// </summary>
+        public string Version
+        {
+            get { return ProjectXmlUtilities.GetAttributeValue(XmlElement, XMakeAttributes.sdkVersion); }
+            set
+            {
+                if (!CheckUpdatedSdk()) return;
+                ProjectXmlUtilities.SetOrRemoveAttribute(XmlElement, XMakeAttributes.sdkVersion, value);
+                MarkDirty("Set Import Version {0}", value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the minimum SDK version required by this import.
+        /// </summary>
+        public string MinimumVersion
+        {
+            get { return ProjectXmlUtilities.GetAttributeValue(XmlElement, XMakeAttributes.sdkMinimumVersion); }
+            set
+            {
+                if (!CheckUpdatedSdk()) return;
+                ProjectXmlUtilities.SetOrRemoveAttribute(XmlElement, XMakeAttributes.sdkMinimumVersion, value);
+                MarkDirty("Set Import Minimum Version {0}", value);
             }
         }
 
@@ -138,6 +167,23 @@ namespace Microsoft.Build.Construction
         protected override ProjectElement CreateNewInstance(ProjectRootElement owner)
         {
             return owner.CreateImportElement(this.Project);
+        }
+
+        private bool CheckUpdatedSdk()
+        {
+
+            SdkReference sdk = new SdkReference(
+                ProjectXmlUtilities.GetAttributeValue(XmlElement, XMakeAttributes.sdk, true),
+                ProjectXmlUtilities.GetAttributeValue(XmlElement, XMakeAttributes.sdkVersion, true),
+                ProjectXmlUtilities.GetAttributeValue(XmlElement, XMakeAttributes.sdkMinimumVersion, true));
+
+            if (sdk.Equals(ParsedSdkReference))
+            {
+                return false;
+            }
+
+            ParsedSdkReference = sdk;
+            return true;
         }
     }
 }

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -523,9 +523,9 @@ namespace Microsoft.Build.Construction
             if (element.HasAttribute(XMakeAttributes.sdk))
             {
                 sdk = new SdkReference(
-                    element.GetAttribute(XMakeAttributes.sdk),
-                    element.GetAttribute(XMakeAttributes.sdkVersion),
-                    element.GetAttribute(XMakeAttributes.sdkMinimumVersion));
+                    ProjectXmlUtilities.GetAttributeValue(element, XMakeAttributes.sdk, nullIfNotExists: true),
+                    ProjectXmlUtilities.GetAttributeValue(element, XMakeAttributes.sdkVersion, nullIfNotExists: true),
+                    ProjectXmlUtilities.GetAttributeValue(element, XMakeAttributes.sdkMinimumVersion, nullIfNotExists: true));
             }
 
             return new ProjectImportElement(element, parent, _project, sdk);

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -11,6 +11,7 @@ using System.Xml;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using Microsoft.Build.Framework;
 #if (!STANDALONEBUILD)
 using Microsoft.Internal.Performance;
 
@@ -515,12 +516,19 @@ namespace Microsoft.Build.Construction
                 );
 
             ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnImport);
-
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.project);
-
             ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
 
-            return new ProjectImportElement(element, parent, _project);
+            SdkReference sdk = null;
+            if (element.HasAttribute(XMakeAttributes.sdk))
+            {
+                sdk = new SdkReference(
+                    element.GetAttribute(XMakeAttributes.sdk),
+                    element.GetAttribute(XMakeAttributes.sdkVersion),
+                    element.GetAttribute(XMakeAttributes.sdkMinimumVersion));
+            }
+
+            return new ProjectImportElement(element, parent, _project, sdk);
         }
 
         /// <summary>

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -267,12 +267,12 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Returns the value of the attribute. 
         /// If the attribute is not present, returns either null or an empty string, depending on the value 
-        /// of returnNullForNonexistentAttributes.
+        /// of nullIfNotExists.
         /// </summary>
-        internal static string GetAttributeValue(XmlElementWithLocation element, string attributeName, bool returnNullForNonexistentAttributes)
+        internal static string GetAttributeValue(XmlElementWithLocation element, string attributeName, bool nullIfNotExists)
         {
             XmlAttributeWithLocation attribute = (XmlAttributeWithLocation)element.GetAttributeNode(attributeName);
-            return GetAttributeValue(attribute, returnNullForNonexistentAttributes);
+            return GetAttributeValue(attribute, nullIfNotExists);
         }
     }
 }

--- a/src/MSBuild/Microsoft.Build.Core.xsd
+++ b/src/MSBuild/Microsoft.Build.Core.xsd
@@ -379,6 +379,24 @@
                 <xs:documentation><!-- _locID_text="ImportType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="Sdk" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <!-- _locID_text="ImportType_Sdk" _locComment="" -->Name of the SDK which contains the project file to import</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="Version" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <!-- _locID_text="ImportType_Version" _locComment="" -->Optional expression used to specify the version of the SDK referenced by this import</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="MinimumVersion" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <!-- _locID_text="ImportType_MinimumVersion" _locComment="" -->Optional expression used to specify the minimum SDK version required by the referring import</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <!-- ======================================================================================= -->  
     <xs:complexType name="ProjectExtensionsType" mixed="true">


### PR DESCRIPTION
* This feature was regressed in #2002
* Update unit tests to verify functionality
* Update ProjectParser to parse SDK name/version values and construct an SdkReference object to be used by the evaluator.

Closes #2034