### PR TITLE
Typo: Intended -> Indented

### DIFF
--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             ";
 
         /// <summary>
-        /// Since when the project file is saved it may be intended we want to make sure the indent characters do not affect the evaluation against empty.
+        /// Since when the project file is saved it may be indented we want to make sure the indent characters do not affect the evaluation against empty.
         /// We test here newline, tab, and carriage return.
         /// </summary>
         [Fact]


### PR DESCRIPTION
@eerhardt pointed out in https://github.com/Microsoft/msbuild/pull/2091#discussion_r116822777 that "indented" was probably "intended" :stuck_out_tongue_winking_eye: 