### PR TITLE
Test: Non existing -> nonexistent

### DIFF
--- a/src/Tasks.UnitTests/Touch_Tests.cs
+++ b/src/Tasks.UnitTests/Touch_Tests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.UnitTests
 
         internal static string myexisting_txt = NativeMethodsShared.IsWindows ? @"c:\touch\myexisting.txt" : @"/touch/myexisting.txt";
         internal static string mynonexisting_txt = NativeMethodsShared.IsWindows ? @"c:\touch\mynonexisting.txt" : @"/touch/mynonexisting.txt";
-        internal static string nonexisting_txt = NativeMethodsShared.IsWindows ? @"c:\touch-non existing\file.txt" : @"/touch-nonexistent/file.txt";
+        internal static string nonexisting_txt = NativeMethodsShared.IsWindows ? @"c:\touch-nonexistent\file.txt" : @"/touch-nonexistent/file.txt";
         internal static string myreadonly_txt = NativeMethodsShared.IsWindows ? @"c:\touch\myreadonly.txt" : @"/touch/myreadonly.txt";
 
         private bool Execute(Touch t)


### PR DESCRIPTION
Although the tests passed as @rainersigwald pointed out in #2085 it makes more sense to keep the space out. It was just an unintentional replacement in the first place that also now makes the ternary look odd.