### PR TITLE
Name framework type in logo

### DIFF
--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -87,10 +87,10 @@
     <comment>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</comment>
   </data>
   <data name="CopyrightMessage" UESanitized="true" Visibility="Public">
-    <value>Microsoft (R) Build Engine version {0}
+    <value>Microsoft (R) Build Engine version {0} for {1}
 Copyright (C) Microsoft Corporation. All rights reserved.
 </value>
-    <comment>LOCALIZATION: {0} contains the DLL version number</comment>
+    <comment>LOCALIZATION: {0} contains the DLL version number. {1} contains the name of a runtime, like ".NET Framework", ".NET Core", or "Mono"</comment>
   </data>
   <data name="DuplicateProjectSwitchError" UESanitized="true" Visibility="Public">
     <value>MSBUILD : error MSB1008: Only one project can be specified.</value>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3288,7 +3288,15 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private static void DisplayCopyrightMessage()
         {
-            Console.WriteLine(ResourceUtilities.FormatResourceString("CopyrightMessage", ProjectCollection.Version.ToString()));
+#if RUNTIME_TYPE_NETCORE
+            const string frameworkName = ".NET Core";
+#elif MONO
+            const string frameworkName = "Mono";
+#else
+            const string frameworkName = ".NET Framework";
+#endif
+
+            Console.WriteLine(ResourceUtilities.FormatResourceString("CopyrightMessage", ProjectCollection.Version.ToString(), frameworkName));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1662. Framework names are not localized (see for example
https://docs.microsoft.com/ko-kr/dotnet/), so I'm just defining the
string in code and passing it to the (localized) resource.