### PR TITLE
Do not leak dummy variable in user owned ProjectInstance object

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -3953,6 +3953,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     var mainProject = new Project(mainRootElement, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, collection);
                     var mainInstance = mainProject.CreateProjectInstance(ProjectInstanceSettings.Immutable).DeepCopy(false);
 
+                    Assert.Equal(0, mainInstance.GlobalProperties.Count);
+
                     var request = new BuildRequestData(mainInstance, new[] {"BuildOther"});
 
                     var parameters = new BuildParameters
@@ -3984,6 +3986,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                         request = new BuildRequestData(p2pInstance, new[] {"Foo"});
                         submission = manager.PendBuildRequest(request);
                         results = submission.Execute();
+
+                        Assert.Equal(0, p2pInstance.GlobalProperties.Count);
 
                         Assert.Equal(BuildResultCode.Success, results.OverallResult);
                         Assert.Equal(newPropertyValue, results.ResultsByTarget["Foo"].Items.First().ItemSpec);

--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Dictionary<string, string> props = new Dictionary<string, string>();
             BuildRequestConfiguration config1 = new BuildRequestConfiguration(new BuildRequestData("file", props, "toolsVersion", new string[0], null), "2.0");
 
-            Assert.Equal(props.Count, Helpers.MakeList((IEnumerable<ProjectPropertyInstance>)(config1.Properties)).Count);
+            Assert.Equal(props.Count, Helpers.MakeList((IEnumerable<ProjectPropertyInstance>)(config1.GlobalProperties)).Count);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 for (int i = 0; i < projectFiles.Length; ++i)
                 {
                     projectFiles[i] = _newRequests[i].Config.ProjectFullPath;
-                    properties[i] = new PropertyDictionary<ProjectPropertyInstance>(_newRequests[i].Config.Properties);
+                    properties[i] = new PropertyDictionary<ProjectPropertyInstance>(_newRequests[i].Config.GlobalProperties);
                     toolsVersions[i] = _newRequests[i].Config.ToolsVersion;
                 }
 

--- a/src/Build.UnitTests/OpportunisticIntern_Tests.cs
+++ b/src/Build.UnitTests/OpportunisticIntern_Tests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using System.IO;
 using Microsoft.Build;
+using Microsoft.Build.Shared;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests
@@ -103,6 +104,15 @@ namespace Microsoft.Build.UnitTests
         public void NonInternableTinyString()
         {
             AssertNotInternable("1234");
+        }
+
+        /// <summary>
+        /// Unique strings should not be interned
+        /// </summary>
+        [Fact]
+        public void NonInternableDummyGlobalVariable()
+        {
+            AssertNotInternable($"{MSBuildConstants.MSBuildDummyGlobalPropertyHeader}{new string('1', 100)}");
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1311,9 +1311,7 @@ namespace Microsoft.Build.Execution
                 // built on another node (e.g. the project was encountered as a p2p reference and scheduled to a node).
                 // Add a dummy property to force cache invalidation in the scheduler and the nodes.
                 // TODO find a better solution than a dummy property
-
-                var key = $"ProjectInstance{Guid.NewGuid():N}";
-                unresolvedConfiguration.Properties[key] = ProjectPropertyInstance.Create(key, "Forces unique project identity in the MSBuild engine");
+                unresolvedConfiguration.StampWithUniqueGlobalProperty();
 
                 resolvedConfiguration = AddNewConfiguration(unresolvedConfiguration);
             }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -911,7 +911,7 @@ namespace Microsoft.Build.Execution
             }
 
             ErrorUtilities.VerifyThrow(FileUtilities.IsSolutionFilename(config.ProjectFullPath), "{0} is not a solution", config.ProjectFullPath);
-            ProjectInstance[] instances = ProjectInstance.LoadSolutionForBuild(config.ProjectFullPath, config.Properties, config.ExplicitToolsVersionSpecified ? config.ToolsVersion : null, _buildParameters, ((IBuildComponentHost)this).LoggingService, buildEventContext, false /* loaded by solution parser*/, config.TargetNames);
+            ProjectInstance[] instances = ProjectInstance.LoadSolutionForBuild(config.ProjectFullPath, config.GlobalProperties, config.ExplicitToolsVersionSpecified ? config.ToolsVersion : null, _buildParameters, ((IBuildComponentHost)this).LoggingService, buildEventContext, false /* loaded by solution parser*/, config.TargetNames);
 
             // The first instance is the traversal project, which goes into this configuration
             config.Project = instances[0];

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1311,7 +1311,7 @@ namespace Microsoft.Build.Execution
                 // built on another node (e.g. the project was encountered as a p2p reference and scheduled to a node).
                 // Add a dummy property to force cache invalidation in the scheduler and the nodes.
                 // TODO find a better solution than a dummy property
-                unresolvedConfiguration.StampWithUniqueGlobalProperty();
+                unresolvedConfiguration.CreateUniqueGlobalProperty();
 
                 resolvedConfiguration = AddNewConfiguration(unresolvedConfiguration);
             }

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1078,7 +1078,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 {
                     ErrorUtilities.VerifyThrow(_configCache.Value.HasConfiguration(projectStartedEventArgs.ProjectId), "Cannot find the project configuration while injecting non-serialized data from out-of-proc node.");
                     BuildRequestConfiguration buildRequestConfiguration = _configCache.Value[projectStartedEventArgs.ProjectId];
-                    s_projectStartedEventArgsGlobalProperties.Value.SetValue(projectStartedEventArgs, buildRequestConfiguration.Properties.ToDictionary(), null);
+                    s_projectStartedEventArgsGlobalProperties.Value.SetValue(projectStartedEventArgs, buildRequestConfiguration.GlobalProperties.ToDictionary(), null);
                     s_projectStartedEventArgsToolsVersion.Value.SetValue(projectStartedEventArgs, buildRequestConfiguration.ToolsVersion, null);
                 }
             }

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Build.BackEnd.Logging
                         properties,
                         items,
                         parentBuildEventContext,
-                        buildRequestConfiguration.Properties.ToDictionary(),
+                        buildRequestConfiguration.GlobalProperties.ToDictionary(),
                         buildRequestConfiguration.ToolsVersion
                     );
                 buildEvent.BuildEventContext = projectBuildEventContext;

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1153,7 +1153,7 @@ namespace Microsoft.Build.BackEnd
 
             Dictionary<string, string> globalProperties = new Dictionary<string, string>(MSBuildNameIgnoreCaseComparer.Default);
 
-            foreach (ProjectPropertyInstance property in _requestEntry.RequestConfiguration.Properties)
+            foreach (ProjectPropertyInstance property in _requestEntry.RequestConfiguration.GlobalProperties)
             {
                 globalProperties.Add(property.Name, ((IProperty)property).EvaluatedValueEscaped);
             }

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2318,7 +2318,7 @@ namespace Microsoft.Build.BackEnd
                         foreach (int config in configurations)
                         {
                             file.WriteLine("Config {0} Node {1} TV: {2} File {3}", config, _schedulingData.GetAssignedNodeForRequestConfiguration(config), _configCache[config].ToolsVersion, _configCache[config].ProjectFullPath);
-                            foreach (ProjectPropertyInstance property in _configCache[config].Properties)
+                            foreach (ProjectPropertyInstance property in _configCache[config].GlobalProperties)
                             {
                                 file.WriteLine("{0} = \"{1}\"", property.Name, property.EvaluatedValue);
                             }

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -485,6 +485,12 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrow(IsLoaded, $"This {nameof(BuildRequestConfiguration)} must be loaded at the end of this method");
         }
 
+        internal void StampWithUniqueGlobalProperty()
+        {
+            var key = $"ProjectInstance{Guid.NewGuid():N}";
+            Properties[key] = ProjectPropertyInstance.Create(key, "Forces unique project identity in the MSBuild engine");
+        }
+
         /// <summary>
         /// Returns true if the default and initial targets have been resolved.
         /// </summary>
@@ -1056,6 +1062,5 @@ namespace Microsoft.Build.BackEnd
                 throw;
             }
         }
-
     }
 }

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -485,10 +485,13 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrow(IsLoaded, $"This {nameof(BuildRequestConfiguration)} must be loaded at the end of this method");
         }
 
-        internal void StampWithUniqueGlobalProperty()
+        internal void CreateUniqueGlobalProperty()
         {
+            // create a copy so the mutation does not leak into the ProjectInstance
+            _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(_globalProperties);
+
             var key = $"ProjectInstance{Guid.NewGuid():N}";
-            GlobalProperties[key] = ProjectPropertyInstance.Create(key, "Forces unique project identity in the MSBuild engine");
+            _globalProperties[key] = ProjectPropertyInstance.Create(key, "Forces unique project identity in the MSBuild engine");
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -490,10 +490,7 @@ namespace Microsoft.Build.BackEnd
             // create a copy so the mutation does not leak into the ProjectInstance
             _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(_globalProperties);
 
-            // if you change the key also change the following so that it does not leak into string caches:
-            // Microsoft.Build.OpportunisticIntern.BucketedPrioritizedStringList.TryIntern
-            // Microsoft.Build.Construction.ProjectStringCache.Add
-            var key = $"ProjectInstance{Guid.NewGuid():N}";
+            var key = $"{MSBuildConstants.MSBuildDummyGlobalPropertyHeader}{Guid.NewGuid():N}";
             _globalProperties[key] = ProjectPropertyInstance.Create(key, "Forces unique project identity in the MSBuild engine");
         }
 

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -490,6 +490,9 @@ namespace Microsoft.Build.BackEnd
             // create a copy so the mutation does not leak into the ProjectInstance
             _globalProperties = new PropertyDictionary<ProjectPropertyInstance>(_globalProperties);
 
+            // if you change the key also change the following so that it does not leak into string caches:
+            // Microsoft.Build.OpportunisticIntern.BucketedPrioritizedStringList.TryIntern
+            // Microsoft.Build.Construction.ProjectStringCache.Add
             var key = $"ProjectInstance{Guid.NewGuid():N}";
             _globalProperties[key] = ProjectPropertyInstance.Create(key, "Forces unique project identity in the MSBuild engine");
         }

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Returns the global properties to use to build this project.
         /// </summary>
-        public PropertyDictionary<ProjectPropertyInstance> Properties
+        public PropertyDictionary<ProjectPropertyInstance> GlobalProperties
         {
             [DebuggerStepThrough]
             get
@@ -488,7 +488,7 @@ namespace Microsoft.Build.BackEnd
         internal void StampWithUniqueGlobalProperty()
         {
             var key = $"ProjectInstance{Guid.NewGuid():N}";
-            Properties[key] = ProjectPropertyInstance.Create(key, "Forces unique project identity in the MSBuild engine");
+            GlobalProperties[key] = ProjectPropertyInstance.Create(key, "Forces unique project identity in the MSBuild engine");
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
+++ b/src/Build/BackEnd/Shared/ConfigurationMetadata.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.BackEnd
         public ConfigurationMetadata(BuildRequestConfiguration configuration)
         {
             ErrorUtilities.VerifyThrowArgumentNull(configuration, "configuration");
-            GlobalProperties = new PropertyDictionary<ProjectPropertyInstance>(configuration.Properties);
+            GlobalProperties = new PropertyDictionary<ProjectPropertyInstance>(configuration.GlobalProperties);
             ProjectFullPath = FileUtilities.NormalizePath(configuration.ProjectFullPath);
             ToolsVersion = configuration.ToolsVersion;
         }

--- a/src/Build/Evaluation/ProjectStringCache.cs
+++ b/src/Build/Evaluation/ProjectStringCache.cs
@@ -85,6 +85,12 @@ namespace Microsoft.Build.Construction
                 return String.Empty;
             }
 
+            // see Microsoft.Build.BackEnd.BuildRequestConfiguration.CreateUniqueGlobalProperty
+            if (key.StartsWith("ProjectInstance", StringComparison.Ordinal))
+            {
+                return key;
+            }
+
             lock (_locker)
             {
                 VerifyState();

--- a/src/Build/Evaluation/ProjectStringCache.cs
+++ b/src/Build/Evaluation/ProjectStringCache.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Build.Construction
             }
 
             // see Microsoft.Build.BackEnd.BuildRequestConfiguration.CreateUniqueGlobalProperty
-            if (key.StartsWith("ProjectInstance", StringComparison.Ordinal))
+            if (key.StartsWith(MSBuildConstants.MSBuildDummyGlobalPropertyHeader, StringComparison.Ordinal))
             {
                 return key;
             }

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -60,6 +60,10 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal const string CurrentToolsVersion = CurrentVisualStudioVersion;
 
+        // if you change the key also change the following clones
+        // Microsoft.Build.OpportunisticIntern.BucketedPrioritizedStringList.TryIntern
+        internal const string MSBuildDummyGlobalPropertyHeader = "MSBuildProjectInstance";
+
         /// <summary>
         /// The most current ToolsVersion known to this version of MSBuild as a Version object. 
         /// </summary>

--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -886,6 +886,28 @@ namespace Microsoft.Build
                             return true;
                         }
                     }
+                    // see Microsoft.Build.BackEnd.BuildRequestConfiguration.CreateUniqueGlobalProperty
+                    else if (length > 15 &&
+                             candidate[0] == 'P' &&
+                             candidate[1] == 'r' &&
+                             candidate[2] == 'o' &&
+                             candidate[3] == 'j' &&
+                             candidate[4] == 'e' &&
+                             candidate[5] == 'c' &&
+                             candidate[6] == 't' &&
+                             candidate[7] == 'I' &&
+                             candidate[8] == 'n' &&
+                             candidate[9] == 's' &&
+                             candidate[10] == 't' &&
+                             candidate[11] == 'a' &&
+                             candidate[12] == 'n' &&
+                             candidate[13] == 'c' &&
+                             candidate[14] == 'e'
+                    )
+                    {
+                        interned = candidate.ExpensiveConvertToString();
+                        return null;
+                    }
                     else if (length == 24)
                     {
                         if (candidate[0] == 'R' && candidate[1] == 'e' && candidate[2] == 's' && candidate[3] == 'o' && candidate[4] == 'l' && candidate[5] == 'v' && candidate[6] == 'e')

--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -13,6 +13,13 @@ using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Build.Shared;
 
+#if MICROSOFT_BUILD_TASKS
+using MSBuildConstants = Microsoft.Build.Tasks.MSBuildConstants;
+#else
+using MSBuildConstants = Microsoft.Build.Shared.MSBuildConstants;
+#endif
+    
+
 namespace Microsoft.Build
 {
     /// <summary>
@@ -752,7 +759,7 @@ namespace Microsoft.Build
             /// Try to intern the string. 
             /// Return true if an interned value could be returned.
             /// Return false if it was added to the intern list, but wasn't there already.
-            /// Return null if it didn't meet the length criteria for any of the buckets.
+            /// Return null if it didn't meet the length criteria for any of the buckets. Interning was rejected
             /// </summary>
             private bool? TryIntern(IInternable candidate, out string interned)
             {
@@ -887,24 +894,32 @@ namespace Microsoft.Build
                         }
                     }
                     // see Microsoft.Build.BackEnd.BuildRequestConfiguration.CreateUniqueGlobalProperty
-                    else if (length > 15 &&
-                             candidate[0] == 'P' &&
-                             candidate[1] == 'r' &&
-                             candidate[2] == 'o' &&
-                             candidate[3] == 'j' &&
-                             candidate[4] == 'e' &&
-                             candidate[5] == 'c' &&
-                             candidate[6] == 't' &&
-                             candidate[7] == 'I' &&
-                             candidate[8] == 'n' &&
-                             candidate[9] == 's' &&
-                             candidate[10] == 't' &&
-                             candidate[11] == 'a' &&
-                             candidate[12] == 'n' &&
-                             candidate[13] == 'c' &&
-                             candidate[14] == 'e'
+                    else if (length > MSBuildConstants.MSBuildDummyGlobalPropertyHeader.Length &&
+                             candidate[0] == 'M' &&
+                             candidate[1] == 'S' &&
+                             candidate[2] == 'B' &&
+                             candidate[3] == 'u' &&
+                             candidate[4] == 'i' &&
+                             candidate[5] == 'l' &&
+                             candidate[6] == 'd' &&
+                             candidate[7] == 'P' &&
+                             candidate[8] == 'r' &&
+                             candidate[9] == 'o' &&
+                             candidate[10] == 'j' &&
+                             candidate[11] == 'e' &&
+                             candidate[12] == 'c' &&
+                             candidate[13] == 't' &&
+                             candidate[14] == 'I' &&
+                             candidate[15] == 'n' &&
+                             candidate[16] == 's' &&
+                             candidate[17] == 't' &&
+                             candidate[18] == 'a' &&
+                             candidate[19] == 'n' &&
+                             candidate[20] == 'c' &&
+                             candidate[21] == 'e'
                     )
                     {
+                        // don't want to leak unique strings into the cache
                         interned = candidate.ExpensiveConvertToString();
                         return null;
                     }


### PR DESCRIPTION
In addition, put a protective check in the two known msbuild string caches to preemptively avoid caching unique strings.

False positive caching is still hit in the following scenarios
- building successive in-memory mutations of the same `ProjectInstance` instance, in the same BeginBuild-EndBuild-ResetCaches session
- building different `ProjectInstance` instances over the same file, in the same BeginBuild-EndBuild-ResetCaches session

To fix these I think we have to actually remove the dummy variable and change `ConfigurationMetadata` (implements what it means to be a unique build in the engine) to account for the entire `ProjectInstance` state.