### PR TITLE
Add a try/catch in BinaryLogger.

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -83,7 +83,15 @@ namespace Microsoft.Build.Logging
 
         private void EventSource_AnyEventRaised(object sender, BuildEventArgs e)
         {
-            Write(e);
+            try
+            {
+                Write(e);
+            }
+            catch
+            {
+                // Exceptions here are unlikely but it'd be bad for a logger to crash the build.
+                // We can't log either because the logger is likely broken. Best just do nothing.
+            }
         }
 
         private void Write(BuildEventArgs e)


### PR DESCRIPTION
Just a safeguard to prevent the logger from crashing the build. I'm not even sure if it's necessary because of downstream catch blocks, but it feels right to contain exceptions here.