### PR TITLE
Avoid CreateFile in hot GetLastWriteFileUtcTime

### DIFF
--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -55,6 +55,9 @@
     <Compile Include="..\Shared\ResourceUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\Traits.cs">
+      <Link>SharedTraits.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\UnitTests\TestEnvironment.cs">
       <Link>TestEnvironment.cs</Link>
     </Compile>

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -164,6 +164,9 @@
     <Compile Include="..\Shared\TaskEngineAssemblyResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\Traits.cs">
+      <Link>SharedTraits.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\AssemblyNameExtension.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -152,6 +152,9 @@
     <Compile Include="..\Shared\TaskParameterTypeVerifier.cs">
       <Link>TaskParameterTypeVerifier.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\Traits.cs">
+      <Link>SharedTraits.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\VisualStudioLocationHelper.cs">
       <Link>VisualStudioLocationHelper.cs</Link>
     </Compile>

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -25,31 +25,31 @@ namespace Microsoft.Build.Utilities
 
     internal class EscapeHatches
     {
-        public ProjectInstanceTranslationMode? ProjectInstanceTranslation => new Lazy<ProjectInstanceTranslationMode?>(
-            () =>
+        public ProjectInstanceTranslationMode? ProjectInstanceTranslation = ComputeProjectInstanceTranslation();
+
+        private static ProjectInstanceTranslationMode? ComputeProjectInstanceTranslation()
+        {
+            var mode = Environment.GetEnvironmentVariable("MSBUILD_PROJECTINSTANCE_TRANSLATION_MODE");
+
+            if (mode == null)
             {
-                var mode = Environment.GetEnvironmentVariable("MSBUILD_PROJECTINSTANCE_TRANSLATION_MODE");
-
-                if (mode == null)
-                {
-                    return null;
-                }
-
-                if (mode.Equals("full", StringComparison.OrdinalIgnoreCase))
-                {
-                    return ProjectInstanceTranslationMode.Full;
-                }
-
-                if (mode.Equals("partial", StringComparison.OrdinalIgnoreCase))
-                {
-                    return ProjectInstanceTranslationMode.Partial;
-                }
-
-                ErrorUtilities.ThrowInvalidOperation("Shared.InvalidEscapeHatchValue", mode);
-
                 return null;
-            },
-            true).Value;
+            }
+
+            if (mode.Equals("full", StringComparison.OrdinalIgnoreCase))
+            {
+                return ProjectInstanceTranslationMode.Full;
+            }
+
+            if (mode.Equals("partial", StringComparison.OrdinalIgnoreCase))
+            {
+                return ProjectInstanceTranslationMode.Partial;
+            }
+
+            ErrorUtilities.ThrowInvalidOperation("Shared.InvalidEscapeHatchValue", mode);
+
+            return null;
+        }
 
         public enum ProjectInstanceTranslationMode
         {

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -25,7 +25,17 @@ namespace Microsoft.Build.Utilities
 
     internal class EscapeHatches
     {
-        public ProjectInstanceTranslationMode? ProjectInstanceTranslation = ComputeProjectInstanceTranslation();
+        /// <summary>
+        /// Always use the accurate-but-slow CreateFile approach to timestamp extraction.
+        /// </summary>
+        public readonly bool AlwaysUseContentTimestamp = Environment.GetEnvironmentVariable("MSBUILDALWAYSCHECKCONTENTTIMESTAMP") == "1";
+
+        public readonly ProjectInstanceTranslationMode? ProjectInstanceTranslation = ComputeProjectInstanceTranslation();
+
+        /// <summary>
+        /// Never use the slow (but more accurate) CreateFile approach to timestamp extraction.
+        /// </summary>
+        public readonly bool UseSymlinkTimeInsteadOfTargetTime = Environment.GetEnvironmentVariable("MSBUILDUSESYMLINKTIMESTAMP") == "1";
 
         private static ProjectInstanceTranslationMode? ComputeProjectInstanceTranslation()
         {

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -179,6 +179,9 @@
     <Compile Include="..\Shared\ReadOnlyEmptyDictionary.cs" />
     <Compile Include="..\Shared\ReadOnlyEmptyList.cs" />
     <Compile Include="..\Shared\Tracing.cs" />
+    <Compile Include="..\Shared\Traits.cs">
+      <Link>SharedTraits.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\VersionUtilities.cs">
       <Link>VersionUtilities.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -177,7 +177,7 @@
       <Link>VisualStudioLocationHelper.cs</Link>
     </Compile>
     <Compile Include="..\Shared\Traits.cs">
-      <Link>Traits</Link>
+      <Link>SharedTraits.cs</Link>
     </Compile>
     <Compile Include="ApiContract.cs" />
     <Compile Include="AppDomainIsolatedTask.cs">


### PR DESCRIPTION
Fixes #2052 by calling the more performant `GetFileAttributesEx()`
first, and falling back to the slower `CreateFile()` + `GetFileTime()`
_only_ if `GetFileAttributesEx` reports that what it opened was a
"reparse point" (symlink).