### PR TITLE
Do not crash worker nodes on shutdown+pipe close

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -203,19 +203,26 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #if RUNTIME_TYPE_NETCORE
         [Theory(Skip = "https://github.com/Microsoft/msbuild/issues/933")]
 #elif MONO
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/1240")]
+        [Theory(Skip = "https://github.com/Microsoft/msbuild/issues/1240")]
 #else
         [Theory]
         [InlineData(2, false)]
+        [InlineData(4, false)]
         [InlineData(8, false)]
+        [InlineData(12, false)]
         [InlineData(16, false)]
+        [InlineData(2, true)]
+        [InlineData(4, true)]
+        [InlineData(8, true)]
+        [InlineData(12, true)]
+        [InlineData(16, true)]
 #endif
         public void ShutdownNodesAfterParallelBuild(int numberOfParallelProjectsToBuild, bool enbaleDebugComm)
         {
             // This test has previously been failing silently. With the addition of TestEnvironment the
             // failure is now noticed (worker node is crashing with "Pipe is broken" exception. See #2057:
             // https://github.com/Microsoft/msbuild/issues/2057
-            _env.ClearTestInvariants();
+            //_env.ClearTestInvariants();
 
             // Communications debug log enabled, picked up by TestEnvironment
             if (enbaleDebugComm) _env.SetEnvironmentVariable("MSBUILDDEBUGCOMM", "1");

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -698,9 +698,9 @@ namespace Microsoft.Build.BackEnd
                             {
                                 // An error in any other situation is unexpected.
                                 ExceptionHandling.DumpExceptionToFile(e);
+                                ChangeLinkStatus(LinkStatus.Failed);
                             }
 
-                            ChangeLinkStatus(LinkStatus.Failed);
                             exitLoop = true;
                             break;
                         }

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -553,6 +553,8 @@ namespace Microsoft.Build.BackEnd
             Task<int> readTask = CommunicationsUtilities.ReadAsync(localReadPipe, headerByte, headerByte.Length);
 #endif
 
+            INodePacket currentLocalPacket = null;
+
             bool exitLoop = false;
             do
             {
@@ -642,22 +644,21 @@ namespace Microsoft.Build.BackEnd
                             // Write out all the queued packets.
                             while (packetCount > 0)
                             {
-                                INodePacket packet;
                                 lock (_packetQueue)
                                 {
-                                    packet = localPacketQueue.Dequeue();
+                                    currentLocalPacket = localPacketQueue.Dequeue();
                                 }
 
                                 MemoryStream packetStream = new MemoryStream();
                                 INodePacketTranslator writeTranslator = NodePacketTranslator.GetWriteTranslator(packetStream);
 
-                                packetStream.WriteByte((byte)packet.Type);
+                                packetStream.WriteByte((byte)currentLocalPacket.Type);
 
                                 // Pad for packet length
                                 packetStream.Write(BitConverter.GetBytes((int)0), 0, 4);
 
                                 // Reset the position in the write buffer.
-                                packet.Translate(writeTranslator);
+                                currentLocalPacket.Translate(writeTranslator);
 
                                 // Now write in the actual packet length
                                 packetStream.Position = 1;
@@ -684,7 +685,21 @@ namespace Microsoft.Build.BackEnd
                         {
                             // Error while deserializing or handling packet.  Abort.
                             CommunicationsUtilities.Trace("Exception while serializing packets: {0}", e);
-                            ExceptionHandling.DumpExceptionToFile(e);
+
+                            if (currentLocalPacket is NodeShutdown)
+                            {
+                                // Failing to send the "I'm shutting down right now" packet
+                                // might fail if the remote node just sent a "shut down right now"
+                                // packet followed by closing the pipe. Log, but don't treat
+                                // this as fatal
+                                CommunicationsUtilities.Trace("Ignoring exception when sending NodeShutdown acknowledgement packet");
+                            }
+                            else
+                            {
+                                // An error in any other situation is unexpected.
+                                ExceptionHandling.DumpExceptionToFile(e);
+                            }
+
                             ChangeLinkStatus(LinkStatus.Failed);
                             exitLoop = true;
                             break;

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Build.Engine.UnitTests
 
                     // Ignore clean shutdown trace logs.
                     if (Regex.IsMatch(file.Name, @"MSBuild_NodeShutdown_\d+\.txt") &&
-                        Regex.IsMatch(contents, @"Node shutting down with reason BuildComplete and exception:\s*"))
+                        Regex.IsMatch(contents, @"Node shutting down with reason BuildComplete(Reuse)* and exception:\s*"))
                     {
                         newFilesCount--;
                         continue;


### PR DESCRIPTION
The `ShutdownNodesAfterParallelBuild` test reliably reported node crashes
when everything seemed to be going fine. This turned out to be because `
`NodeProviderOutOfProcBase.ShutdownAllNodes()` sent a shutdown-request
packet and then *immediately* closed the communications pipe, so
(depending on process scheduling) the pipe might not exist for the worker
node to send back its "I am shutting down" packet.

Fixes #2057 by swallowing exceptions when sending the `NodeShutdown`
packet.