### PR TITLE
Fix regression with log file summary.

### DIFF
--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -2001,11 +2001,11 @@ namespace Microsoft.Build.UnitTests
 
             L.Parameters = "";
             L.ParseParameters();
-            Assert.False(L.ShowSummary);
+            Assert.Null(L.ShowSummary);
 
             L.Parameters = null;
             L.ParseParameters();
-            Assert.False(L.ShowSummary);
+            Assert.Null(L.ShowSummary);
 
             sc = new SimulatedConsole();
             ParallelConsoleLogger cl2 = new ParallelConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);

--- a/src/Build.UnitTests/FileLogger_Tests.cs
+++ b/src/Build.UnitTests/FileLogger_Tests.cs
@@ -340,6 +340,7 @@ namespace Microsoft.Build.UnitTests
         [Theory]
         [InlineData("warningsonly")]
         [InlineData("errorsonly")]
+        [InlineData("errorsonly;warningsonly")]
         public void EmptyErrorLogUsingWarningsErrorsOnly(string loggerOption)
         {
             using (var env = TestEnvironment.Create())

--- a/src/Build.UnitTests/FileLogger_Tests.cs
+++ b/src/Build.UnitTests/FileLogger_Tests.cs
@@ -68,13 +68,7 @@ namespace Microsoft.Build.UnitTests
 
                 
                 byte[] content = ReadRawBytes(log);
-#if FEATURE_ENCODING_DEFAULT
-                // Verify no BOM (ANSI encoding)
                 Assert.Equal((byte)109, content[0]); // 'm'
-#else
-                // Verify BOM (UTF-8 encoding)
-                Assert.Equal((byte)109, content[3]); // 'm'
-#endif
             }
             finally
             {

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -123,18 +123,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Suppresses the display of error and warnings summary.
         /// </summary>
-        internal bool ShowSummary
-        {
-            get
-            {
-                return _showSummary ?? false;
-            }
-
-            set
-            {
-                _showSummary = value;
-            }
-        }
+        internal bool? ShowSummary { get; set; }
 
         /// <summary>
         /// Provide access to the write hander delegate so that it can be redirected
@@ -1016,23 +1005,23 @@ namespace Microsoft.Build.BackEnd.Logging
 
             showTargetOutputs = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING"));
 
-            // If not specifically instructed otherwise, show a summary in normal
-            // and higher verbosities.
-            if (_showSummary == null && IsVerbosityAtLeast(LoggerVerbosity.Normal))
-            {
-                _showSummary = true;
-            }
-
             if (showOnlyWarnings || showOnlyErrors)
             {
-                if (!_showSummary.HasValue)
+                if (ShowSummary == null)
                 {
                     // By default don't show the summary when the showOnlyWarnings / showOnlyErrors is specified.
                     // However, if the user explicitly specified summary or nosummary, use that.
-                    _showSummary = false;
+                    ShowSummary = false;
                 }
 
                 this.showPerfSummary = false;
+            }
+
+            // If not specifically instructed otherwise, show a summary in normal
+            // and higher verbosities.
+            if (ShowSummary == null && IsVerbosityAtLeast(LoggerVerbosity.Normal))
+            {
+                ShowSummary = true;
             }
 
             // Put this after reading the parameters, since it may want to initialize something
@@ -1087,10 +1076,10 @@ namespace Microsoft.Build.BackEnd.Logging
                     showPerfSummary = true;
                     return true;
                 case "NOSUMMARY":
-                    _showSummary = false;
+                    ShowSummary = false;
                     return true;
                 case "SUMMARY":
-                    _showSummary = true;
+                    ShowSummary = true;
                     return true;
                 case "NOITEMANDPROPERTYLIST":
                     showItemAndPropertyList = false;
@@ -1270,12 +1259,6 @@ namespace Microsoft.Build.BackEnd.Logging
         /// Console logger parameter value split character.
         /// </summary>
         private static readonly char[] s_parameterValueSplitCharacter = { '=' };
-
-        /// <summary>
-        /// Console logger should show error and warning summary at the end of build?
-        /// If null, user has made no indication.
-        /// </summary>
-        private bool? _showSummary;
 
         /// <summary>
         /// When true, accumulate performance numbers.

--- a/src/Build/Logging/ConsoleLogger.cs
+++ b/src/Build/Logging/ConsoleLogger.cs
@@ -266,7 +266,11 @@ namespace Microsoft.Build.Logging
         {
             get
             {
-                return (_consoleLogger == null ? _showSummary : _consoleLogger.ShowSummary) ?? false;
+                if (_consoleLogger == null)
+                {
+                    return _showSummary == true;
+                }
+                return _consoleLogger.ShowSummary == true;
             }
 
             set

--- a/src/Build/Logging/FileLogger.cs
+++ b/src/Build/Logging/FileLogger.cs
@@ -214,6 +214,11 @@ namespace Microsoft.Build.Logging
                 case "NOAUTOFLUSH":
                     _autoFlush = false;
                     break;
+                case "ERRORSONLY":
+                case "WARNINGSONLY":
+                    ShowSummary = false;
+                    SkipProjectStartedText = true;
+                    break;
                 case "ENCODING":
                     try
                     {

--- a/src/Build/Logging/FileLogger.cs
+++ b/src/Build/Logging/FileLogger.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Build.Logging
         /// <summary>
         /// Encoding for the output. Defaults to UTF-8.
         /// </summary>
-        private Encoding _encoding = Encoding.UTF8;
+        private Encoding _encoding = new UTF8Encoding(false);
 #endif
         /// <summary>
         /// File logger parameters delimiters.

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal override void ResetConsoleLoggerState()
         {
-            if (ShowSummary)
+            if (ShowSummary == true)
             {
                 errorList = new ArrayList();
                 warningList = new ArrayList();
@@ -264,7 +264,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // Write the "Build Finished" event if verbosity is normal, detailed or diagnostic or the user
             // specified to show the summary.
-            if (IsVerbosityAtLeast(LoggerVerbosity.Normal) || ShowSummary)
+            if (ShowSummary == true)
             {
                 if (e.Succeeded)
                 {
@@ -279,7 +279,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // The decision whether or not to show a summary at this verbosity
             // was made during initialization. We just do what we're told.
-            if (ShowSummary)
+            if (ShowSummary == true)
             {
                 // We can't display a nice nested summary unless we're at Normal or above,
                 // since we need to have gotten TargetStarted events, which aren't forwarded otherwise.
@@ -313,7 +313,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             // Show build time if verbosity is normal, detailed or diagnostic or the user specified to
             // show the summary.
-            if (IsVerbosityAtLeast(LoggerVerbosity.Normal) || ShowSummary)
+            if (ShowSummary == true)
             {
                 // The time elapsed is the difference between when the BuildStartedEventArg
                 // was created and when the BuildFinishedEventArg was created
@@ -943,7 +943,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 setColor(ConsoleColor.Red);
                 WriteMessageAligned(EventArgsFormatting.FormatEventMessage(e, runningWithCharacterFileType, showProjectFile), true);
                 ShownBuildEventContext(e.BuildEventContext);
-                if (ShowSummary)
+                if (ShowSummary == true)
                 {
                     if (!errorList.Contains(e))
                     {
@@ -992,7 +992,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
             ShownBuildEventContext(e.BuildEventContext);
 
-            if (ShowSummary)
+            if (ShowSummary == true)
             {
                 if (!warningList.Contains(e))
                 {

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal override void ResetConsoleLoggerState()
         {
-            if (ShowSummary)
+            if (ShowSummary == true)
             {
                 errorList = new ArrayList();
                 warningList = new ArrayList();
@@ -105,8 +105,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             buildStarted = e.Timestamp;
 
-            // if verbosity is detailed or diagnostic
-            if (IsVerbosityAtLeast(LoggerVerbosity.Normal))
+            if (ShowSummary == true)
             {
                 WriteLinePrettyFromResource("BuildStartedWithTime", e.Timestamp);
             }
@@ -128,8 +127,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 ShowPerfSummary();
             }
 
-            // if verbosity is normal, detailed or diagnostic
-            if (IsVerbosityAtLeast(LoggerVerbosity.Normal))
+            if (ShowSummary == true)
             {
                 if (e.Succeeded)
                 {
@@ -144,8 +142,8 @@ namespace Microsoft.Build.BackEnd.Logging
             }
 
             // The decision whether or not to show a summary at this verbosity
-            // was made during initalization. We just do what we're told.
-            if (ShowSummary)
+            // was made during initialization. We just do what we're told.
+            if (ShowSummary == true)
             {
                 ShowErrorWarningSummary();
 
@@ -171,7 +169,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 }
             }
 
-            if (IsVerbosityAtLeast(LoggerVerbosity.Normal))
+            if (ShowSummary == true)
             {
                 string timeElapsed = LogFormatter.FormatTimeSpan(e.Timestamp - buildStarted);
 
@@ -227,7 +225,7 @@ namespace Microsoft.Build.BackEnd.Logging
             }
 
             // if verbosity is normal, detailed or diagnostic
-            if (IsVerbosityAtLeast(LoggerVerbosity.Normal))
+            if (IsVerbosityAtLeast(LoggerVerbosity.Normal) && ShowSummary != false)
             {
                 ShowDeferredMessages();
 
@@ -474,7 +472,7 @@ namespace Microsoft.Build.BackEnd.Logging
             ShowDeferredMessages();
             setColor(ConsoleColor.Red);
             WriteLinePretty(EventArgsFormatting.FormatEventMessage(e, runningWithCharacterFileType, showProjectFile));
-            if (ShowSummary)
+            if (ShowSummary == true)
             {
                 errorList.Add(e);
             }
@@ -491,7 +489,7 @@ namespace Microsoft.Build.BackEnd.Logging
             ShowDeferredMessages();
             setColor(ConsoleColor.Yellow);
             WriteLinePretty(EventArgsFormatting.FormatEventMessage(e, runningWithCharacterFileType, showProjectFile));
-            if (ShowSummary)
+            if (ShowSummary == true)
             {
                 warningList.Add(e);
             }


### PR DESCRIPTION
A change was (#1513) to allow for more control over log summary text.
Specifically, the ask was to allow for the use of ErrorsOnly /
WarningsOnly with Summary. That change also impacted the file log output
and in some cases caused build summary to output to the log file when
using ErrorsOnly.

This change defaults to not showing the summary text in the FileLogger
when ErrorsOnly or WarningsOnly is set (it can still be displayed with
the Summary flag). This reverts behavior back to pre-VS2017 behavior and
allows for an empty err/wrn file to be produced.

Closes #1968