### PR TITLE
Enable PdbGit - stamp .pdbs with links to sources on GitHub.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -422,4 +422,6 @@
     <IBCMergeSubPath>x86/MSBuild</IBCMergeSubPath>
   </PropertyGroup>
 
+  <Import Project="$(PackagesDir)\pdbgit\3.0.41\build\PdbGit.props" Condition="'$(IsTestProject)' != 'true' And Exists('$(PackagesDir)\pdbgit\3.0.41\build\PdbGit.props')" />
+
 </Project>

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -3,6 +3,7 @@
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
+        "PdbGit": "3.0.41",
         "System.Collections.Immutable": "1.3.1",
         "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
         "System.Threading.Tasks.Dataflow": "4.5.24.0"

--- a/src/Framework/project.json
+++ b/src/Framework/project.json
@@ -4,6 +4,7 @@
     "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "PdbGit": "3.0.41",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Threading.Thread": "4.0.0"
       }

--- a/src/MSBuild/project.json
+++ b/src/MSBuild/project.json
@@ -3,6 +3,7 @@
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5",
+        "PdbGit": "3.0.41",
         "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },

--- a/src/MSBuildTaskHost/project.json
+++ b/src/MSBuildTaskHost/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5"
+    "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5",
+    "PdbGit": "3.0.41"
   },
   "frameworks": {
     "net35": { }

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -3,6 +3,7 @@
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
+        "PdbGit": "3.0.41",
         "System.Collections.Immutable": "1.3.1",
         "System.Reflection.Metadata": "1.3.0",
         "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -3,6 +3,7 @@
     "net46": {
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.2.304-preview5",
+        "PdbGit": "3.0.41",
         "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -108,4 +108,9 @@
       </ReferencePath>
     </ItemGroup>
   </Target>
+
+  <!-- https://github.com/AArnott/PdbGit - stamps the .pdbs with URLs to sources on GitHub 
+  so that the debugger can download the exact matching source files during debugging -->
+  <Import Project="$(PackagesDir)\pdbgit\3.0.41\build\PdbGit.targets" Condition="'$(IsTestProject)' != 'true' And Exists('$(PackagesDir)\pdbgit\3.0.41\build\PdbGit.targets')" />
+
 </Project>


### PR DESCRIPTION
https://github.com/AArnott/PdbGit rewrites the .pdb files post-compilation to include full URLs to GitHub for each source file. That way when the VS debugger is using the .pdb to find the source code, it will download the exact .cs source file that was used during compilation from the blob on GitHub.