### PR TITLE
Do not use PLINQ in CompositeGlob

### DIFF
--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -44,7 +44,10 @@ namespace Microsoft.Build.Globbing
         /// <inheritdoc />
         public bool IsMatch(string stringToMatch)
         {
-            return Globs.AsParallel().Any(g => g.IsMatch(stringToMatch));
+            // Threadpools are a scarce resource in Visual Studio, do not use them.
+            //return Globs.AsParallel().Any(g => g.IsMatch(stringToMatch));
+
+            return Globs.Any(g => g.IsMatch(stringToMatch));
         }
     }
 }


### PR DESCRIPTION
Threadpools are a scarce resource in VS, do not use them.

We should instead consider other optimisations: #2044 