### PR TITLE
Fix custom localization and packing of satellite assemblies

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5411,7 +5411,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <ItemGroup>
       <SatelliteDllsProjectOutputGroupOutputIntermediate Include="$(IntermediateOutputPath)%(EmbeddedResource.Culture)\$(TargetName).resources.dll"
-                                                         Condition="'%(WithCulture)' == 'true'">
+                                                         Condition="'%(EmbeddedResource.WithCulture)' == 'true'">
         <TargetPath>%(EmbeddedResource.Culture)\$(TargetName).resources.dll</TargetPath>
         <Culture>%(EmbeddedResource.Culture)</Culture>
       </SatelliteDllsProjectOutputGroupOutputIntermediate>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5420,7 +5420,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Convert intermediate items into final items; this way we can get the full path for each item. -->
     <ItemGroup>
       <SatelliteDllsProjectOutputGroupOutput Include="@(SatelliteDllsProjectOutputGroupOutputIntermediate->'%(FullPath)')">
-        <FinalOutputPath>$(TargetDir)%(SatelliteDllsProjectOutputGroupOutputIntermediate.TargetPath)</FinalOutputPath>
+        <FinalOutputPath Condition=" '%(SatelliteDllsProjectOutputGroupOutputIntermediate.FinalOutputPath)' == '' ">$(TargetDir)%(SatelliteDllsProjectOutputGroupOutputIntermediate.TargetPath)</FinalOutputPath>
         <!-- For compatibility with 2.0 -->
         <OriginalItemSpec>%(SatelliteDllsProjectOutputGroupOutputIntermediate.Identity)</OriginalItemSpec>
       </SatelliteDllsProjectOutputGroupOutput>


### PR DESCRIPTION
## Add missing item type qualifier in Condition

This fixes SatelliteDllsProjectOutputGroup when SatelliteDllsProjectOutputGroupOutputIntermediate items already exist so that it doesn't double up and malform SatelliteDllsProjectOutputGroupOutputIntermediate items.

## Preserve FinalOutputPath metadata if preset 

When localization for an app occurs another way (like Microsoft's own LCL tooling) the FinalOutputPath isn't what is calculated here. We can preset it in the Intermediate items, but we need MSBuild to preserve that metadata when it is there.