### PR TITLE
Add Version and fix ProjectPath in SdkResolverContext

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -414,6 +414,7 @@ namespace Microsoft.Build.Framework
     {
         protected SdkResolverContext() { }
         public virtual Microsoft.Build.Framework.SdkLogger Logger { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual System.Version MSBuildVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string ProjectFilePath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string SolutionFilePath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
     }

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -411,6 +411,7 @@ namespace Microsoft.Build.Framework
     {
         protected SdkResolverContext() { }
         public virtual Microsoft.Build.Framework.SdkLogger Logger { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual System.Version MSBuildVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string ProjectFilePath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string SolutionFilePath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
     }

--- a/src/Build.UnitTests/BackEnd/SdkResolution_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolution_Tests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var bec = new BuildEventContext(0, 0, 0, 0, 0);
             
             SdkResolution resolution = new SdkResolution(new MockLoaderStrategy());
-            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln");
+            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln", "projectPath");
 
             Assert.Equal("resolverpath1", result);
             Assert.Equal("MockSdkResolver1 running", log.ToString().Trim());
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var bec = new BuildEventContext(0, 0, 0, 0, 0);
 
             SdkResolution resolution = new SdkResolution(new MockLoaderStrategy());
-            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln");
+            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln", "projectPath");
 
             var logResult = log.ToString();
             Assert.Equal("resolverpath2", result);
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var bec = new BuildEventContext(0, 0, 0, 0, 0);
 
             SdkResolution resolution = new SdkResolution(new MockLoaderStrategy());
-            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln");
+            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln", "projectPath");
 
             var logResult = log.ToString();
             Assert.Null(result);
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var bec = new BuildEventContext(0, 0, 0, 0, 0);
 
             SdkResolution resolution = new SdkResolution(new MockLoaderStrategy(true));
-            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln");
+            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln", "projectPath");
 
             Assert.Equal("resolverpath1", result);
             Assert.Contains("EXMESSAGE", log.ToString());

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -40,9 +41,10 @@ namespace Microsoft.Build.BackEnd
         /// <param name="buildEventContext">Build event context for logging.</param>
         /// <param name="sdkReferenceLocation">Location of the element within the project which referenced the SDK.</param>
         /// <param name="solutionPath">Path to the solution if known.</param>
+        /// <param name="projectPath">Path to the project being.</param>
         /// <returns>Path to the root of the referenced SDK.</returns>
         internal string GetSdkPath(SdkReference sdk, ILoggingService logger, BuildEventContext buildEventContext,
-            ElementLocation sdkReferenceLocation, string solutionPath)
+            ElementLocation sdkReferenceLocation, string solutionPath, string projectPath)
         {
             ErrorUtilities.VerifyThrowInternalNull(sdk, nameof(sdk));
             ErrorUtilities.VerifyThrowInternalNull(logger, nameof(logger));
@@ -58,7 +60,7 @@ namespace Microsoft.Build.BackEnd
                 var buildEngineLogger = new SdkLoggerImpl(logger, buildEventContext);
                 foreach (var sdkResolver in _resolvers)
                 {
-                    var context = new SdkResolverContextImpl(buildEngineLogger, sdkReferenceLocation.File, solutionPath);
+                    var context = new SdkResolverContextImpl(buildEngineLogger, projectPath, solutionPath, ProjectCollection.Version);
                     var resultFactory = new SdkResultFactoryImpl(sdk);
                     try
                     {
@@ -98,6 +100,16 @@ namespace Microsoft.Build.BackEnd
             }
 
             return null;
+        }
+
+        internal void InitializeForTests(IList<SdkResolver> resolvers, ILoggingService logger, BuildEventContext buildEventContext, ElementLocation location)
+        {
+            _resolvers = resolvers;
+        }
+
+        internal void ResetInitializeForTests()
+        {
+            _resolvers = null;
         }
 
         private void Initialize(ILoggingService logger, BuildEventContext buildEventContext, ElementLocation location)
@@ -187,11 +199,12 @@ namespace Microsoft.Build.BackEnd
 
         private sealed class SdkResolverContextImpl : SdkResolverContext
         {
-            public SdkResolverContextImpl(SdkLogger logger, string projectFilePath, string solutionPath)
+            public SdkResolverContextImpl(SdkLogger logger, string projectFilePath, string solutionPath, Version msBuildVersion)
             {
                 Logger = logger;
                 ProjectFilePath = projectFilePath;
                 SolutionFilePath = solutionPath;
+                MSBuildVersion = msBuildVersion;
             }
         }
     }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="buildEventContext">Build event context for logging.</param>
         /// <param name="sdkReferenceLocation">Location of the element within the project which referenced the SDK.</param>
         /// <param name="solutionPath">Path to the solution if known.</param>
-        /// <param name="projectPath">Path to the project being.</param>
+        /// <param name="projectPath">Path to the project being built.</param>
         /// <returns>Path to the root of the referenced SDK.</returns>
         internal string GetSdkPath(SdkReference sdk, ILoggingService logger, BuildEventContext buildEventContext,
             ElementLocation sdkReferenceLocation, string solutionPath, string projectPath)

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
@@ -102,14 +102,13 @@ namespace Microsoft.Build.BackEnd
             return null;
         }
 
-        internal void InitializeForTests(IList<SdkResolver> resolvers, ILoggingService logger, BuildEventContext buildEventContext, ElementLocation location)
+        /// <summary>
+        /// Used for unit tests only.
+        /// </summary>
+        /// <param name="resolvers">Explicit set of SdkResolvers to use for all SDK resolution.</param>
+        internal void InitializeForTests(IList<SdkResolver> resolvers)
         {
             _resolvers = resolvers;
-        }
-
-        internal void ResetInitializeForTests()
-        {
-            _resolvers = null;
         }
 
         private void Initialize(ILoggingService logger, BuildEventContext buildEventContext, ElementLocation location)

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2370,12 +2370,15 @@ namespace Microsoft.Build.Evaluation
 
             if (importElement.ParsedSdkReference != null)
             {
-                // Try to get the solution path when available.
+                // Try to get the path to the solution and project being built. If the solution path equals "*Undefined*" 
+                // (hard coded in Microsoft.Common.CurrentVersion.targets) set to null for consistency.
                 var solutionPath = _data.GetProperty(SolutionProjectGenerator.SolutionPathPropertyName)?.EvaluatedValue;
+                var projectPath = _data.GetProperty(ReservedPropertyNames.projectFullPath)?.EvaluatedValue;
+                if (solutionPath == "*Undefined*") solutionPath = null;
 
                 // Combine SDK path with the "project" relative path
                 var sdkRootPath = _sdkResolution.GetSdkPath(importElement.ParsedSdkReference, _loggingService,
-                    _buildEventContext, importElement.Location, solutionPath);
+                    _buildEventContext, importElement.Location, solutionPath, projectPath);
 
                 if (string.IsNullOrEmpty(sdkRootPath))
                 {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2370,11 +2370,14 @@ namespace Microsoft.Build.Evaluation
 
             if (importElement.ParsedSdkReference != null)
             {
-                // Try to get the path to the solution and project being built. If the solution path equals "*Undefined*" 
-                // (hard coded in Microsoft.Common.CurrentVersion.targets) set to null for consistency.
+                // Try to get the path to the solution and project being built. The solution path is not directly known
+                // in MSBuild. It is passed in as a property either by the VS project system or by MSBuild's solution
+                // metaproject. Microsoft.Common.CurrentVersion.targets sets the value to *Undefined* when not set, and
+                // for backward compatibility, we shouldn't change that. But resolvers should be exposed to a string
+                // that's null or a full path, so correct that here.
                 var solutionPath = _data.GetProperty(SolutionProjectGenerator.SolutionPathPropertyName)?.EvaluatedValue;
-                var projectPath = _data.GetProperty(ReservedPropertyNames.projectFullPath)?.EvaluatedValue;
                 if (solutionPath == "*Undefined*") solutionPath = null;
+                var projectPath = _data.GetProperty(ReservedPropertyNames.projectFullPath)?.EvaluatedValue;
 
                 // Combine SDK path with the "project" relative path
                 var sdkRootPath = _sdkResolution.GetSdkPath(importElement.ParsedSdkReference, _loggingService,

--- a/src/Framework/Sdk/SdkResolverContext.cs
+++ b/src/Framework/Sdk/SdkResolverContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.Build.Framework
 {
     /// <summary>
@@ -22,5 +24,10 @@ namespace Microsoft.Build.Framework
         ///     Path to the solution file being built, if known. May be null.
         /// </summary>
         public virtual string SolutionFilePath { get; protected set; }
+
+        /// <summary>
+        ///     Version of MSBuild currently running.
+        /// </summary>
+        public virtual Version MSBuildVersion { get; protected set; }
     }
 }

--- a/src/Framework/Sdk/SdkResolverContext.cs
+++ b/src/Framework/Sdk/SdkResolverContext.cs
@@ -27,6 +27,10 @@ namespace Microsoft.Build.Framework
 
         /// <summary>
         ///     Version of MSBuild currently running.
+        /// <remarks>
+        ///     File version based on commit height from our public git repository. This is informational
+        ///     and not equal to the assembly version.
+        /// </remarks>
         /// </summary>
         public virtual Version MSBuildVersion { get; protected set; }
     }

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -424,7 +424,7 @@ namespace Microsoft.Build.Engine.UnitTests
         private static void CallResetForTests(IList<SdkResolver> resolvers)
         {
             // Get the Singleton and call InitializeForTests
-            var t = typeof(Evaluation.ProjectCollection).Assembly.GetType("Microsoft.Build.BackEnd.SdkResolution");
+            var t = typeof(Evaluation.ProjectCollection).GetTypeInfo().Assembly.GetType("Microsoft.Build.BackEnd.SdkResolution");
             var method = t.GetMethod("InitializeForTests", BindingFlags.NonPublic | BindingFlags.Instance);
             var instanceMethod = t.GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic);
             var instance = instanceMethod.GetValue(null);

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Xunit;
@@ -179,6 +182,11 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             return WithTransientTestState(
                 new TransientTestProjectWithFiles(projectContents, files, relativePathFromRootToProject));
+        }
+
+        public TransientSdkResolution CustomSdkResolution(Dictionary<string, string> sdkToFolderMapping)
+        {
+            return WithTransientTestState(new TransientSdkResolution(sdkToFolderMapping));
         }
 
         #endregion
@@ -387,6 +395,63 @@ namespace Microsoft.Build.Engine.UnitTests
         public override void Revert()
         {
             _folder.Revert();
+        }
+    }
+
+    /// <summary>
+    /// Represents custom SDK resolution in the context of this test.
+    /// </summary>
+    public class TransientSdkResolution : TransientTestState
+    {
+        private readonly Dictionary<string, string> _mapping;
+
+        public TransientSdkResolution(Dictionary<string, string> mapping)
+        {
+            _mapping = mapping;
+            CallResetForTests(new List<SdkResolver> { new TestSdkResolver(_mapping) });
+        }
+
+        public override void Revert()
+        {
+            CallResetForTests(null);
+        }
+
+        /// <summary>
+        /// SdkResolution is internal (by design) and not all UnitTest projects are allowed to have
+        /// InternalsVisibleTo.
+        /// </summary>
+        /// <param name="resolvers"></param>
+        private static void CallResetForTests(IList<SdkResolver> resolvers)
+        {
+            // Get the Singleton and call InitializeForTests
+            var t = typeof(Evaluation.ProjectCollection).Assembly.GetType("Microsoft.Build.BackEnd.SdkResolution");
+            var method = t.GetMethod("InitializeForTests", BindingFlags.NonPublic | BindingFlags.Instance);
+            var instanceMethod = t.GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic);
+            var instance = instanceMethod.GetValue(null);
+            method.Invoke(instance, new[] { resolvers });
+        }
+
+        private class TestSdkResolver : SdkResolver
+        {
+            private readonly Dictionary<string, string> _mapping;
+
+            public TestSdkResolver(Dictionary<string, string> mapping)
+            {
+                _mapping = mapping;
+            }
+            public override string Name => "TestSdkResolver";
+            public override int Priority => int.MinValue;
+
+            public override SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
+            {
+                resolverContext.Logger.LogMessage($"{nameof(resolverContext.ProjectFilePath)} = {resolverContext.ProjectFilePath}", MessageImportance.High);
+                resolverContext.Logger.LogMessage($"{nameof(resolverContext.SolutionFilePath)} = {resolverContext.SolutionFilePath}", MessageImportance.High);
+                resolverContext.Logger.LogMessage($"{nameof(resolverContext.MSBuildVersion)} = {resolverContext.MSBuildVersion}", MessageImportance.High);
+
+                return _mapping.ContainsKey(sdkReference.Name)
+                    ? factory.IndicateSuccess(_mapping[sdkReference.Name], null)
+                    : factory.IndicateFailure(new[] {$"Not in {nameof(_mapping)}"});
+            }
         }
     }
 }


### PR DESCRIPTION
 * Adds MSBuild version.
 * Fix ProjectFilePath to be the full path to the project (equivalent to
 '$(MSBuildProjectFullPath)').
 * Fix issue where SolutionFilePath can be set by Common targets to
 '*Undefined*'. When this is the case, set to null for consistency.

Closes #2097, #2083, #2082 

Looking into adding some tests, will have a followup commit.