### PR TITLE
Common.targets support for reference assemblies

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4038,6 +4038,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             >
 
       <Output TaskParameter="DestinationPath" ItemName="ReferenceAssembly"/>
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
 
     </CopyRefAssembly>
 
@@ -4502,6 +4503,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!--Record the main compile outputs.-->
     <ItemGroup>
       <FileWrites Include="@(IntermediateAssembly)" Condition="Exists('@(IntermediateAssembly)')"/>
+      <FileWrites Include="@(IntermediateRefAssembly)" Condition="'@(IntermediateRefAssembly)' != '' and Exists('@(IntermediateRefAssembly)')"/>
     </ItemGroup>
 
     <!-- Record the .xml if one was produced. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2060,6 +2060,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </ReferencePathWithRefAssemblies>
       <ReferencePathWithRefAssemblies Include="@(ReferencePath)"
                                       Condition="'$(CompileUsingReferenceAssemblies)' == 'false'" />
+
+      <!-- The project system normally looks only at the inputs to the compiler in its
+           fast up-to-date check, but if the implementation assembly of a ref is stale
+           we still want to rerun to ensure copies, etc. happen. -->
+      <UpToDateCheckInput Include="@(ReferencePathWithRefAssemblies->'%(OriginalPath)')" />
     </ItemGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1372,9 +1372,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       AfterResolveReferences
     </ResolveReferencesDependsOn>
   </PropertyGroup>
+
+  <!-- FindReferenceAssembliesForReferences needs to see a fully-populated @(ReferencePath),
+       so it should run after all of the subcomponents of ResolveReferences, including
+       user overrides of AfterResolveReferences and targets added by appending to
+       $(ResolveReferencesDependsOn) (like ImplicitlyExpandDesignTimeFacades). So list it
+       last explicitly, rather than adding it to the property.   -->
   <Target
       Name="ResolveReferences"
-      DependsOnTargets="$(ResolveReferencesDependsOn)"/>
+      DependsOnTargets="$(ResolveReferencesDependsOn);FindReferenceAssembliesForReferences"/>
 
   <!--
     ============================================================
@@ -2028,8 +2034,26 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="DependsOnSystemRuntime" PropertyName="DependsOnSystemRuntime"/>
     </ResolveAssemblyReference>
+  </Target>
 
-    <ItemGroup>
+  <!--
+    ============================================================
+
+                                        FindReferenceAssembliesForReferences
+
+    Given the list of references, create a list of assemblies to pass to the compiler that
+    includes reference assemblies rather than implementation assemblies where possible.
+
+        [IN]
+        @(ReferencePath) - List of assembly references as resolved paths with ReferenceAssembly metadata
+
+        [OUT]
+        @(ReferencePathWithRefAssemblies) - Paths to resolved reference (or implementation) assemblies.
+    ============================================================
+    -->
+  <Target Name="FindReferenceAssembliesForReferences"
+          DependsOnTargets="$(ResolveReferencesDependsOn)">
+      <ItemGroup>
       <ReferencePathWithRefAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')" />
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2032,6 +2032,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <ItemDefinitionGroup>
+    <!-- Reference assemblies are not produced in all cases, but it's easier to consume them
+         if this metadatum is always populated. This item definition ensures that it points
+         to the implementation assembly unless specified. -->
     <ReferencePath>
       <ReferenceAssembly>%(FullPath)</ReferenceAssembly>
     </ReferencePath>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2030,6 +2030,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="SerializationAssemblyFiles" ItemName="_ReferenceSerializationAssemblyPaths"/>
       <Output TaskParameter="ScatterFiles" ItemName="_ReferenceScatterPaths"/>
       <Output TaskParameter="CopyLocalFiles" ItemName="ReferenceCopyLocalPaths"/>
+      <!-- Indicate to the IDE that updated (possibly transitive) references should trigger
+           an (incremental) build. -->
+      <Output TaskParameter="CopyLocalFiles" ItemName="UpToDateCheckInput"/>
       <Output TaskParameter="SuggestedRedirects" ItemName="SuggestedBindingRedirects"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="DependsOnSystemRuntime" PropertyName="DependsOnSystemRuntime"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2030,7 +2030,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ResolveAssemblyReference>
 
     <ItemGroup>
-      <ReferencePathWithInterfaceOnlyAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')" />
+      <ReferencePathWithRefAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')" />
     </ItemGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2053,8 +2053,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target Name="FindReferenceAssembliesForReferences"
           DependsOnTargets="$(ResolveReferencesDependsOn)">
-      <ItemGroup>
-      <ReferencePathWithRefAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')" />
+    <ItemGroup>
+      <ReferencePathWithRefAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')"
+                                      Condition="'$(CompileUsingReferenceAssemblies)' != 'false'" />
+      <ReferencePathWithRefAssemblies Include="@(ReferencePath)"
+                                      Condition="'$(CompileUsingReferenceAssemblies)' == 'false'" />
     </ItemGroup>
   </Target>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1809,7 +1809,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TargetPathWithTargetPlatformMoniker Include="$(TargetPath)">
         <TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
         <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
-        <ReferenceAssembly Condition="'$(ProduceReferenceAssembly)' != ''">$(TargetRefPath)</ReferenceAssembly>
+        <ReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == 'true'">$(TargetRefPath)</ReferenceAssembly>
       </TargetPathWithTargetPlatformMoniker>
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -281,6 +281,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Example, c:\MyProjects\MyProject\bin\debug\MyAssembly.dll -->
     <TargetPath Condition=" '$(TargetPath)' == '' ">$(TargetDir)$(TargetFileName)</TargetPath>
 
+    <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(Deterministic)' == 'true' ">$([System.IO.Path]::Combine(`$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetFullPath(`$(TargetPath)`))))`, 'ref', `$(TargetFileName)`))</TargetRefPath>
+
     <!-- Example, c:\MyProjects\MyProject\ -->
     <ProjectDir Condition=" '$(ProjectDir)' == '' ">$(MSBuildProjectDirectory)\</ProjectDir>
 
@@ -348,6 +350,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <ItemGroup>
     <IntermediateAssembly Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)"/>
     <FinalDocFile Include="@(DocFileItem->'$(OutDir)%(Filename)%(Extension)')"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Deterministic)' == 'true'">
+    <!-- TODO: should this be configurable? Default path obeys conventions. -->
+    <IntermediateRefAssembly Include="$(IntermediateOutputPath)ref\$(TargetName)$(TargetExt)" Condition="'@(IntermediateRefAssembly)' == ''" />
+    <CreateDirectory Include="@(IntermediateRefAssembly->'%(RootDir)%(Directory)')" />
+    <CreateDirectory Include="$(OutDir)ref" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(_DebugSymbolsProduced)' == 'true'">
@@ -771,7 +780,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="Build"
       Condition=" '$(_InvalidConfigurationWarning)' != 'true' "
       DependsOnTargets="$(BuildDependsOn)"
-      Returns="$(TargetPath)" />
+      Returns="@(TargetPathWithTargetPlatformMoniker)" />
 
   <!--
     ============================================================
@@ -1797,6 +1806,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TargetPathWithTargetPlatformMoniker Include="$(TargetPath)">
         <TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
         <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+        <ReferenceAssembly Condition="'$(TargetRefPath)' != ''">$(TargetRefPath)</ReferenceAssembly>
       </TargetPathWithTargetPlatformMoniker>
     </ItemGroup>
   </Target>
@@ -2015,7 +2025,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="DependsOnSystemRuntime" PropertyName="DependsOnSystemRuntime"/>
     </ResolveAssemblyReference>
+
+    <ItemGroup>
+      <ReferencePathWithInterfaceOnlyAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')" />
+    </ItemGroup>
   </Target>
+
+  <ItemDefinitionGroup>
+    <ReferencePath>
+      <ReferenceAssembly>%(FullPath)</ReferenceAssembly>
+    </ReferencePath>
+  </ItemDefinitionGroup>
 
   <!--
     ====================================================================================================
@@ -4006,6 +4026,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
 
     </Copy>
+
+    <!-- Copy the build product (.dll or .exe). -->
+    <CopyRefAssembly
+        SourcePath="@(IntermediateRefAssembly)"
+        DestinationPath="$(TargetRefPath)"
+        Condition="'$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)' != 'true' and Exists('@(IntermediateRefAssembly)')"
+            >
+
+      <Output TaskParameter="DestinationPath" ItemName="ReferenceAssembly"/>
+
+    </CopyRefAssembly>
 
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; @(MainAssembly->'%(FullPath)')" Condition="'$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)'!='true'" />
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2055,7 +2055,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
           DependsOnTargets="$(ResolveReferencesDependsOn)">
     <ItemGroup>
       <ReferencePathWithRefAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')"
-                                      Condition="'$(CompileUsingReferenceAssemblies)' != 'false'" />
+                                      Condition="'$(CompileUsingReferenceAssemblies)' != 'false'">
+        <OriginalPath Condition="'%(ReferencePath.Identity)' != '@(ReferencePath->'%(ReferenceAssembly)')'">%(ReferencePath.Identity)</OriginalPath>
+      </ReferencePathWithRefAssemblies>
       <ReferencePathWithRefAssemblies Include="@(ReferencePath)"
                                       Condition="'$(CompileUsingReferenceAssemblies)' == 'false'" />
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -155,8 +155,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DocumentationFileProduced Condition="'$(DocumentationFile)'==''">false</_DocumentationFileProduced>
 
     <!-- Whether or not a reference assembly is produced. -->
-    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(Deterministic)' != 'true'">false</ProduceReferenceAssembly>
-    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(Deterministic)' == 'true'">true</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == ''">false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OutputPath)' == '' ">

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4030,7 +4030,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     </Copy>
 
-    <!-- Copy the build product (.dll or .exe). -->
+    <!-- Copy the reference assembly build product (.dll or .exe). -->
     <CopyRefAssembly
         SourcePath="@(IntermediateRefAssembly)"
         DestinationPath="$(TargetRefPath)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -154,9 +154,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DocumentationFileProduced>true</_DocumentationFileProduced>
     <_DocumentationFileProduced Condition="'$(DocumentationFile)'==''">false</_DocumentationFileProduced>
 
-    <!-- Whether or not a reference assembly is produced-->
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-    <ProduceReferenceAssembly Condition="'$(Deterministic)' == 'true'">true</ProduceReferenceAssembly>
+    <!-- Whether or not a reference assembly is produced. -->
+    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(Deterministic)' != 'true'">false</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == '' and '$(Deterministic)' == 'true'">true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OutputPath)' == '' ">

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4041,7 +4041,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             >
 
       <Output TaskParameter="DestinationPath" ItemName="ReferenceAssembly"/>
-      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+      <Output TaskParameter="DestinationPath" ItemName="FileWrites"/>
 
     </CopyRefAssembly>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -348,6 +348,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
     <_GenerateBindingRedirectsIntermediateAppConfig>$(IntermediateOutputPath)$(MSBuildProjectFile).$(TargetFileName).config</_GenerateBindingRedirectsIntermediateAppConfig>
+    <CopyUpToDateMarker Condition="'$(ProduceReferenceAssembly)' == 'true'">$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', '$(MSBuildProjectFile).CopyComplete'))</CopyUpToDateMarker>
   </PropertyGroup>
   <ItemGroup>
     <IntermediateAssembly Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)"/>
@@ -1814,6 +1815,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
         <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
         <ReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == 'true'">$(TargetRefPath)</ReferenceAssembly>
+        <CopyUpToDateMarker Condition="'$(ProduceReferenceAssembly)' == 'true'">$(CopyUpToDateMarker)</CopyUpToDateMarker>
       </TargetPathWithTargetPlatformMoniker>
     </ItemGroup>
   </Target>
@@ -2065,7 +2067,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <!-- The project system normally looks only at the inputs to the compiler in its
            fast up-to-date check, but if the implementation assembly of a ref is stale
            we still want to rerun to ensure copies, etc. happen. -->
-      <UpToDateCheckInput Include="@(ReferencePathWithRefAssemblies->'%(OriginalPath)')" />
+      <!-- The remote project might not have done anything to _its own_ assemblies, but
+           still need to invalidate the fast up-to-date check in projects that depend on
+           it because it has brought along a new implementation of one of its references. -->
+      <UpToDateCheckInput Include="@(ReferencePathWithRefAssemblies->'%(CopyUpToDateMarker)')" />
     </ItemGroup>
   </Target>
 
@@ -4235,8 +4240,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             >
 
       <Output TaskParameter="DestinationFiles" ItemName="FileWritesShareable"/>
+      <Output TaskParameter="CopiedFiles" ItemName="ReferencesCopiedInThisBuild"/>
 
     </Copy>
+
+    <!-- If this project produces reference assemblies *and* copied (possibly transitive)
+         references on this build, subsequent builds of projects that depend on it must
+         not be considered up to date, so touch this marker file that is considered an
+         input to projects that reference this one. -->
+    <Touch Files="$(CopyUpToDateMarker)"
+           AlwaysCreate="true"
+           Condition="'$(ProduceReferenceAssembly)' == 'true' and '@(ReferencesCopiedInThisBuild)' != ''" />
 
   </Target>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -154,6 +154,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DocumentationFileProduced>true</_DocumentationFileProduced>
     <_DocumentationFileProduced Condition="'$(DocumentationFile)'==''">false</_DocumentationFileProduced>
 
+    <!-- Whether or not a reference assembly is produced-->
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly Condition="'$(Deterministic)' == 'true'">true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OutputPath)' == '' ">
@@ -281,7 +284,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Example, c:\MyProjects\MyProject\bin\debug\MyAssembly.dll -->
     <TargetPath Condition=" '$(TargetPath)' == '' ">$(TargetDir)$(TargetFileName)</TargetPath>
 
-    <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(Deterministic)' == 'true' ">$([System.IO.Path]::Combine(`$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetFullPath(`$(TargetPath)`))))`, 'ref', `$(TargetFileName)`))</TargetRefPath>
+    <TargetRefPath Condition=" '$(TargetRefPath)' == '' and '$(ProduceReferenceAssembly)' == 'true' ">$([MSBuild]::NormalizePath($(TargetDir), 'ref', $(TargetFileName)))</TargetRefPath>
 
     <!-- Example, c:\MyProjects\MyProject\ -->
     <ProjectDir Condition=" '$(ProjectDir)' == '' ">$(MSBuildProjectDirectory)\</ProjectDir>
@@ -1806,7 +1809,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TargetPathWithTargetPlatformMoniker Include="$(TargetPath)">
         <TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
         <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
-        <ReferenceAssembly Condition="'$(TargetRefPath)' != ''">$(TargetRefPath)</ReferenceAssembly>
+        <ReferenceAssembly Condition="'$(ProduceReferenceAssembly)' != ''">$(TargetRefPath)</ReferenceAssembly>
       </TargetPathWithTargetPlatformMoniker>
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -355,8 +355,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <FinalDocFile Include="@(DocFileItem->'$(OutDir)%(Filename)%(Extension)')"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Deterministic)' == 'true'">
-    <!-- TODO: should this be configurable? Default path obeys conventions. -->
+  <ItemGroup Condition="'$(ProduceReferenceAssembly)' == 'true'">
     <IntermediateRefAssembly Include="$(IntermediateOutputPath)ref\$(TargetName)$(TargetExt)" Condition="'@(IntermediateRefAssembly)' == ''" />
     <CreateDirectory Include="@(IntermediateRefAssembly->'%(RootDir)%(Directory)')" />
     <CreateDirectory Include="$(OutDir)ref" />
@@ -4074,7 +4073,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CopyRefAssembly
         SourcePath="@(IntermediateRefAssembly)"
         DestinationPath="$(TargetRefPath)"
-        Condition="'$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)' != 'true' and Exists('@(IntermediateRefAssembly)')"
+        Condition="'$(ProduceReferenceAssembly)' == 'true' and '$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)' != 'true'"
             >
 
       <Output TaskParameter="DestinationPath" ItemName="ReferenceAssembly"/>
@@ -4543,7 +4542,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!--Record the main compile outputs.-->
     <ItemGroup>
       <FileWrites Include="@(IntermediateAssembly)" Condition="Exists('@(IntermediateAssembly)')"/>
-      <FileWrites Include="@(IntermediateRefAssembly)" Condition="'@(IntermediateRefAssembly)' != '' and Exists('@(IntermediateRefAssembly)')"/>
+      <FileWrites Include="@(IntermediateRefAssembly)" Condition="'$(ProduceReferenceAssembly)' == 'true' and Exists('@(IntermediateRefAssembly)')"/>
     </ItemGroup>
 
     <!-- Record the .xml if one was produced. -->

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -172,5 +172,6 @@
     <!-- Roslyn tasks are now in an assembly owned and shipped by Roslyn -->
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"                       AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"                       AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly"           AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
 </Project>
 


### PR DESCRIPTION
Provides an item, `ReferencePathWithInterfaceOnlyAssemblies`, that
consists of the reference (interface-only) versions of assemblies where
available, allowing a consuming task to be incrementally up-to-date
after implementation-only changes have been made to a reference.

When `%(ReferenceAssembly)` metadata is unavailable for a given
reference, the new item contains the implementation assembly directly.

Additionally creates a new output item for the current project's
reference assembly by default when `$(Deterministic)` is `true`. If this
is created, it is copied to the output directory using the new
`CopyRefAssembly` task, which copies only if the ref assembly is
different from the current file. If present, the ref asm is passed to
the project's consumes in metadata.

See #1986, dotnet/roslyn#2184.