### PR TITLE
Revert "Use Dev15.1 in CI"

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -44,7 +44,7 @@ def branch = GithubBranchName
 
                         skipTestsWhenResultsNotFound = false
                     }
-                    Utilities.setMachineAffinity(newJob, 'Windows_NT', 'latest-dev15-1')
+                    Utilities.setMachineAffinity(newJob, 'Windows_NT', 'latest-or-auto-dev15-rc')
 
                     break;
                 case 'OSX':


### PR DESCRIPTION
Reverts Microsoft/msbuild#2068

Appears to cause test failures on `Microsoft.Build.UnitTests.ToolLocationHelper_Tests.GetUnversionedSDKUnionMetadataLocation`.