### PR TITLE
Evaluations have unique IDs

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Build.Framework
     }
     public partial class BuildEventContext
     {
+        public const int InvalidEvaluationID = -1;
         public const int InvalidNodeId = -2;
         public const int InvalidProjectContextId = -2;
         public const int InvalidProjectInstanceId = -1;
@@ -47,7 +48,9 @@ namespace Microsoft.Build.Framework
         public BuildEventContext(int nodeId, int targetId, int projectContextId, int taskId) { }
         public BuildEventContext(int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
         public BuildEventContext(int submissionId, int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+        public BuildEventContext(int submissionId, int nodeId, int evaluationID, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
         public long BuildRequestId { get { throw null; } }
+        public int EvaluationID { get { throw null; } }
         public static Microsoft.Build.Framework.BuildEventContext Invalid { get { throw null; } }
         public int NodeId { get { throw null; } }
         public int ProjectContextId { get { throw null; } }

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -575,6 +575,7 @@ namespace Microsoft.Build.Evaluation
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> Items { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> ItemsIgnoringCondition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.ICollection<string> ItemTypes { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public int LastEvaluationID { get { throw null; } }
         public Microsoft.Build.Evaluation.ProjectCollection ProjectCollection { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectProperty> Properties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
@@ -1082,6 +1083,7 @@ namespace Microsoft.Build.Execution
         public System.Collections.Generic.List<string> DefaultTargets { get { throw null; } }
         public string Directory { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.List<Microsoft.Build.Construction.ProjectItemElement> EvaluatedItemElements { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public int EvaluationID { get { throw null; } set { } }
         public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.List<string> InitialTargets { get { throw null; } }

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -564,6 +564,7 @@ namespace Microsoft.Build.Evaluation
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.List<string>> ConditionedProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public string DirectoryPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public bool DisableMarkDirty { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ObsoleteAttribute("Use Project.LastEvaluationID instead")]
         public int EvaluationCounter { get { throw null; } }
         public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Build.Framework
     }
     public partial class BuildEventContext
     {
+        public const int InvalidEvaluationID = -1;
         public const int InvalidNodeId = -2;
         public const int InvalidProjectContextId = -2;
         public const int InvalidProjectInstanceId = -1;
@@ -47,7 +48,9 @@ namespace Microsoft.Build.Framework
         public BuildEventContext(int nodeId, int targetId, int projectContextId, int taskId) { }
         public BuildEventContext(int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
         public BuildEventContext(int submissionId, int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+        public BuildEventContext(int submissionId, int nodeId, int evaluationID, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
         public long BuildRequestId { get { throw null; } }
+        public int EvaluationID { get { throw null; } }
         public static Microsoft.Build.Framework.BuildEventContext Invalid { get { throw null; } }
         public int NodeId { get { throw null; } }
         public int ProjectContextId { get { throw null; } }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -563,6 +563,7 @@ namespace Microsoft.Build.Evaluation
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> Items { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> ItemsIgnoringCondition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.ICollection<string> ItemTypes { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
+        public int LastEvaluationID { get { throw null; } }
         public Microsoft.Build.Evaluation.ProjectCollection ProjectCollection { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectProperty> Properties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
@@ -1059,6 +1060,7 @@ namespace Microsoft.Build.Execution
         public System.Collections.Generic.List<string> DefaultTargets { get { throw null; } }
         public string Directory { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.List<Microsoft.Build.Construction.ProjectItemElement> EvaluatedItemElements { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public int EvaluationID { get { throw null; } set { } }
         public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.List<string> InitialTargets { get { throw null; } }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -552,6 +552,7 @@ namespace Microsoft.Build.Evaluation
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.List<string>> ConditionedProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public string DirectoryPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public bool DisableMarkDirty { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [System.ObsoleteAttribute("Use Project.LastEvaluationID instead")]
         public int EvaluationCounter { get { throw null; } }
         public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -1357,25 +1357,25 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         /// Reevaluation should update the evaluation counter.
         /// </summary>
         [Fact]
-        public void ReevaluationCounter()
+        public void LastEvaluationID()
         {
             Project project = new Project();
-            int last = project.EvaluationCounter;
+            int last = project.LastEvaluationID;
 
             project.ReevaluateIfNecessary();
-            Assert.Equal(project.EvaluationCounter, last);
-            last = project.EvaluationCounter;
+            Assert.Equal(project.LastEvaluationID, last);
+            last = project.LastEvaluationID;
 
             project.SetProperty("p", "v");
             project.ReevaluateIfNecessary();
-            Assert.NotEqual(project.EvaluationCounter, last);
+            Assert.NotEqual(project.LastEvaluationID, last);
         }
 
         /// <summary>
         /// Unload should not reset the evaluation counter.
         /// </summary>
         [Fact]
-        public void ReevaluationCounterUnload()
+        public void LastEvaluationIDAndUnload()
         {
             string path = null;
 
@@ -1385,12 +1385,12 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 ProjectRootElement.Create().Save(path);
 
                 Project project = new Project(path);
-                int last = project.EvaluationCounter;
+                int last = project.LastEvaluationID;
 
                 project.ProjectCollection.UnloadAllProjects();
 
                 project = new Project(path);
-                Assert.NotEqual(project.EvaluationCounter, last);
+                Assert.NotEqual(project.LastEvaluationID, last);
             }
             finally
             {
@@ -1414,25 +1414,25 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 import.Save();
 
                 Project project = new Project();
-                int last = project.EvaluationCounter;
+                int last = project.LastEvaluationID;
 
                 project.Xml.AddImport(path);
                 project.ReevaluateIfNecessary();
-                Assert.NotEqual(project.EvaluationCounter, last);
-                last = project.EvaluationCounter;
+                Assert.NotEqual(project.LastEvaluationID, last);
+                last = project.LastEvaluationID;
 
                 project.ReevaluateIfNecessary();
-                Assert.Equal(project.EvaluationCounter, last);
+                Assert.Equal(project.LastEvaluationID, last);
 
                 import.AddProperty("p", "v");
                 Assert.Equal(true, project.IsDirty);
                 project.ReevaluateIfNecessary();
-                Assert.NotEqual(project.EvaluationCounter, last);
-                last = project.EvaluationCounter;
+                Assert.NotEqual(project.LastEvaluationID, last);
+                last = project.LastEvaluationID;
                 Assert.Equal("v", project.GetPropertyValue("p"));
 
                 project.ReevaluateIfNecessary();
-                Assert.Equal(project.EvaluationCounter, last);
+                Assert.Equal(project.LastEvaluationID, last);
             }
             finally
             {

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -3808,6 +3808,33 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             }
         }
 
+        [Fact]
+        public void ProjectInstanceShouldInitiallyHaveSameEvaluationIDAsTheProjectItCameFrom()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                var projectCollection = env.CreateProjectCollection().Collection;
+
+                var project = new Project(null, null, projectCollection);
+                var initialEvaluationID = project.LastEvaluationID;
+
+                var projectInstance = project.CreateProjectInstance();
+
+                Assert.NotEqual(BuildEventContext.InvalidEvaluationID, initialEvaluationID);
+                Assert.Equal(initialEvaluationID, projectInstance.EvaluationID);
+
+                // trigger a new evaluation which increments the evaluation ID in the Project
+                project.AddItem("foo", "bar");
+                project.ReevaluateIfNecessary();
+
+                Assert.NotEqual(initialEvaluationID, project.LastEvaluationID);
+                Assert.Equal(initialEvaluationID, projectInstance.EvaluationID);
+
+                var newProjectInstance = project.CreateProjectInstance();
+                Assert.Equal(project.LastEvaluationID, newProjectInstance.EvaluationID);
+            }
+        }
+
         private static void AssertGlobResult(GlobResultList expected, string project)
         {
             var globs = ObjectModelHelpers.CreateInMemoryProject(project).GetAllGlobs();

--- a/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Build.UnitTests.Logging
 
         #region LogErrorFromText
         /// <summary>
-        /// Verify an InternalErrorException is thrown when BuildEventContext is null.
+        /// Verify an InternalErrorException is thrown when buildEventContext is null.
         /// </summary>
         [Fact]
         public void LogErrorFromTextNullBuildEventContext()
@@ -600,7 +600,7 @@ namespace Microsoft.Build.UnitTests.Logging
 
         #region LogWarningErrorFromText
         /// <summary>
-        /// Verify an InternalErrorException is thrown when a null BuildEventContext is passed in
+        /// Verify an InternalErrorException is thrown when a null buildEventContext is passed in
         /// </summary>
         [Fact]
         public void LogWarningFromTextNullBuildEventContext()

--- a/src/Build.UnitTests/BackEnd/SdkResolution_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolution_Tests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 _includeErrorResolver = includeErrorResolver;
             }
 
-            internal override IList<SdkResolver> LoadResolvers(BaseLoggingContext loggingContext, ElementLocation location)
+            internal override IList<SdkResolver> LoadResolvers(LoggingContext loggingContext, ElementLocation location)
             {
                 return _includeErrorResolver
                     ? new List<SdkResolver> {new MockSdkResolverThrows(),new MockSdkResolver1(),new MockSdkResolver2()}

--- a/src/Build.UnitTests/BackEnd/SdkResolution_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolution_Tests.cs
@@ -13,19 +13,29 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
     public class SdkResolution_Tests
     {
+        private readonly StringBuilder _log;
+        private readonly MockLoggingContext _loggingContext;
+
+        public SdkResolution_Tests()
+        {
+            _log = new StringBuilder();
+
+            var logger = new MockLoggingService(message => _log.AppendLine(message));
+            var bec = new BuildEventContext(0, 0, 0, 0, 0);
+
+            _loggingContext = new MockLoggingContext(logger, bec);
+        }
+
         [Fact]
         public void AssertFirstResolverCanResolve()
         {
-            var log = new StringBuilder();
             var sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
-            var logger = new MockLoggingService(message => log.AppendLine(message));
-            var bec = new BuildEventContext(0, 0, 0, 0, 0);
             
             SdkResolution resolution = new SdkResolution(new MockLoaderStrategy());
-            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln", "projectPath");
+            var result = resolution.GetSdkPath(sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath");
 
             Assert.Equal("resolverpath1", result);
-            Assert.Equal("MockSdkResolver1 running", log.ToString().Trim());
+            Assert.Equal("MockSdkResolver1 running", _log.ToString().Trim());
         }
 
         [Fact]
@@ -39,9 +49,9 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var bec = new BuildEventContext(0, 0, 0, 0, 0);
 
             SdkResolution resolution = new SdkResolution(new MockLoaderStrategy());
-            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln", "projectPath");
+            var result = resolution.GetSdkPath(sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath");
 
-            var logResult = log.ToString();
+            var logResult = _log.ToString();
             Assert.Equal("resolverpath2", result);
 
             // Both resolvers should run, and no ERROR string.
@@ -62,9 +72,9 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var bec = new BuildEventContext(0, 0, 0, 0, 0);
 
             SdkResolution resolution = new SdkResolution(new MockLoaderStrategy());
-            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln", "projectPath");
+            var result = resolution.GetSdkPath(sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath");
 
-            var logResult = log.ToString();
+            var logResult = _log.ToString();
             Assert.Null(result);
             Assert.Contains("MockSdkResolver1 running", logResult);
             Assert.Contains("MockSdkResolver2 running", logResult);
@@ -82,10 +92,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             var bec = new BuildEventContext(0, 0, 0, 0, 0);
 
             SdkResolution resolution = new SdkResolution(new MockLoaderStrategy(true));
-            var result = resolution.GetSdkPath(sdk, logger, bec, new MockElementLocation("file"), "sln", "projectPath");
+            var result = resolution.GetSdkPath(sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath");
 
             Assert.Equal("resolverpath1", result);
-            Assert.Contains("EXMESSAGE", log.ToString());
+            Assert.Contains("EXMESSAGE", _log.ToString());
         }
 
         private class MockLoaderStrategy : SdkResolverLoader
@@ -97,7 +107,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 _includeErrorResolver = includeErrorResolver;
             }
 
-            internal override IList<SdkResolver> LoadResolvers(ILoggingService logger, BuildEventContext bec, ElementLocation location)
+            internal override IList<SdkResolver> LoadResolvers(BaseLoggingContext loggingContext, ElementLocation location)
             {
                 return _includeErrorResolver
                     ? new List<SdkResolver> {new MockSdkResolverThrows(),new MockSdkResolver1(),new MockSdkResolver2()}

--- a/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -15,15 +11,25 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
     public class SdkResolverLoader_Tests
     {
+        private readonly StringBuilder _log;
+        private readonly MockLoggingContext _loggingContext;
+
+        public SdkResolverLoader_Tests()
+        {
+            _log = new StringBuilder();
+
+            var logger = new MockLoggingService(message => _log.AppendLine(message));
+            var bec = new BuildEventContext(0, 0, 0, 0, 0);
+
+            _loggingContext = new MockLoggingContext(logger, bec);
+        }
+
         [Fact]
         public void AssertDefaultLoaderReturnsDefaultResolver()
         {
             var loader = new SdkResolverLoader();
-            var log = new StringBuilder();
-            var logger = new MockLoggingService(message => log.AppendLine(message));
-            var bec = new BuildEventContext(0, 0, 0, 0, 0);
 
-            var resolvers = loader.LoadResolvers(logger, bec, new MockElementLocation("file"));
+            var resolvers = loader.LoadResolvers(_loggingContext, new MockElementLocation("file"));
 
             Assert.Equal(1, resolvers.Count);
             Assert.Equal(typeof(DefaultSdkResolver), resolvers[0].GetType());

--- a/src/Build.UnitTests/Evaluation/EvaluationLogging_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationLogging_Tests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+// <summary>Tests for evaluation logging</summary>
+//-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Engine.UnitTests;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    /// <summary>
+    ///     Tests mainly for project evaluation logging
+    /// </summary>
+    public class EvaluationLogging_Tests : IDisposable
+    {
+        /// <summary>
+        ///     Cleanup
+        /// </summary>
+        public EvaluationLogging_Tests()
+        {
+            ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
+            GC.Collect();
+        }
+
+        /// <summary>
+        ///     Cleanup
+        /// </summary>
+        public void Dispose()
+        {
+            ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
+            GC.Collect();
+        }
+
+        private static void AssertLoggingEvents(Action<Project, MockLogger> loggingTest)
+        {
+            var projectImportContents =
+                @"<Project>
+                    <Target Name=`Foo`
+                            AfterTargets=`X`
+                            BeforeTargets=`Y`
+                    >
+                    </Target>
+
+                    <PropertyGroup>
+                      <P>Bar</P>
+                      <P2>$(NonExisting)</P2>
+                    </PropertyGroup>
+                  </Project>".Cleanup();
+
+            var projectContents =
+                @"<Project>
+                    <Target Name=`Foo`>
+                    </Target>
+
+                    <PropertyGroup>
+                      <P>Foo</P>
+                    </PropertyGroup>
+
+                    <Import Project=`{0}`/>
+                    <Import Project=`{0}`/>
+                  </Project>".Cleanup();
+
+            using (var env = TestEnvironment.Create())
+            {
+                var collection = env.CreateProjectCollection().Collection;
+
+                var importFile = env.CreateFile().Path;
+                File.WriteAllText(importFile, projectImportContents);
+
+                projectContents = string.Format(projectContents, importFile);
+
+
+                var projectFile = env.CreateFile().Path;
+                File.WriteAllText(projectFile, projectContents);
+
+                var logger = new MockLogger();
+                collection.RegisterLogger(logger);
+
+                var project = new Project(projectFile, null, null, collection);
+
+                Assert.NotEmpty(logger.AllBuildEvents);
+
+                loggingTest.Invoke(project, logger);
+            }
+        }
+
+        [Fact]
+        public void AllEvaluationEventsShouldHaveAnEvaluationID()
+        {
+            AssertLoggingEvents(
+                (project, mockLogger) =>
+                {
+                    var evaluationID = project.LastEvaluationID;
+
+                    Assert.NotEqual(BuildEventContext.InvalidEvaluationID, evaluationID);
+
+                    foreach (var buildEvent in mockLogger.AllBuildEvents)
+                    {
+                        Assert.Equal(evaluationID, buildEvent.BuildEventContext.EvaluationID);
+                    }
+                });
+        }
+
+        [Fact]
+        public void FirstAndLastEvaluationEventsShouldBeStartedAndEnded()
+        {
+            AssertLoggingEvents(
+                (project, mockLogger) =>
+                {
+                    Assert.True(mockLogger.AllBuildEvents.Count >= 2);
+
+                    Assert.StartsWith("Evaluation started", mockLogger.AllBuildEvents.First().Message);
+                    Assert.StartsWith("Evaluation finished", mockLogger.AllBuildEvents.Last().Message);
+                });
+        }
+    }
+}

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="BackEnd\TaskHostTaskCancelled_Tests.cs" />
     <Compile Include="BackEnd\TaskHostTaskComplete_Tests.cs" />
     <Compile Include="BackEnd\TaskHost_Tests.cs" />
+    <Compile Include="MockLoggingContext.cs" />
     <Compile Include="TestComparers\TaskRegistryComparers.cs" />
     <Compile Include="BackEnd\TaskRegistry_Tests.cs" />
     <Compile Include="BackEnd\TranslationHelpers.cs" />

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="BackEnd\TaskHostTaskCancelled_Tests.cs" />
     <Compile Include="BackEnd\TaskHostTaskComplete_Tests.cs" />
     <Compile Include="BackEnd\TaskHost_Tests.cs" />
+    <Compile Include="Evaluation\EvaluationLogging_Tests.cs" />
     <Compile Include="MockLoggingContext.cs" />
     <Compile Include="TestComparers\TaskRegistryComparers.cs" />
     <Compile Include="BackEnd\TaskRegistry_Tests.cs" />

--- a/src/Build.UnitTests/MockLoggingContext.cs
+++ b/src/Build.UnitTests/MockLoggingContext.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.Engine.UnitTests
     /// <summary>
     /// Logging context and helpers for evaluation logging
     /// </summary>
-    internal class MockLoggingContext : BaseLoggingContext
+    internal class MockLoggingContext : LoggingContext
     {
         public MockLoggingContext(ILoggingService loggingService, BuildEventContext eventContext) : base(loggingService, eventContext)
         {

--- a/src/Build.UnitTests/MockLoggingContext.cs
+++ b/src/Build.UnitTests/MockLoggingContext.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+
+using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Engine.UnitTests
+{
+    /// <summary>
+    /// Logging context and helpers for evaluation logging
+    /// </summary>
+    internal class MockLoggingContext : BaseLoggingContext
+    {
+        public MockLoggingContext(ILoggingService loggingService, BuildEventContext eventContext) : base(loggingService, eventContext)
+        {
+            IsValid = true;
+        }
+    }
+}

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -897,8 +897,8 @@ namespace Microsoft.Build.BackEnd
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {
                     _nodeLoggingContext.LogFatalBuildError(
-                        new BuildEventFileInfo(Microsoft.Build.Construction.ElementLocation.EmptyLocation),
-                        e);
+                        e,
+                        new BuildEventFileInfo(Microsoft.Build.Construction.ElementLocation.EmptyLocation));
                     throw new BuildAbortedException(e.Message, e);
                 }
             }

--- a/src/Build/BackEnd/Components/Logging/BaseBuildLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/BaseBuildLoggingContext.cs
@@ -19,33 +19,14 @@ using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFil
 namespace Microsoft.Build.BackEnd.Logging
 {
     /// <summary>
-    /// This object encapsulates the logging service plus the current BuildEventContext and
-    /// hides the requirement to pass BuildEventContexts to the logging service or query the
-    /// host for the logging service all of the time.
-    /// 
-    /// Its intended use is in the nodes, where a base LoggingContext is created when the node
+    /// Intended to be used in the nodes, during a build, where a base LoggingContext is created when the node
     /// initializes for a build (this is the public constructor.)  When a new project, target batch
     /// or task batch is started, the appropriate method on the current LoggingContext is invoked
     /// and a new LoggingContext is returned.  This new LoggingContext should be used for all
     /// subsequent logging within the subcontext.
     /// </summary>
-    internal class BaseBuildLoggingContext
+    internal class BaseBuildLoggingContext : BaseLoggingContext
     {
-        /// <summary>
-        /// The logging service to which this context is attached
-        /// </summary>
-        private ILoggingService _loggingService;
-
-        /// <summary>
-        /// The build event context understood by the logging service.
-        /// </summary>
-        private BuildEventContext _eventContext;
-
-        /// <summary>
-        /// True if this context is still valid (i.e. hasn't been "finished")
-        /// </summary>
-        private bool _isValid;
-
         /// <summary>
         /// True if this context comes from the in-proc node.
         /// </summary>
@@ -55,81 +36,17 @@ namespace Microsoft.Build.BackEnd.Logging
         /// Constructs the logging context from a logging service and an event context.
         /// </summary>
         /// <param name="loggingService">The logging service to use</param>
-        /// <param name="eventContext">The event context</param>
+        /// <param name="buildEventContext">The event context</param>
         /// <param name="inProc">Flag indicating if this context belongs to an in-proc node.</param>
-        protected BaseBuildLoggingContext(ILoggingService loggingService, BuildEventContext eventContext, bool inProc)
+        protected BaseBuildLoggingContext(ILoggingService loggingService, BuildEventContext buildEventContext, bool inProc) : base(loggingService, buildEventContext)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(loggingService, "loggingService");
-            ErrorUtilities.VerifyThrowArgumentNull(eventContext, "eventContext");
-
-            _loggingService = loggingService;
-            _eventContext = eventContext;
-            _isValid = false;
             _isInProcNode = inProc;
         }
 
-        /// <summary>
-        /// Constructs a logging context from another logging context.  This is used primarily in
-        /// the constructors for other logging contexts to populate the logging service parameter,
-        /// while the event context will come from a call into the logging service itself.
-        /// </summary>
-        /// <param name="baseContext">The context from which this context is being created.</param>
-        protected BaseBuildLoggingContext(BaseBuildLoggingContext baseContext)
+        /// <inheritdoc cref="BaseLoggingContext"/>
+        protected BaseBuildLoggingContext(BaseBuildLoggingContext baseContext) : base(baseContext)
         {
-            _loggingService = baseContext._loggingService;
-            _eventContext = null;
-            _isValid = baseContext._isValid;
             _isInProcNode = baseContext._isInProcNode;
-        }
-
-        /// <summary>
-        /// Retrieves the logging service
-        /// </summary>
-        public ILoggingService LoggingService
-        {
-            [DebuggerStepThrough]
-            get
-            { return _loggingService; }
-        }
-
-        /// <summary>
-        /// Retrieves the build event context
-        /// UNDONE: (Refactor) We eventually want to remove this because all logging should go
-        /// through a context object.  This exists only so we can make certain 
-        /// logging calls in code which has not yet been fully refactored.
-        /// </summary>
-        public BuildEventContext BuildEventContext
-        {
-            [DebuggerStepThrough]
-            get
-            {
-                return _eventContext;
-            }
-
-            protected set
-            {
-                ErrorUtilities.VerifyThrow(_eventContext == null, "eventContext should be null");
-                _eventContext = value;
-            }
-        }
-
-        /// <summary>
-        /// Returns true if the context is still valid, false if the
-        /// appropriate 'Finished' call has been invoked.
-        /// </summary>
-        public bool IsValid
-        {
-            [DebuggerStepThrough]
-            get
-            {
-                return _isValid;
-            }
-
-            [DebuggerStepThrough]
-            protected set
-            {
-                _isValid = value;
-            }
         }
 
         /// <summary>
@@ -141,104 +58,6 @@ namespace Microsoft.Build.BackEnd.Logging
             get
             { return _isInProcNode; }
         }
-        #region Log comments
-        /// <summary>
-        ///  Helper method to create a message build event from a string resource and some parameters
-        /// </summary>
-        /// <param name="importance">Importance level of the message</param>
-        /// <param name="messageResourceName">string within the resource which indicates the format string to use</param>
-        /// <param name="messageArgs">string resource arguments</param>
-        internal void LogComment(MessageImportance importance, string messageResourceName, params object[] messageArgs)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogComment(_eventContext, importance, messageResourceName, messageArgs);
-        }
-
-        /// <summary>
-        /// Helper method to create a message build event from a string
-        /// </summary>
-        /// <param name="importance">Importance level of the message</param>
-        /// <param name="message">message to log</param>
-        internal void LogCommentFromText(MessageImportance importance, string message)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogCommentFromText(_eventContext, importance, message);
-        }
-        #endregion
-
-        #region Log events
-        /// <summary>
-        /// Will Log a build Event. Will also take into account OnlyLogCriticalEvents when determining if to drop the event or to log it.
-        /// </summary>
-        /// <param name="buildEvent">The event to log</param>
-        internal void LogBuildEvent(BuildEventArgs buildEvent)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogBuildEvent(buildEvent);
-        }
-
-        #endregion
-
-        #region Log errors
-        /// <summary>
-        /// Log an error
-        /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
-        /// <param name="messageResourceName">The resource name for the error</param>
-        /// <param name="messageArgs">Parameters for the resource string</param>
-        internal void LogError(BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogError(_eventContext, file, messageResourceName, messageArgs);
-        }
-
-        /// <summary>
-        /// Log an error
-        /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
-        /// <param name="subcategoryResourceName">The resource name which indicates the subCategory</param>
-        /// <param name="messageResourceName">The resource name for the error</param>
-        /// <param name="messageArgs">Parameters for the resource string</param>
-        internal void LogErrorWithSubcategory(BuildEventFileInfo file, string subcategoryResourceName, string messageResourceName, params object[] messageArgs)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogError(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
-        }
-
-        /// <summary>
-        /// Log an error
-        /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
-        /// <param name="subcategoryResourceName">The resource name which indicates the subCategory</param>
-        /// <param name="errorCode"> Error code</param>
-        /// <param name="helpKeyword">Help keyword</param>
-        /// <param name="message">Error message</param>
-        internal void LogErrorFromText(BuildEventFileInfo file, string subcategoryResourceName, string errorCode, string helpKeyword, string message)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogErrorFromText(_eventContext, subcategoryResourceName, errorCode, helpKeyword, file, message);
-        }
-
-        /// <summary>
-        /// Log an invalid project file exception
-        /// </summary>
-        /// <param name="invalidProjectFileException">The invalid Project File Exception which is to be logged</param>
-        internal void LogInvalidProjectFileError(InvalidProjectFileException invalidProjectFileException)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogInvalidProjectFileError(_eventContext, invalidProjectFileException);
-        }
-
-        /// <summary>
-        /// Log an error based on an exception
-        /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
-        /// <param name="exception">The exception wich is to be logged</param>
-        internal void LogFatalBuildError(BuildEventFileInfo file, Exception exception)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogFatalBuildError(_eventContext, exception, file);
-        }
 
         /// <summary>
         /// Log an error based on an exception during the execution of a task
@@ -248,65 +67,8 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="taskName">The task in which the error occurred</param>
         internal void LogFatalTaskError(BuildEventFileInfo file, Exception exception, string taskName)
         {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogFatalTaskError(_eventContext, exception, file, taskName);
+            ErrorUtilities.VerifyThrow(IsValid, "must be valid");
+            LoggingService.LogFatalTaskError(BuildEventContext, exception, file, taskName);
         }
-
-        /// <summary>
-        /// Log an error based on an exception
-        /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
-        /// <param name="exception">The exception wich is to be logged</param>
-        /// <param name="messageResourceName">The string resource which has the formatting string for the error</param>
-        /// <param name="messageArgs">The arguments for the error message</param>
-        internal void LogFatalError(BuildEventFileInfo file, Exception exception, string messageResourceName, params object[] messageArgs)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogFatalError(_eventContext, exception, file, messageResourceName, messageArgs);
-        }
-
-        #endregion
-
-        #region Log warnings
-        /// <summary>
-        /// Log a warning based on an exception
-        /// </summary>
-        /// <param name="file">The file in which the warning occurred</param>
-        /// <param name="exception">The exception to be logged as a warning</param>
-        /// <param name="taskName">The task in which the warning occurred</param>
-        internal void LogTaskWarningFromException(BuildEventFileInfo file, Exception exception, string taskName)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogTaskWarningFromException(_eventContext, exception, file, taskName);
-        }
-
-        /// <summary>
-        /// Log a warning
-        /// </summary>
-        /// <param name="file">The file in which the warning occurred</param>
-        /// <param name="subcategoryResourceName">The subcategory resource name</param>
-        /// <param name="messageResourceName">The string resource which contains the formatted warning string</param>
-        /// <param name="messageArgs">parameters for the string resource</param>
-        internal void LogWarning(BuildEventFileInfo file, string subcategoryResourceName, string messageResourceName, params object[] messageArgs)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogWarning(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
-        }
-
-        /// <summary>
-        /// Log a warning based on a text message
-        /// </summary>
-        /// <param name="file">The file in which the warning occurred</param>
-        /// <param name="subcategoryResourceName">The subcategory resource name</param>
-        /// <param name="warningCode"> Warning code</param>
-        /// <param name="helpKeyword"> Help keyword</param>
-        /// <param name="message">The message to be logged as a warning</param>
-        internal void LogWarningFromText(BuildEventFileInfo file, string subcategoryResourceName, string warningCode, string helpKeyword, string message)
-        {
-            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
-            _loggingService.LogWarningFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);
-        }
-
-        #endregion
     }
 }

--- a/src/Build/BackEnd/Components/Logging/BaseBuildLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/BaseBuildLoggingContext.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// and a new LoggingContext is returned.  This new LoggingContext should be used for all
     /// subsequent logging within the subcontext.
     /// </summary>
-    internal class BaseLoggingContext
+    internal class BaseBuildLoggingContext
     {
         /// <summary>
         /// The logging service to which this context is attached
@@ -57,7 +57,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="loggingService">The logging service to use</param>
         /// <param name="eventContext">The event context</param>
         /// <param name="inProc">Flag indicating if this context belongs to an in-proc node.</param>
-        protected BaseLoggingContext(ILoggingService loggingService, BuildEventContext eventContext, bool inProc)
+        protected BaseBuildLoggingContext(ILoggingService loggingService, BuildEventContext eventContext, bool inProc)
         {
             ErrorUtilities.VerifyThrowArgumentNull(loggingService, "loggingService");
             ErrorUtilities.VerifyThrowArgumentNull(eventContext, "eventContext");
@@ -74,7 +74,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// while the event context will come from a call into the logging service itself.
         /// </summary>
         /// <param name="baseContext">The context from which this context is being created.</param>
-        protected BaseLoggingContext(BaseLoggingContext baseContext)
+        protected BaseBuildLoggingContext(BaseBuildLoggingContext baseContext)
         {
             _loggingService = baseContext._loggingService;
             _eventContext = null;

--- a/src/Build/BackEnd/Components/Logging/BaseLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/BaseLoggingContext.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Build.Exceptions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.BackEnd.Logging
+{
+    /// <summary>
+    /// This object encapsulates the logging service plus the current BuildEventContext and
+    /// hides the requirement to pass BuildEventContexts to the logging service or query the
+    /// host for the logging service all of the time.
+    /// </summary>
+    internal class BaseLoggingContext
+    {
+        /// <summary>
+        /// The logging service to which this context is attached
+        /// </summary>
+        private readonly ILoggingService _loggingService;
+
+        /// <summary>
+        /// The build event context understood by the logging service.
+        /// </summary>
+        private BuildEventContext _eventContext;
+
+        /// <summary>
+        /// True if this context is still valid (i.e. hasn't been "finished")
+        /// </summary>
+        private bool _isValid;
+
+        /// <summary>
+        /// Constructs the logging context from a logging service and an event context.
+        /// </summary>
+        /// <param name="loggingService">The logging service to use</param>
+        /// <param name="eventContext">The event context</param>
+        public BaseLoggingContext(ILoggingService loggingService, BuildEventContext eventContext)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(loggingService, "loggingService");
+            ErrorUtilities.VerifyThrowArgumentNull(eventContext, "eventContext");
+
+            _loggingService = loggingService;
+            _eventContext = eventContext;
+            _isValid = false;
+        }
+
+        /// <summary>
+        /// Constructs a logging context from another logging context.  This is used primarily in
+        /// the constructors for other logging contexts to populate the logging service parameter,
+        /// while the event context will come from a call into the logging service itself.
+        /// </summary>
+        /// <param name="baseContext">The context from which this context is being created.</param>
+        public BaseLoggingContext(BaseLoggingContext baseContext)
+        {
+            _loggingService = baseContext._loggingService;
+            _eventContext = null;
+            _isValid = baseContext._isValid;
+        }
+
+        /// <summary>
+        /// Retrieves the logging service
+        /// </summary>
+        public ILoggingService LoggingService
+        {
+            [DebuggerStepThrough]
+            get
+            { return _loggingService; }
+        }
+
+        /// <summary>
+        /// Retrieves the build event context
+        /// UNDONE: (Refactor) We eventually want to remove this because all logging should go
+        /// through a context object.  This exists only so we can make certain 
+        /// logging calls in code which has not yet been fully refactored.
+        /// </summary>
+        public BuildEventContext BuildEventContext
+        {
+            [DebuggerStepThrough]
+            get
+            {
+                return _eventContext;
+            }
+
+            protected set
+            {
+                ErrorUtilities.VerifyThrow(_eventContext == null, "eventContext should be null");
+                _eventContext = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the context is still valid, false if the
+        /// appropriate 'Finished' call has been invoked.
+        /// </summary>
+        public bool IsValid
+        {
+            [DebuggerStepThrough]
+            get
+            {
+                return _isValid;
+            }
+
+            [DebuggerStepThrough]
+            protected set
+            {
+                _isValid = value;
+            }
+        }
+
+        /// <summary>
+        ///  Helper method to create a message build event from a string resource and some parameters
+        /// </summary>
+        /// <param name="importance">Importance level of the message</param>
+        /// <param name="messageResourceName">string within the resource which indicates the format string to use</param>
+        /// <param name="messageArgs">string resource arguments</param>
+        internal void LogComment(MessageImportance importance, string messageResourceName, params object[] messageArgs)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogComment(_eventContext, importance, messageResourceName, messageArgs);
+        }
+
+        /// <summary>
+        /// Helper method to create a message build event from a string
+        /// </summary>
+        /// <param name="importance">Importance level of the message</param>
+        /// <param name="message">message to log</param>
+        internal void LogCommentFromText(MessageImportance importance, string message)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogCommentFromText(_eventContext, importance, message);
+        }
+
+        /// <summary>
+        /// Log an error
+        /// </summary>
+        /// <param name="file">The file in which the error occurred</param>
+        /// <param name="messageResourceName">The resource name for the error</param>
+        /// <param name="messageArgs">Parameters for the resource string</param>
+        internal void LogError(BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogError(_eventContext, file, messageResourceName, messageArgs);
+        }
+
+        /// <summary>
+        /// Log an error
+        /// </summary>
+        /// <param name="file">The file in which the error occurred</param>
+        /// <param name="subcategoryResourceName">The resource name which indicates the subCategory</param>
+        /// <param name="messageResourceName">The resource name for the error</param>
+        /// <param name="messageArgs">Parameters for the resource string</param>
+        internal void LogErrorWithSubcategory(BuildEventFileInfo file, string subcategoryResourceName, string messageResourceName, params object[] messageArgs)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogError(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
+        }
+
+        /// <summary>
+        /// Log an error
+        /// </summary>
+        /// <param name="file">The file in which the error occurred</param>
+        /// <param name="subcategoryResourceName">The resource name which indicates the subCategory</param>
+        /// <param name="errorCode"> Error code</param>
+        /// <param name="helpKeyword">Help keyword</param>
+        /// <param name="message">Error message</param>
+        internal void LogErrorFromText(BuildEventFileInfo file, string subcategoryResourceName, string errorCode, string helpKeyword, string message)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogErrorFromText(_eventContext, subcategoryResourceName, errorCode, helpKeyword, file, message);
+        }
+
+        /// <summary>
+        /// Log an invalid project file exception
+        /// </summary>
+        /// <param name="invalidProjectFileException">The invalid Project File Exception which is to be logged</param>
+        internal void LogInvalidProjectFileError(InvalidProjectFileException invalidProjectFileException)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogInvalidProjectFileError(_eventContext, invalidProjectFileException);
+        }
+
+        /// <summary>
+        /// Log an error based on an exception
+        /// </summary>
+        /// <param name="file">The file in which the error occurred</param>
+        /// <param name="exception">The exception wich is to be logged</param>
+        /// <param name="messageResourceName">The string resource which has the formatting string for the error</param>
+        /// <param name="messageArgs">The arguments for the error message</param>
+        internal void LogFatalError(BuildEventFileInfo file, Exception exception, string messageResourceName, params object[] messageArgs)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogFatalError(_eventContext, exception, file, messageResourceName, messageArgs);
+        }
+
+        /// <summary>
+        /// Log a warning
+        /// </summary>
+        /// <param name="file">The file in which the warning occurred</param>
+        /// <param name="subcategoryResourceName">The subcategory resource name</param>
+        /// <param name="messageResourceName">The string resource which contains the formatted warning string</param>
+        /// <param name="messageArgs">parameters for the string resource</param>
+        internal void LogWarning(BuildEventFileInfo file, string subcategoryResourceName, string messageResourceName, params object[] messageArgs)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogWarning(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
+        }
+
+        /// <summary>
+        /// Log a warning based on a text message
+        /// </summary>
+        /// <param name="file">The file in which the warning occurred</param>
+        /// <param name="subcategoryResourceName">The subcategory resource name</param>
+        /// <param name="warningCode"> Warning code</param>
+        /// <param name="helpKeyword"> Help keyword</param>
+        /// <param name="message">The message to be logged as a warning</param>
+        internal void LogWarningFromText(BuildEventFileInfo file, string subcategoryResourceName, string warningCode, string helpKeyword, string message)
+        {
+            ErrorUtilities.VerifyThrow(_isValid, "must be valid");
+            _loggingService.LogWarningFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);
+        }
+
+        /// <summary>
+        /// Will Log a build Event. Will also take into account OnlyLogCriticalEvents when determining if to drop the event or to log it.
+        /// </summary>
+        /// <param name="buildEvent">The event to log</param>
+        internal void LogBuildEvent(BuildEventArgs buildEvent)
+        {
+            ErrorUtilities.VerifyThrow(IsValid, "must be valid");
+            LoggingService.LogBuildEvent(buildEvent);
+        }
+
+        /// <summary>
+        /// Log an error based on an exception
+        /// </summary>
+        /// <param name="file">The file in which the error occurred</param>
+        /// <param name="exception">The exception wich is to be logged</param>
+        internal void LogFatalBuildError(BuildEventFileInfo file, Exception exception)
+        {
+            ErrorUtilities.VerifyThrow(IsValid, "must be valid");
+            LoggingService.LogFatalBuildError(BuildEventContext, exception, file);
+        }
+    }
+}

--- a/src/Build/BackEnd/Components/Logging/BuildLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/BuildLoggingContext.cs
@@ -62,10 +62,10 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log an error based on an exception during the execution of a task
         /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
         /// <param name="exception">The exception wich is to be logged</param>
+        /// <param name="file">The file in which the error occurred</param>
         /// <param name="taskName">The task in which the error occurred</param>
-        internal void LogFatalTaskError(BuildEventFileInfo file, Exception exception, string taskName)
+        internal void LogFatalTaskError(Exception exception, BuildEventFileInfo file, string taskName)
         {
             ErrorUtilities.VerifyThrow(IsValid, "must be valid");
             LoggingService.LogFatalTaskError(BuildEventContext, exception, file, taskName);

--- a/src/Build/BackEnd/Components/Logging/BuildLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/BuildLoggingContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// and a new LoggingContext is returned.  This new LoggingContext should be used for all
     /// subsequent logging within the subcontext.
     /// </summary>
-    internal class BaseBuildLoggingContext : BaseLoggingContext
+    internal class BuildLoggingContext : LoggingContext
     {
         /// <summary>
         /// True if this context comes from the in-proc node.
@@ -38,13 +38,13 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="loggingService">The logging service to use</param>
         /// <param name="buildEventContext">The event context</param>
         /// <param name="inProc">Flag indicating if this context belongs to an in-proc node.</param>
-        protected BaseBuildLoggingContext(ILoggingService loggingService, BuildEventContext buildEventContext, bool inProc) : base(loggingService, buildEventContext)
+        protected BuildLoggingContext(ILoggingService loggingService, BuildEventContext buildEventContext, bool inProc) : base(loggingService, buildEventContext)
         {
             _isInProcNode = inProc;
         }
 
-        /// <inheritdoc cref="BaseLoggingContext"/>
-        protected BaseBuildLoggingContext(BaseBuildLoggingContext baseContext) : base(baseContext)
+        /// <inheritdoc cref="LoggingContext"/>
+        protected BuildLoggingContext(BuildLoggingContext baseContext) : base(baseContext)
         {
             _isInProcNode = baseContext._isInProcNode;
         }

--- a/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+
+using Microsoft.Build.Framework;
+
+using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
+
+namespace Microsoft.Build.BackEnd.Logging
+{
+    /// <summary>
+    /// Logging context and helpers for evaluation logging
+    /// </summary>
+    internal class EvaluationLoggingContext : BaseLoggingContext
+    {
+        public EvaluationLoggingContext(ILoggingService loggingService, BuildEventContext eventContext) : base(loggingService, eventContext)
+        {
+            IsValid = true;
+        }
+    }
+}

--- a/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
@@ -3,18 +3,27 @@
 //-----------------------------------------------------------------------
 // </copyright>
 
+using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Framework;
 
-using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
-
-namespace Microsoft.Build.BackEnd.Logging
+namespace Microsoft.Build.BackEnd.Components.Logging
 {
     /// <summary>
-    /// Logging context and helpers for evaluation logging
+    ///     Logging context and helpers for evaluation logging
     /// </summary>
     internal class EvaluationLoggingContext : BaseLoggingContext
     {
-        public EvaluationLoggingContext(ILoggingService loggingService, BuildEventContext eventContext) : base(loggingService, eventContext)
+        public EvaluationLoggingContext(ILoggingService loggingService, BuildEventContext eventContext, int evaluationID) : base(
+            loggingService,
+            new BuildEventContext(
+                eventContext.SubmissionId,
+                eventContext.NodeId,
+                evaluationID,
+                eventContext.ProjectInstanceId,
+                eventContext.ProjectContextId,
+                eventContext.TargetId,
+                eventContext.TaskId
+            ))
         {
             IsValid = true;
         }

--- a/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.BackEnd.Components.Logging
     /// <summary>
     ///     Logging context and helpers for evaluation logging
     /// </summary>
-    internal class EvaluationLoggingContext : BaseLoggingContext
+    internal class EvaluationLoggingContext : LoggingContext
     {
         public EvaluationLoggingContext(ILoggingService loggingService, BuildEventContext eventContext, int evaluationID) : base(
             loggingService,

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -144,11 +144,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log an error
         /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
         /// <param name="subcategoryResourceName">The resource name which indicates the subCategory</param>
+        /// <param name="file">The file in which the error occurred</param>
         /// <param name="messageResourceName">The resource name for the error</param>
         /// <param name="messageArgs">Parameters for the resource string</param>
-        internal void LogErrorWithSubcategory(BuildEventFileInfo file, string subcategoryResourceName, string messageResourceName, params object[] messageArgs)
+        internal void LogErrorWithSubcategory(string subcategoryResourceName, BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogError(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
@@ -157,12 +157,12 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log an error
         /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
         /// <param name="subcategoryResourceName">The resource name which indicates the subCategory</param>
         /// <param name="errorCode"> Error code</param>
         /// <param name="helpKeyword">Help keyword</param>
+        /// <param name="file">The file in which the error occurred</param>
         /// <param name="message">Error message</param>
-        internal void LogErrorFromText(BuildEventFileInfo file, string subcategoryResourceName, string errorCode, string helpKeyword, string message)
+        internal void LogErrorFromText(string subcategoryResourceName, string errorCode, string helpKeyword, BuildEventFileInfo file, string message)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogErrorFromText(_eventContext, subcategoryResourceName, errorCode, helpKeyword, file, message);
@@ -181,11 +181,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log an error based on an exception
         /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
         /// <param name="exception">The exception wich is to be logged</param>
+        /// <param name="file">The file in which the error occurred</param>
         /// <param name="messageResourceName">The string resource which has the formatting string for the error</param>
         /// <param name="messageArgs">The arguments for the error message</param>
-        internal void LogFatalError(BuildEventFileInfo file, Exception exception, string messageResourceName, params object[] messageArgs)
+        internal void LogFatalError(Exception exception, BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogFatalError(_eventContext, exception, file, messageResourceName, messageArgs);
@@ -194,11 +194,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log a warning
         /// </summary>
-        /// <param name="file">The file in which the warning occurred</param>
         /// <param name="subcategoryResourceName">The subcategory resource name</param>
+        /// <param name="file">The file in which the warning occurred</param>
         /// <param name="messageResourceName">The string resource which contains the formatted warning string</param>
         /// <param name="messageArgs">parameters for the string resource</param>
-        internal void LogWarning(BuildEventFileInfo file, string subcategoryResourceName, string messageResourceName, params object[] messageArgs)
+        internal void LogWarning(string subcategoryResourceName, BuildEventFileInfo file, string messageResourceName, params object[] messageArgs)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogWarning(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
@@ -207,12 +207,12 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log a warning based on a text message
         /// </summary>
-        /// <param name="file">The file in which the warning occurred</param>
         /// <param name="subcategoryResourceName">The subcategory resource name</param>
         /// <param name="warningCode"> Warning code</param>
         /// <param name="helpKeyword"> Help keyword</param>
+        /// <param name="file">The file in which the warning occurred</param>
         /// <param name="message">The message to be logged as a warning</param>
-        internal void LogWarningFromText(BuildEventFileInfo file, string subcategoryResourceName, string warningCode, string helpKeyword, string message)
+        internal void LogWarningFromText(string subcategoryResourceName, string warningCode, string helpKeyword, BuildEventFileInfo file, string message)
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogWarningFromText(_eventContext, subcategoryResourceName, warningCode, helpKeyword, file, message);
@@ -231,9 +231,9 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log an error based on an exception
         /// </summary>
-        /// <param name="file">The file in which the error occurred</param>
         /// <param name="exception">The exception wich is to be logged</param>
-        internal void LogFatalBuildError(BuildEventFileInfo file, Exception exception)
+        /// <param name="file">The file in which the error occurred</param>
+        internal void LogFatalBuildError(Exception exception, BuildEventFileInfo file)
         {
             ErrorUtilities.VerifyThrow(IsValid, "must be valid");
             LoggingService.LogFatalBuildError(BuildEventContext, exception, file);

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// hides the requirement to pass BuildEventContexts to the logging service or query the
     /// host for the logging service all of the time.
     /// </summary>
-    internal class BaseLoggingContext
+    internal class LoggingContext
     {
         /// <summary>
         /// The logging service to which this context is attached
@@ -33,7 +33,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         /// <param name="loggingService">The logging service to use</param>
         /// <param name="eventContext">The event context</param>
-        public BaseLoggingContext(ILoggingService loggingService, BuildEventContext eventContext)
+        public LoggingContext(ILoggingService loggingService, BuildEventContext eventContext)
         {
             ErrorUtilities.VerifyThrowArgumentNull(loggingService, "loggingService");
             ErrorUtilities.VerifyThrowArgumentNull(eventContext, "eventContext");
@@ -49,7 +49,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// while the event context will come from a call into the logging service itself.
         /// </summary>
         /// <param name="baseContext">The context from which this context is being created.</param>
-        public BaseLoggingContext(BaseLoggingContext baseContext)
+        public LoggingContext(LoggingContext baseContext)
         {
             _loggingService = baseContext._loggingService;
             _eventContext = null;

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// <summary>
     /// The logging context for an entire node.
     /// </summary>
-    internal class NodeLoggingContext : BaseBuildLoggingContext
+    internal class NodeLoggingContext : BuildLoggingContext
     {
         /// <summary>
         /// Used to create the initial, base logging context for the node.

--- a/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/NodeLoggingContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// <summary>
     /// The logging context for an entire node.
     /// </summary>
-    internal class NodeLoggingContext : BaseLoggingContext
+    internal class NodeLoggingContext : BaseBuildLoggingContext
     {
         /// <summary>
         /// Used to create the initial, base logging context for the node.

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// <summary>
     /// A logging context for a project.
     /// </summary>
-    internal class ProjectLoggingContext : BaseBuildLoggingContext
+    internal class ProjectLoggingContext : BuildLoggingContext
     {
         /// <summary>
         /// The project's full path

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// <summary>
     /// A logging context for a project.
     /// </summary>
-    internal class ProjectLoggingContext : BaseLoggingContext
+    internal class ProjectLoggingContext : BaseBuildLoggingContext
     {
         /// <summary>
         /// The project's full path

--- a/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// <summary>
     /// A logging context for building a specific target within a project.
     /// </summary>
-    internal class TargetLoggingContext : BaseLoggingContext
+    internal class TargetLoggingContext : BaseBuildLoggingContext
     {
         /// <summary>
         /// Should target outputs be logged also.

--- a/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// <summary>
     /// A logging context for building a specific target within a project.
     /// </summary>
-    internal class TargetLoggingContext : BaseBuildLoggingContext
+    internal class TargetLoggingContext : BuildLoggingContext
     {
         /// <summary>
         /// Should target outputs be logged also.

--- a/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// <summary>
     /// A logging context representing a task being built.
     /// </summary>
-    internal class TaskLoggingContext : BaseLoggingContext
+    internal class TaskLoggingContext : BaseBuildLoggingContext
     {
         /// <summary>
         /// The target context in which this task is being built.

--- a/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
@@ -145,10 +145,10 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log a warning based on an exception
         /// </summary>
-        /// <param name="file">The file in which the warning occurred</param>
         /// <param name="exception">The exception to be logged as a warning</param>
+        /// <param name="file">The file in which the warning occurred</param>
         /// <param name="taskName">The task in which the warning occurred</param>
-        internal void LogTaskWarningFromException(BuildEventFileInfo file, Exception exception, string taskName)
+        internal void LogTaskWarningFromException(Exception exception, BuildEventFileInfo file, string taskName)
         {
             ErrorUtilities.VerifyThrow(IsValid, "must be valid");
             LoggingService.LogTaskWarningFromException(BuildEventContext, exception, file, taskName);

--- a/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// <summary>
     /// A logging context representing a task being built.
     /// </summary>
-    internal class TaskLoggingContext : BaseBuildLoggingContext
+    internal class TaskLoggingContext : BuildLoggingContext
     {
         /// <summary>
         /// The target context in which this task is being built.

--- a/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TaskLoggingContext.cs
@@ -141,5 +141,17 @@ namespace Microsoft.Build.BackEnd.Logging
                 );
             this.IsValid = false;
         }
+
+        /// <summary>
+        /// Log a warning based on an exception
+        /// </summary>
+        /// <param name="file">The file in which the warning occurred</param>
+        /// <param name="exception">The exception to be logged as a warning</param>
+        /// <param name="taskName">The task in which the warning occurred</param>
+        internal void LogTaskWarningFromException(BuildEventFileInfo file, Exception exception, string taskName)
+        {
+            ErrorUtilities.VerifyThrow(IsValid, "must be valid");
+            LoggingService.LogTaskWarningFromException(BuildEventContext, exception, file, taskName);
+        }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -897,10 +897,9 @@ namespace Microsoft.Build.BackEnd
                         {
                             taskLoggingContext.LogTaskWarningFromException
                             (
-                                new BuildEventFileInfo(_targetChildInstance.Location),
                                 exceptionToLog,
-                                _taskNode.Name
-                            );
+                                new BuildEventFileInfo(_targetChildInstance.Location),
+                                _taskNode.Name);
 
                             // Log a message explaining why we converted the previous error into a warning.
                             taskLoggingContext.LogComment(MessageImportance.Normal, "ErrorConvertedIntoWarning");
@@ -909,10 +908,9 @@ namespace Microsoft.Build.BackEnd
                         {
                             taskLoggingContext.LogFatalTaskError
                             (
-                                new BuildEventFileInfo(_targetChildInstance.Location),
                                 exceptionToLog,
-                                _taskNode.Name
-                            );
+                                new BuildEventFileInfo(_targetChildInstance.Location),
+                                _taskNode.Name);
                         }
                     }
                     else

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -807,7 +807,7 @@ namespace Microsoft.Build.BackEnd
             if (!NodePacketTranslator.IsSerializable(e))
 #endif
             {
-                _taskLoggingContext.LogWarning(new BuildEventFileInfo(string.Empty), null, "ExpectedEventToBeSerializable", e.GetType().Name);
+                _taskLoggingContext.LogWarning(null, new BuildEventFileInfo(string.Empty), "ExpectedEventToBeSerializable", e.GetType().Name);
                 return false;
             }
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
@@ -37,27 +37,25 @@ namespace Microsoft.Build.BackEnd
         ///     Get path on disk to the referenced SDK.
         /// </summary>
         /// <param name="sdk">SDK referenced by the Project.</param>
-        /// <param name="logger">Logging service.</param>
-        /// <param name="buildEventContext">Build event context for logging.</param>
+        /// <param name="loggingContext">The logging service</param>
         /// <param name="sdkReferenceLocation">Location of the element within the project which referenced the SDK.</param>
         /// <param name="solutionPath">Path to the solution if known.</param>
         /// <param name="projectPath">Path to the project being built.</param>
         /// <returns>Path to the root of the referenced SDK.</returns>
-        internal string GetSdkPath(SdkReference sdk, ILoggingService logger, BuildEventContext buildEventContext,
+        internal string GetSdkPath(SdkReference sdk, BaseLoggingContext loggingContext,
             ElementLocation sdkReferenceLocation, string solutionPath, string projectPath)
         {
             ErrorUtilities.VerifyThrowInternalNull(sdk, nameof(sdk));
-            ErrorUtilities.VerifyThrowInternalNull(logger, nameof(logger));
-            ErrorUtilities.VerifyThrowInternalNull(buildEventContext, nameof(buildEventContext));
+            ErrorUtilities.VerifyThrowInternalNull(loggingContext, nameof(loggingContext));
             ErrorUtilities.VerifyThrowInternalNull(sdkReferenceLocation, nameof(sdkReferenceLocation));
 
-            if (_resolvers == null) Initialize(logger, buildEventContext, sdkReferenceLocation);
+            if (_resolvers == null) Initialize(loggingContext, sdkReferenceLocation);
 
             var results = new List<SdkResultImpl>();
 
             try
             {
-                var buildEngineLogger = new SdkLoggerImpl(logger, buildEventContext);
+                var buildEngineLogger = new SdkLoggerImpl(loggingContext);
                 foreach (var sdkResolver in _resolvers)
                 {
                     var context = new SdkResolverContextImpl(buildEngineLogger, projectPath, solutionPath, ProjectCollection.Version);
@@ -67,7 +65,7 @@ namespace Microsoft.Build.BackEnd
                         var result = (SdkResultImpl)sdkResolver.Resolve(sdk, context, resultFactory);
                         if (result != null && result.Success)
                         {
-                            LogWarnings(logger, buildEventContext, sdkReferenceLocation, result);
+                            LogWarnings(loggingContext, sdkReferenceLocation, result);
                             return result.Path;
                         }
 
@@ -75,25 +73,25 @@ namespace Microsoft.Build.BackEnd
                     }
                     catch (Exception e)
                     {
-                        logger.LogFatalBuildError(buildEventContext, e, new BuildEventFileInfo(sdkReferenceLocation));
+                        loggingContext.LogFatalBuildError(new BuildEventFileInfo(sdkReferenceLocation), e);
                     }
                 }
             }
             catch (Exception e)
             {
-                logger.LogFatalBuildError(buildEventContext, e, new BuildEventFileInfo(sdkReferenceLocation));
+                loggingContext.LogFatalBuildError(new BuildEventFileInfo(sdkReferenceLocation), e);
                 throw;
             }
 
             foreach (var result in results)
             {
-                LogWarnings(logger, buildEventContext, sdkReferenceLocation, result);
+                LogWarnings(loggingContext, sdkReferenceLocation, result);
 
                 if (result.Errors != null)
                 {
                     foreach (var error in result.Errors)
                     {
-                        logger.LogErrorFromText(buildEventContext, subcategoryResourceName: null, errorCode: null,
+                        loggingContext.LogErrorFromText(subcategoryResourceName: null, errorCode: null,
                             helpKeyword: null, file: new BuildEventFileInfo(sdkReferenceLocation), message: error);
                     }
                 }
@@ -111,38 +109,36 @@ namespace Microsoft.Build.BackEnd
             _resolvers = resolvers;
         }
 
-        private void Initialize(ILoggingService logger, BuildEventContext buildEventContext, ElementLocation location)
+        private void Initialize(BaseLoggingContext loggingContext, ElementLocation location)
         {
             lock (_lockObject)
             {
                 if (_resolvers != null) return;
-                _resolvers = _sdkResolverLoader.LoadResolvers(logger, buildEventContext, location);
+                _resolvers = _sdkResolverLoader.LoadResolvers(loggingContext, location);
             }
         }
 
-        private static void LogWarnings(ILoggingService logger, BuildEventContext bec, ElementLocation location,
+        private static void LogWarnings(BaseLoggingContext loggingContext, ElementLocation location,
             SdkResultImpl result)
         {
             if (result.Warnings == null) return;
 
             foreach (var warning in result.Warnings)
-                logger.LogWarningFromText(bec, null, null, null, new BuildEventFileInfo(location), warning);
+                loggingContext.LogWarningFromText(new BuildEventFileInfo(location), null, null, null, warning);
         }
 
         private class SdkLoggerImpl : SdkLogger
         {
-            private readonly BuildEventContext _buildEventContext;
-            private readonly ILoggingService _loggingService;
+            private readonly BaseLoggingContext _loggingContext;
 
-            public SdkLoggerImpl(ILoggingService loggingService, BuildEventContext buildEventContext)
+            public SdkLoggerImpl(BaseLoggingContext loggingContext)
             {
-                _loggingService = loggingService;
-                _buildEventContext = buildEventContext;
+                _loggingContext = loggingContext;
             }
 
             public override void LogMessage(string message, MessageImportance messageImportance = MessageImportance.Low)
             {
-                _loggingService.LogCommentFromText(_buildEventContext, messageImportance, message);
+                _loggingContext.LogCommentFromText(messageImportance, message);
             }
         }
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
@@ -73,13 +73,13 @@ namespace Microsoft.Build.BackEnd
                     }
                     catch (Exception e)
                     {
-                        loggingContext.LogFatalBuildError(new BuildEventFileInfo(sdkReferenceLocation), e);
+                        loggingContext.LogFatalBuildError(e, new BuildEventFileInfo(sdkReferenceLocation));
                     }
                 }
             }
             catch (Exception e)
             {
-                loggingContext.LogFatalBuildError(new BuildEventFileInfo(sdkReferenceLocation), e);
+                loggingContext.LogFatalBuildError(e, new BuildEventFileInfo(sdkReferenceLocation));
                 throw;
             }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Build.BackEnd
             if (result.Warnings == null) return;
 
             foreach (var warning in result.Warnings)
-                loggingContext.LogWarningFromText(new BuildEventFileInfo(location), null, null, null, warning);
+                loggingContext.LogWarningFromText(null, null, null, new BuildEventFileInfo(location), warning);
         }
 
         private class SdkLoggerImpl : SdkLogger

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="solutionPath">Path to the solution if known.</param>
         /// <param name="projectPath">Path to the project being built.</param>
         /// <returns>Path to the root of the referenced SDK.</returns>
-        internal string GetSdkPath(SdkReference sdk, BaseLoggingContext loggingContext,
+        internal string GetSdkPath(SdkReference sdk, LoggingContext loggingContext,
             ElementLocation sdkReferenceLocation, string solutionPath, string projectPath)
         {
             ErrorUtilities.VerifyThrowInternalNull(sdk, nameof(sdk));
@@ -109,7 +109,7 @@ namespace Microsoft.Build.BackEnd
             _resolvers = resolvers;
         }
 
-        private void Initialize(BaseLoggingContext loggingContext, ElementLocation location)
+        private void Initialize(LoggingContext loggingContext, ElementLocation location)
         {
             lock (_lockObject)
             {
@@ -118,7 +118,7 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
-        private static void LogWarnings(BaseLoggingContext loggingContext, ElementLocation location,
+        private static void LogWarnings(LoggingContext loggingContext, ElementLocation location,
             SdkResultImpl result)
         {
             if (result.Warnings == null) return;
@@ -129,9 +129,9 @@ namespace Microsoft.Build.BackEnd
 
         private class SdkLoggerImpl : SdkLogger
         {
-            private readonly BaseLoggingContext _loggingContext;
+            private readonly LoggingContext _loggingContext;
 
-            public SdkLoggerImpl(BaseLoggingContext loggingContext)
+            public SdkLoggerImpl(LoggingContext loggingContext)
             {
                 _loggingContext = loggingContext;
             }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.BackEnd
 {
     internal class SdkResolverLoader
     {
-        internal virtual IList<SdkResolver> LoadResolvers(BaseLoggingContext loggingContext,
+        internal virtual IList<SdkResolver> LoadResolvers(LoggingContext loggingContext,
             ElementLocation location)
         {
             // Always add the default resolver

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.BackEnd
 {
     internal class SdkResolverLoader
     {
-        internal virtual IList<SdkResolver> LoadResolvers(ILoggingService logger, BuildEventContext buildEventContext,
+        internal virtual IList<SdkResolver> LoadResolvers(BaseLoggingContext loggingContext,
             ElementLocation location)
         {
             // Always add the default resolver
@@ -46,8 +46,7 @@ namespace Microsoft.Build.BackEnd
                 }
                 catch (Exception e)
                 {
-                    logger.LogWarning(buildEventContext, string.Empty, new BuildEventFileInfo(location),
-                        "CouldNotLoadSdkResolver", e.Message);
+                    loggingContext.LogWarning(new BuildEventFileInfo(location), string.Empty, "CouldNotLoadSdkResolver", e.Message);
                 }
 
             return resolvers.OrderBy(t => t.Priority).ToList();

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.BackEnd
                 }
                 catch (Exception e)
                 {
-                    loggingContext.LogWarning(new BuildEventFileInfo(location), string.Empty, "CouldNotLoadSdkResolver", e.Message);
+                    loggingContext.LogWarning(string.Empty, new BuildEventFileInfo(location), "CouldNotLoadSdkResolver", e.Message);
                 }
 
             return resolvers.OrderBy(t => t.Priority).ToList();

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -529,10 +529,9 @@ namespace Microsoft.Build.BackEnd
                 // because this will be a hard error anyway.
                 _targetLoggingContext.LogFatalTaskError
                 (
-                    new BuildEventFileInfo(parameterLocation),
                     e.InnerException,
-                    _taskName
-                );
+                    new BuildEventFileInfo(parameterLocation),
+                    _taskName);
 
                 // We do not recover from a task exception while getting outputs,
                 // so do not merely set gatheredGeneratedOutputsSuccessfully = false; here
@@ -707,7 +706,7 @@ namespace Microsoft.Build.BackEnd
 
                     try
                     {
-                        _taskLoggingContext.LogFatalTaskError(new BuildEventFileInfo(_taskLocation), e, ((ProjectTaskInstance)_taskLoggingContext.Task).Name);
+                        _taskLoggingContext.LogFatalTaskError(e, new BuildEventFileInfo(_taskLocation), ((ProjectTaskInstance)_taskLoggingContext.Task).Name);
                     }
                     catch (InternalErrorException)
                     {
@@ -1412,10 +1411,9 @@ namespace Microsoft.Build.BackEnd
                 // Log the stack, so the task vendor can fix their code
                 _taskLoggingContext.LogFatalTaskError
                 (
-                    new BuildEventFileInfo(_taskLocation),
                     e.InnerException,
-                    _taskName
-                );
+                    new BuildEventFileInfo(_taskLocation),
+                    _taskName);
             }
             catch (Exception e)
             {
@@ -1427,10 +1425,9 @@ namespace Microsoft.Build.BackEnd
 
                 _taskLoggingContext.LogFatalTaskError
                 (
-                    new BuildEventFileInfo(_taskLocation),
                     e,
-                    _taskName
-                );
+                    new BuildEventFileInfo(_taskLocation),
+                    _taskName);
             }
 
             return success;
@@ -1661,7 +1658,7 @@ namespace Microsoft.Build.BackEnd
             string message = ResourceUtilities.FormatResourceString(out warningCode, out helpKeyword, "UnableToCancelTask", _taskName);
             try
             {
-                _taskLoggingContext.LogWarningFromText(new BuildEventFileInfo(_taskLocation), null, warningCode, helpKeyword, message);
+                _taskLoggingContext.LogWarningFromText(null, warningCode, helpKeyword, new BuildEventFileInfo(_taskLocation), message);
             }
             catch (InternalErrorException) // BUGBUG, should never catch this
             {

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -1027,6 +1027,14 @@ namespace Microsoft.Build.Evaluation
             get { return _xml.ProjectFileLocation; }
         }
 
+
+        /// <summary>
+        /// The ID of the last evaluation for this Project.
+        /// A project is always evaluated upon construction and can subsequently get evaluated multiple times via
+        /// <see cref="Project.ReevaluateIfNecessary()" />
+        /// </summary>
+        public int LastEvaluationID => _data.EvaluationID;
+
         /// <summary>
         /// List of names of the properties that, while global, are still treated as overridable 
         /// </summary>
@@ -3121,6 +3129,9 @@ namespace Microsoft.Build.Evaluation
                 private set;
             }
 
+            /// <inheritdoc />
+            public int EvaluationID { get; set; }
+
             /// <summary>
             /// The root directory for this project
             /// </summary>
@@ -3306,6 +3317,7 @@ namespace Microsoft.Build.Evaluation
                 this.AllEvaluatedItemDefinitionMetadata = new List<ProjectMetadata>();
                 this.AllEvaluatedItems = new List<ProjectItem>();
                 this.EvaluatedItemElements = new List<ProjectItemElement>();
+                this.EvaluationID = BuildEventContext.InvalidEvaluationID;
 
                 if (_globalPropertiesToTreatAsLocal != null)
                 {

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Build.Evaluation
 
             try
             {
-                _xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, LoggingService, projectCollection.ProjectRootElementCache, s_buildEventContext, true /*Explicitly loaded*/);
+                _xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, projectCollection.ProjectRootElementCache, true /*Explicitly loaded*/);
             }
             catch (InvalidProjectFileException ex)
             {

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1071,7 +1071,7 @@ namespace Microsoft.Build.Evaluation
                     // Either way, no time wasted.
                     try
                     {
-                        ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(fileName, globalProperties, toolsVersion, LoggingService, ProjectRootElementCache, buildEventContext, true /*explicitlyloaded*/);
+                        ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(fileName, globalProperties, toolsVersion, ProjectRootElementCache, true /*explicitlyloaded*/);
                         toolsVersionFromProject = (xml.ToolsVersion.Length > 0) ? xml.ToolsVersion : DefaultToolsVersion;
                     }
                     catch (InvalidProjectFileException ex)

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1634,7 +1634,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     // Once we are going to warn for a property once, remove it from the list so we do not add it again.
                     _expander.UsedUninitializedProperties.Properties.Remove(propertyElement.Name);
-                    _evaluationLoggingContext.LogWarning(new BuildEventFileInfo(propertyElement.Location), null, "UsedUninitializedProperty", propertyElement.Name, elementWhichUsedProperty.LocationString);
+                    _evaluationLoggingContext.LogWarning(null, new BuildEventFileInfo(propertyElement.Location), "UsedUninitializedProperty", propertyElement.Name, elementWhichUsedProperty.LocationString);
                 }
             }
 
@@ -2471,7 +2471,7 @@ namespace Microsoft.Build.Evaluation
                     // and issue a warning to that effect.
                     if (String.Equals(_projectRootElement.FullPath, importFileUnescaped, StringComparison.OrdinalIgnoreCase) /* We are trying to import ourselves */)
                     {
-                        _evaluationLoggingContext.LogWarning(new BuildEventFileInfo(importLocationInProject), null, "SelfImport", importFileUnescaped);
+                        _evaluationLoggingContext.LogWarning(null, new BuildEventFileInfo(importLocationInProject), "SelfImport", importFileUnescaped);
                         atleastOneImportIgnored = true;
 
                         continue;
@@ -2488,7 +2488,7 @@ namespace Microsoft.Build.Evaluation
                             // Get the full path of the MSBuild file that has this import.
                             string importedBy = importElement.ContainingProject.FullPath ?? String.Empty;
 
-                            _evaluationLoggingContext.LogWarning(new BuildEventFileInfo(importLocationInProject), null, "ImportIntroducesCircularity", importFileUnescaped, importedBy);
+                            _evaluationLoggingContext.LogWarning(null, new BuildEventFileInfo(importLocationInProject), "ImportIntroducesCircularity", importFileUnescaped, importedBy);
 
                             // Throw exception if the project load settings requires us to stop the evaluation of a project when circular imports are detected.
                             if ((_loadSettings & ProjectLoadSettings.RejectCircularImports) != 0)
@@ -2515,7 +2515,7 @@ namespace Microsoft.Build.Evaluation
                             parenthesizedProjectLocation = "[" + _projectRootElement.FullPath + "]";
                         }
                         // TODO: Detect if the duplicate import came from an SDK attribute
-                        _evaluationLoggingContext.LogWarning(new BuildEventFileInfo(importLocationInProject), null, "DuplicateImport", importFileUnescaped, previouslyImportedAt.Location.LocationString, parenthesizedProjectLocation);
+                        _evaluationLoggingContext.LogWarning(null, new BuildEventFileInfo(importLocationInProject), "DuplicateImport", importFileUnescaped, previouslyImportedAt.Location.LocationString, parenthesizedProjectLocation);
                         duplicateImport = true;
                     }
 

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -29,6 +29,16 @@ namespace Microsoft.Build.Evaluation
         where M : class, IMetadatum
         where D : class, IItemDefinition<M>
     {
+
+        /// <summary>
+        /// The ID of this evaluation
+        /// </summary>
+        int EvaluationID
+        {
+            get;
+            set;
+        }
+
         /// <summary>
         /// The (project) directory that should be used during evaluation
         /// </summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -92,6 +92,12 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
+            public int EvaluationID
+            {
+                get { return _wrappedData.EvaluationID; }
+                set { _wrappedData.EvaluationID = value; }
+            }
+
             public string Directory
             {
                 get

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -28,20 +28,11 @@ namespace Microsoft.Build.Evaluation
         private readonly Expander<P, I> _outerExpander;
         private readonly IEvaluatorData<P, I, M, D> _evaluatorData;
         private readonly Expander<P, I> _expander;
-
         private readonly IItemFactory<I, I> _itemFactory;
+        private readonly BaseLoggingContext _loggingContext;
 
         private int _nextElementOrder = 0;
 
-        /// <summary>
-        /// Build event context to log evaluator events in.
-        /// </summary>
-        private BuildEventContext _buildEventContext = null;
-
-        /// <summary>
-        /// The logging service for use during evaluation
-        /// </summary>
-        private readonly ILoggingService _loggingService;
 
         /// <summary>
         /// The CultureInfo from the invariant culture. Used to avoid allocations for
@@ -57,16 +48,14 @@ namespace Microsoft.Build.Evaluation
             new Dictionary<string, LazyItemList>() :
             new Dictionary<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
 
-        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, BuildEventContext buildEventContext, ILoggingService loggingService)
+        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, BaseLoggingContext loggingContext)
         {
             _outerEvaluatorData = data;
             _outerExpander = new Expander<P, I>(_outerEvaluatorData, _outerEvaluatorData);
             _evaluatorData = new EvaluatorData(_outerEvaluatorData, itemType => GetItems(itemType).Select(itemData => itemData.Item).ToList());
             _expander = new Expander<P, I>(_evaluatorData, _evaluatorData);
             _itemFactory = itemFactory;
-
-            _buildEventContext = buildEventContext;
-            _loggingService = loggingService;
+            _loggingContext = loggingContext;
         }
 
         private ICollection<ItemData> GetItems(string itemType)
@@ -99,8 +88,8 @@ namespace Microsoft.Build.Evaluation
                 expanderOptions,
                 GetCurrentDirectoryForConditionEvaluation(element, lazyEvaluator),
                 element.ConditionLocation,
-                lazyEvaluator._loggingService,
-                lazyEvaluator._buildEventContext
+                lazyEvaluator._loggingContext.LoggingService,
+                lazyEvaluator._loggingContext.BuildEventContext
                 );
 
             return result;

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Evaluation
         private readonly IEvaluatorData<P, I, M, D> _evaluatorData;
         private readonly Expander<P, I> _expander;
         private readonly IItemFactory<I, I> _itemFactory;
-        private readonly BaseLoggingContext _loggingContext;
+        private readonly LoggingContext _loggingContext;
 
         private int _nextElementOrder = 0;
 
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Evaluation
             new Dictionary<string, LazyItemList>() :
             new Dictionary<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
 
-        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, BaseLoggingContext loggingContext)
+        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, LoggingContext loggingContext)
         {
             _outerEvaluatorData = data;
             _outerExpander = new Expander<P, I>(_outerEvaluatorData, _outerEvaluatorData);

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Build.Execution
         private string _subToolsetVersion;
         private TaskRegistry _taskRegistry;
         private bool _translateEntireState;
+        private int _evaluationID = BuildEventContext.InvalidEvaluationID;
 
 
         /// <summary>
@@ -418,6 +419,8 @@ namespace Microsoft.Build.Execution
             _projectFileLocation = ElementLocation.Create(fullPath);
             _hostServices = hostServices;
 
+            EvaluationID = data.EvaluationID;
+
             var immutable = (settings & ProjectInstanceSettings.Immutable) == ProjectInstanceSettings.Immutable;
             this.CreatePropertiesSnapshot(data, immutable);
 
@@ -474,6 +477,7 @@ namespace Microsoft.Build.Execution
             _projectFileLocation = that._projectFileLocation;
             _hostServices = that._hostServices;
             _isImmutable = isImmutable;
+            _evaluationID = that.EvaluationID;
 
             TranslateEntireState = that.TranslateEntireState;
 
@@ -639,6 +643,15 @@ namespace Microsoft.Build.Execution
                     _translateEntireState = value;
                 }
             }
+        }
+
+        /// <summary>
+        /// The ID of the evaluation that produced this ProjectInstance.
+        /// </summary>
+        public int EvaluationID
+        {
+            get { return _evaluationID; }
+            set { _evaluationID = value; }
         }
 
         /// <summary>
@@ -1764,6 +1777,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _projectFileLocation, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _taskRegistry, TaskRegistry.FactoryForDeserialization);
             translator.Translate(ref _isImmutable);
+            translator.Translate(ref _evaluationID);
 
             translator.TranslateDictionary(
                 ref _itemDefinitions,
@@ -2427,7 +2441,11 @@ namespace Microsoft.Build.Execution
                 Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Creating a ProjectInstance from an unevaluated state [{0}]", FullPath));
             }
 
+            ErrorUtilities.VerifyThrow(EvaluationID == BuildEventContext.InvalidEvaluationID, "Evaluation ID is invalid prior to evaluation");
+
             _initialGlobalsForDebugging = Evaluator<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.Evaluate(this, xml, ProjectLoadSettings.Default, buildParameters.MaxNodeCount, buildParameters.EnvironmentPropertiesInternal, loggingService, new ProjectItemInstanceFactory(this), buildParameters.ToolsetProvider, ProjectRootElementCache, buildEventContext, this /* for debugging only */, sdkResolution);
+
+            ErrorUtilities.VerifyThrow(EvaluationID != BuildEventContext.InvalidEvaluationID, "Evaluation should produce an evaluation ID");
         }
 
         /// <summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Build.Execution
             BuildParameters buildParameters = new BuildParameters(projectCollection);
 
             BuildEventContext buildEventContext = new BuildEventContext(buildParameters.NodeId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
-            ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, projectCollection.LoggingService, buildParameters.ProjectRootElementCache, buildEventContext, true /*Explicitly Loaded*/);
+            ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, buildParameters.ProjectRootElementCache, true /*Explicitly Loaded*/);
 
             Initialize(xml, globalProperties, toolsVersion, subToolsetVersion, 0 /* no solution version provided */, buildParameters, projectCollection.LoggingService, buildEventContext, projectCollection.SdkResolution);
         }
@@ -386,7 +386,7 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, "toolsVersion");
             ErrorUtilities.VerifyThrowArgumentNull(buildParameters, "buildParameters");
 
-            ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, loggingService, buildParameters.ProjectRootElementCache, buildEventContext, false /*Not explicitly loaded*/);
+            ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, buildParameters.ProjectRootElementCache, false /*Not explicitly loaded*/);
 
             Initialize(xml, globalProperties, toolsVersion, null, 0 /* no solution version specified */, buildParameters, loggingService, buildEventContext, ProjectCollection.GlobalProjectCollection.SdkResolution);
         }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -647,6 +647,8 @@ namespace Microsoft.Build.Execution
 
         /// <summary>
         /// The ID of the evaluation that produced this ProjectInstance.
+        /// 
+        /// See <see cref="Project.LastEvaluationID"/>.
         /// </summary>
         public int EvaluationID
         {

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -490,7 +490,7 @@ namespace Microsoft.Build.BackEnd
                         string.Empty };
                 }
 
-                _taskLoggingContext.LogFatalError(new BuildEventFileInfo(_taskLocation), taskHostTaskComplete.TaskException, taskHostTaskComplete.TaskExceptionMessage, taskHostTaskComplete.TaskExceptionMessageArgs);
+                _taskLoggingContext.LogFatalError(taskHostTaskComplete.TaskException, new BuildEventFileInfo(_taskLocation), taskHostTaskComplete.TaskExceptionMessage, taskHostTaskComplete.TaskExceptionMessageArgs);
             }
 
             // Set the output parameters for later

--- a/src/Build/Instance/TaskFactoryLoggingHost.cs
+++ b/src/Build/Instance/TaskFactoryLoggingHost.cs
@@ -9,13 +9,13 @@ using System;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System.Diagnostics;
-using BaseLoggingContext = Microsoft.Build.BackEnd.Logging.BaseLoggingContext;
 using ElementLocation = Microsoft.Build.Construction.ElementLocation;
 #if FEATURE_APPDOMAIN
 using System.Runtime.Remoting.Lifetime;
 using System.Runtime.Remoting;
 #endif
 using System.Reflection;
+using Microsoft.Build.BackEnd.Logging;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -36,7 +36,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The task factory logging context
         /// </summary>
-        private BaseLoggingContext _loggingContext;
+        private BaseBuildLoggingContext _loggingContext;
 
         /// <summary>
         /// Is the system running in multi-process mode and requires events to be serializable
@@ -60,7 +60,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Constructor
         /// </summary>
-        public TaskFactoryLoggingHost(bool isRunningWithMultipleNodes, ElementLocation elementLocation, BaseLoggingContext loggingContext)
+        public TaskFactoryLoggingHost(bool isRunningWithMultipleNodes, ElementLocation elementLocation, BaseBuildLoggingContext loggingContext)
         {
             ErrorUtilities.VerifyThrowArgumentNull(loggingContext, "loggingContext");
             ErrorUtilities.VerifyThrowInternalNull(elementLocation, "elementLocation");
@@ -141,7 +141,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Sets or retrieves the logging context
         /// </summary>
-        internal BaseLoggingContext LoggingContext
+        internal BaseBuildLoggingContext LoggingContext
         {
             [DebuggerStepThrough]
             get

--- a/src/Build/Instance/TaskFactoryLoggingHost.cs
+++ b/src/Build/Instance/TaskFactoryLoggingHost.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Build.BackEnd
             if (!NodePacketTranslator.IsSerializable(e))
 #endif
             {
-                _loggingContext.LogWarning(new BuildEventFileInfo(string.Empty), null, "ExpectedEventToBeSerializable", e.GetType().Name);
+                _loggingContext.LogWarning(null, new BuildEventFileInfo(string.Empty), "ExpectedEventToBeSerializable", e.GetType().Name);
                 return false;
             }
 

--- a/src/Build/Instance/TaskFactoryLoggingHost.cs
+++ b/src/Build/Instance/TaskFactoryLoggingHost.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The task factory logging context
         /// </summary>
-        private BaseBuildLoggingContext _loggingContext;
+        private BuildLoggingContext _loggingContext;
 
         /// <summary>
         /// Is the system running in multi-process mode and requires events to be serializable
@@ -60,7 +60,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Constructor
         /// </summary>
-        public TaskFactoryLoggingHost(bool isRunningWithMultipleNodes, ElementLocation elementLocation, BaseBuildLoggingContext loggingContext)
+        public TaskFactoryLoggingHost(bool isRunningWithMultipleNodes, ElementLocation elementLocation, BuildLoggingContext loggingContext)
         {
             ErrorUtilities.VerifyThrowArgumentNull(loggingContext, "loggingContext");
             ErrorUtilities.VerifyThrowInternalNull(elementLocation, "elementLocation");
@@ -141,7 +141,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Sets or retrieves the logging context
         /// </summary>
-        internal BaseBuildLoggingContext LoggingContext
+        internal BuildLoggingContext LoggingContext
         {
             [DebuggerStepThrough]
             get

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1402,14 +1402,13 @@ namespace Microsoft.Build.Execution
                                         {
                                             targetLoggingContext.LogWarning
                                                 (
+                                                null,
                                                     new BuildEventFileInfo(elementLocation),
-                                                    null,
                                                     "TaskFactoryWillIgnoreTaskFactoryParameters",
                                                     factory.FactoryName,
                                                     XMakeAttributes.runtime,
                                                     XMakeAttributes.architecture,
-                                                    RegisteredName
-                                                );
+                                                RegisteredName);
                                         }
                                     }
                                 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -493,10 +493,12 @@ namespace Microsoft.Build.Logging
             int taskId = ReadInt32();
             int submissionId = ReadInt32();
             int projectInstanceId = ReadInt32();
+            int evaluationID = ReadInt32();
 
             var result = new BuildEventContext(
                 submissionId,
                 nodeId,
+                evaluationID,
                 projectInstanceId,
                 projectContextId,
                 targetId,

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -498,6 +498,7 @@ namespace Microsoft.Build.Logging
             Write(buildEventContext.TaskId);
             Write(buildEventContext.SubmissionId);
             Write(buildEventContext.ProjectInstanceId);
+            Write(buildEventContext.EvaluationID);
         }
 
         private void Write<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs)

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -192,6 +192,7 @@
     <Compile Include="BackEnd\Components\Caching\IRegisteredTaskObjectCache.cs" />
     <Compile Include="..\Shared\RegisteredTaskObjectCacheBase.cs" />
     <Compile Include="BackEnd\Components\Caching\RegisteredTaskObjectCache.cs" />
+    <Compile Include="BackEnd\Components\Logging\EvaluationLoggingContext.cs" />
     <Compile Include="BackEnd\Components\Logging\BaseBuildLoggingContext.cs" />
     <Compile Include="BackEnd\Components\Logging\BaseLoggingContext.cs" />
     <Compile Include="BackEnd\Components\Logging\BuildEventArgTransportSink.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -193,6 +193,7 @@
     <Compile Include="..\Shared\RegisteredTaskObjectCacheBase.cs" />
     <Compile Include="BackEnd\Components\Caching\RegisteredTaskObjectCache.cs" />
     <Compile Include="BackEnd\Components\Logging\BaseBuildLoggingContext.cs" />
+    <Compile Include="BackEnd\Components\Logging\BaseLoggingContext.cs" />
     <Compile Include="BackEnd\Components\Logging\BuildEventArgTransportSink.cs" />
     <Compile Include="BackEnd\Components\Logging\CentralForwardingLogger.cs" />
     <Compile Include="BackEnd\Components\Logging\EventRedirectorToSink.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -192,7 +192,7 @@
     <Compile Include="BackEnd\Components\Caching\IRegisteredTaskObjectCache.cs" />
     <Compile Include="..\Shared\RegisteredTaskObjectCacheBase.cs" />
     <Compile Include="BackEnd\Components\Caching\RegisteredTaskObjectCache.cs" />
-    <Compile Include="BackEnd\Components\Logging\BaseLoggingContext.cs" />
+    <Compile Include="BackEnd\Components\Logging\BaseBuildLoggingContext.cs" />
     <Compile Include="BackEnd\Components\Logging\BuildEventArgTransportSink.cs" />
     <Compile Include="BackEnd\Components\Logging\CentralForwardingLogger.cs" />
     <Compile Include="BackEnd\Components\Logging\EventRedirectorToSink.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -193,8 +193,8 @@
     <Compile Include="..\Shared\RegisteredTaskObjectCacheBase.cs" />
     <Compile Include="BackEnd\Components\Caching\RegisteredTaskObjectCache.cs" />
     <Compile Include="BackEnd\Components\Logging\EvaluationLoggingContext.cs" />
-    <Compile Include="BackEnd\Components\Logging\BaseBuildLoggingContext.cs" />
-    <Compile Include="BackEnd\Components\Logging\BaseLoggingContext.cs" />
+    <Compile Include="BackEnd\Components\Logging\BuildLoggingContext.cs" />
+    <Compile Include="BackEnd\Components\Logging\LoggingContext.cs" />
     <Compile Include="BackEnd\Components\Logging\BuildEventArgTransportSink.cs" />
     <Compile Include="BackEnd\Components\Logging\CentralForwardingLogger.cs" />
     <Compile Include="BackEnd\Components\Logging\EventRedirectorToSink.cs" />

--- a/src/Framework.UnitTests/EventArgs_Tests.cs
+++ b/src/Framework.UnitTests/EventArgs_Tests.cs
@@ -86,54 +86,68 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ExerciseBuildEventContext()
         {
-            BuildEventContext parentBuildEventContext = new BuildEventContext(0, 0, 0, 0);
-            BuildEventContext currentBuildEventContext = new BuildEventContext(0, 2, 1, 1);
+            BuildEventContext parentBuildEventContext = new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
 
-            BuildEventContext currentBuildEventContextNode = new BuildEventContext(1, 0, 0, 0);
-            BuildEventContext currentBuildEventContextTarget = new BuildEventContext(0, 1, 0, 0);
-            BuildEventContext currentBuildEventContextPci = new BuildEventContext(0, 0, 1, 0);
-            BuildEventContext currentBuildEventContextTask = new BuildEventContext(0, 0, 0, 1);
-            BuildEventContext allDifferent = new BuildEventContext(1, 1, 1, 1);
-            BuildEventContext allSame = new BuildEventContext(0, 0, 0, 0);
+            BuildEventContext currentBuildEventContext = new BuildEventContext(0, 1, 2, 3, 4, 5, 6);
+
+            BuildEventContext currentBuildEventContextSubmission = new BuildEventContext(1, 0, 0, 0, 0, 0, 0);
+            BuildEventContext currentBuildEventContextNode = new BuildEventContext(0, 1, 0, 0, 0, 0, 0);
+            BuildEventContext currentBuildEventContextEvaluation = new BuildEventContext(0, 0, 1, 0, 0, 0, 0);
+            BuildEventContext currentBuildEventContextProjectInstance = new BuildEventContext(0, 0, 0, 1, 0, 0, 0);
+            BuildEventContext currentBuildEventProjectContext = new BuildEventContext(0, 0, 0, 0, 1, 0, 0);
+            BuildEventContext currentBuildEventContextTarget = new BuildEventContext(0, 0, 0, 0, 0, 1, 0);
+            BuildEventContext currentBuildEventContextTask = new BuildEventContext(0, 0, 0, 0, 0, 0, 1);
+            BuildEventContext allDifferent = new BuildEventContext(1, 1, 1, 1, 1, 1, 1);
+            BuildEventContext allSame = new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
 
             ProjectStartedEventArgs startedEvent = new ProjectStartedEventArgs(-1, "Message", "HELP", "File", "Targets", null, null, parentBuildEventContext);
             startedEvent.BuildEventContext = currentBuildEventContext;
-            Assert.Equal(0, parentBuildEventContext.GetHashCode());
+            
+            // submissison ID does not partake into equality
+            Assert.Equal(parentBuildEventContext.GetHashCode(), currentBuildEventContextSubmission.GetHashCode());
+            Assert.NotEqual(parentBuildEventContext.GetHashCode(), currentBuildEventContext.GetHashCode());
+            Assert.NotEqual(parentBuildEventContext.GetHashCode(), currentBuildEventContextNode.GetHashCode());
+            Assert.NotEqual(parentBuildEventContext.GetHashCode(), currentBuildEventContextEvaluation.GetHashCode());
+            Assert.NotEqual(parentBuildEventContext.GetHashCode(), currentBuildEventContextProjectInstance.GetHashCode());
+            Assert.NotEqual(parentBuildEventContext.GetHashCode(), currentBuildEventProjectContext.GetHashCode());
+            Assert.NotEqual(parentBuildEventContext.GetHashCode(), currentBuildEventContextTarget.GetHashCode());
+            Assert.NotEqual(parentBuildEventContext.GetHashCode(), currentBuildEventContextTask.GetHashCode());
+            Assert.NotEqual(parentBuildEventContext.GetHashCode(), allDifferent.GetHashCode());
+            Assert.Equal(parentBuildEventContext.GetHashCode(), allSame.GetHashCode());
 
-            // Node is different
-            Assert.False(parentBuildEventContext.Equals(currentBuildEventContextNode));
+            // submissison ID does not partake into equality
+            Assert.Equal(parentBuildEventContext, currentBuildEventContextSubmission);
+            Assert.NotEqual(parentBuildEventContext, currentBuildEventContext);
+            Assert.NotEqual(parentBuildEventContext, currentBuildEventContextNode);
+            Assert.NotEqual(parentBuildEventContext, currentBuildEventContextEvaluation);
+            Assert.NotEqual(parentBuildEventContext, currentBuildEventContextProjectInstance);
+            Assert.NotEqual(parentBuildEventContext, currentBuildEventProjectContext);
+            Assert.NotEqual(parentBuildEventContext, currentBuildEventContextTarget);
+            Assert.NotEqual(parentBuildEventContext, currentBuildEventContextTask);
+            Assert.NotEqual(parentBuildEventContext, allDifferent);
+            Assert.Equal(parentBuildEventContext, allSame);
 
-            // Target is different
-            Assert.False(parentBuildEventContext.Equals(currentBuildEventContextTarget));
+            Assert.Equal(currentBuildEventContext, currentBuildEventContext);
+            Assert.NotEqual(parentBuildEventContext, null);
+            Assert.NotEqual(currentBuildEventContext, new object());
 
-            // PCI is different
-            Assert.False(parentBuildEventContext.Equals(currentBuildEventContextPci));
-
-            // Task is different
-            Assert.False(parentBuildEventContext.Equals(currentBuildEventContextTask));
-
-            // All fields are different
-            Assert.False(parentBuildEventContext.Equals(allDifferent));
-
-            // All fields are same
-            Assert.True(parentBuildEventContext.Equals(allSame));
-
-            // Compare with null
-            Assert.False(parentBuildEventContext.Equals(null));
-
-            // Compare with self
-            Assert.True(currentBuildEventContext.Equals(currentBuildEventContext));
-            Assert.False(currentBuildEventContext.Equals(new object()));
             Assert.NotNull(startedEvent.BuildEventContext);
 
+            Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.SubmissionId);
             Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.NodeId);
-            Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.TargetId);
+            Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.EvaluationID);
+            Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.ProjectInstanceId);
             Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.ProjectContextId);
+            Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.TargetId);
             Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.TaskId);
-            Assert.Equal(0, startedEvent.BuildEventContext.NodeId);
-            Assert.Equal(2, startedEvent.BuildEventContext.TargetId);
-            Assert.Equal(1, startedEvent.BuildEventContext.ProjectContextId);
-            Assert.Equal(1, startedEvent.BuildEventContext.TaskId);
+
+            Assert.Equal(0, startedEvent.BuildEventContext.SubmissionId);
+            Assert.Equal(1, startedEvent.BuildEventContext.NodeId);
+            Assert.Equal(2, startedEvent.BuildEventContext.EvaluationID);
+            Assert.Equal(3, startedEvent.BuildEventContext.ProjectInstanceId);
+            Assert.Equal(4, startedEvent.BuildEventContext.ProjectContextId);
+            Assert.Equal(5, startedEvent.BuildEventContext.TargetId);
+            Assert.Equal(6, startedEvent.BuildEventContext.TaskId);
         }
 
         /// <summary>

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -49,6 +49,11 @@ namespace Microsoft.Build.Framework
         /// </summary>
         private int submissionId;
 
+        /// <summary>
+        /// The id of the evaluation
+        /// </summary>
+        private int evaluationID;
+
         #endregion
 
         #region Constructor
@@ -63,7 +68,7 @@ namespace Microsoft.Build.Framework
             int projectContextId,
             int taskId
         )
-            : this(InvalidSubmissionId, nodeId, InvalidProjectInstanceId, projectContextId, targetId, taskId)
+            : this(InvalidSubmissionId, nodeId, InvalidEvaluationID, InvalidProjectInstanceId, projectContextId, targetId, taskId)
         {
             // UNDONE: This is obsolete.
         }
@@ -79,7 +84,7 @@ namespace Microsoft.Build.Framework
             int targetId,
             int taskId
         )
-            : this(InvalidSubmissionId, nodeId, projectInstanceId, projectContextId, targetId, taskId)
+            : this(InvalidSubmissionId, nodeId, InvalidEvaluationID, projectInstanceId, projectContextId, targetId, taskId)
         {
         }
 
@@ -95,9 +100,27 @@ namespace Microsoft.Build.Framework
             int targetId,
             int taskId
         )
+            :this(submissionId, nodeId, InvalidEvaluationID, projectInstanceId, projectContextId, targetId, taskId)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a BuildEventContext
+        /// </summary>
+        public BuildEventContext
+        (
+            int submissionId,
+            int nodeId,
+            int evaluationID,
+            int projectInstanceId,
+            int projectContextId,
+            int targetId,
+            int taskId
+        )
         {
             this.submissionId = submissionId;
             this.nodeId = nodeId;
+            this.evaluationID = evaluationID;
             this.targetId = targetId;
             this.projectContextId = projectContextId;
             this.taskId = taskId;
@@ -116,6 +139,17 @@ namespace Microsoft.Build.Framework
             get
             {
                 return new BuildEventContext(BuildEventContext.InvalidNodeId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the Evaluation id.
+        /// </summary>
+        public int EvaluationID => _submissionId;
+        {
+            get
+            {
+                return evaluationID;
             }
         }
 
@@ -223,6 +257,11 @@ namespace Microsoft.Build.Framework
         /// Indicates an invalid submission identifier.
         /// </summary>
         public const int InvalidSubmissionId = -1;
+        /// <summary>
+        /// Indicates an invalid evaluation identifier.
+        /// </summary>
+        public const int InvalidEvaluationID = -1;
+
         #endregion
 
         #region Equals
@@ -307,10 +346,11 @@ namespace Microsoft.Build.Framework
         /// <returns>True if the value fields are the same, false if otherwise</returns>
         private bool InternalEquals(BuildEventContext buildEventContext)
         {
-            return ((nodeId == buildEventContext.NodeId)
-                   && (projectContextId == buildEventContext.ProjectContextId)
-                   && (targetId == buildEventContext.TargetId)
-                   && (taskId == buildEventContext.TaskId));
+            return nodeId == buildEventContext.NodeId
+                   && projectContextId == buildEventContext.ProjectContextId
+                   && targetId == buildEventContext.TargetId
+                   && taskId == buildEventContext.TaskId
+                   && evaluationID == buildEventContext.evaluationID;
         }
         #endregion
 

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -22,37 +22,37 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Node event was in 
         /// </summary>
-        private int nodeId;
+        private readonly int _nodeId;
 
         /// <summary>
         /// Target event was in
         /// </summary>
-        private int targetId;
+        private readonly int _targetId;
 
         /// <summary>
         ///The node-unique project request context the event was in
         /// </summary>
-        private int projectContextId;
+        private readonly int _projectContextId;
 
         /// <summary>
         /// Id of the task the event was caused from
         /// </summary>
-        private int taskId;
+        private readonly int _taskId;
 
         /// <summary>
         /// The id of the project instance to which this event refers.
         /// </summary>
-        private int projectInstanceId;
+        private readonly int _projectInstanceId;
 
         /// <summary>
         /// The id of the submission.
         /// </summary>
-        private int submissionId;
+        private readonly int _submissionId;
 
         /// <summary>
         /// The id of the evaluation
         /// </summary>
-        private int evaluationID;
+        private readonly int _evaluationID;
 
         #endregion
 
@@ -118,13 +118,13 @@ namespace Microsoft.Build.Framework
             int taskId
         )
         {
-            this.submissionId = submissionId;
-            this.nodeId = nodeId;
-            this.evaluationID = evaluationID;
-            this.targetId = targetId;
-            this.projectContextId = projectContextId;
-            this.taskId = taskId;
-            this.projectInstanceId = projectInstanceId;
+            _submissionId = submissionId;
+            _nodeId = nodeId;
+            _evaluationID = evaluationID;
+            _targetId = targetId;
+            _projectContextId = projectContextId;
+            _taskId = taskId;
+            _projectInstanceId = projectInstanceId;
         }
 
         #endregion
@@ -134,90 +134,42 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Returns a default invalid BuildEventContext
         /// </summary>
-        public static BuildEventContext Invalid
-        {
-            get
-            {
-                return new BuildEventContext(BuildEventContext.InvalidNodeId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
-            }
-        }
+        public static BuildEventContext Invalid => new BuildEventContext(InvalidNodeId, InvalidTargetId, InvalidProjectContextId, InvalidTaskId);
 
         /// <summary>
         /// Retrieves the Evaluation id.
         /// </summary>
-        public int EvaluationID => _submissionId;
-        {
-            get
-            {
-                return evaluationID;
-            }
-        }
+        public int EvaluationID => _evaluationID;
 
         /// <summary>
         /// NodeId where event took place
         /// </summary>
-        public int NodeId
-        {
-            get
-            {
-                return nodeId;
-            }
-        }
+        public int NodeId => _nodeId;
 
         /// <summary>
         /// Id of the target the event was in when the event was fired
         /// </summary>
-        public int TargetId
-        {
-            get
-            {
-                return targetId;
-            }
-        }
+        public int TargetId => _targetId;
 
         /// <summary>
         /// Retrieves the Project Context id.
         /// </summary>
-        public int ProjectContextId
-        {
-            get
-            {
-                return projectContextId;
-            }
-        }
+        public int ProjectContextId => _projectContextId;
 
         /// <summary>
         /// Retrieves the task id.
         /// </summary>
-        public int TaskId
-        {
-            get
-            {
-                return taskId;
-            }
-        }
+        public int TaskId => _taskId;
 
         /// <summary>
         /// Retrieves the project instance id.
         /// </summary>
-        public int ProjectInstanceId
-        {
-            get
-            {
-                return projectInstanceId;
-            }
-        }
+        public int ProjectInstanceId => _projectInstanceId;
 
         /// <summary>
         /// Retrieves the Submission id.
         /// </summary>
-        public int SubmissionId
-        {
-            get
-            {
-                return submissionId;
-            }
-        }
+        public int SubmissionId => _submissionId;
 
         /// <summary>
         /// Retrieves the BuildRequest id.  Note that this is not the same as the global request id on a BuildRequest or BuildResult.
@@ -268,13 +220,13 @@ namespace Microsoft.Build.Framework
         {
             var hash = 17;
             // submission ID does not contribute to equality
-            //hash = hash * 31 + submissionId;
-            hash = hash * 31 + nodeId;
-            hash = hash * 31 + evaluationID;
-            hash = hash * 31 + targetId;
-            hash = hash * 31 + projectContextId;
-            hash = hash * 31 + taskId;
-            hash = hash * 31 + projectInstanceId;
+            //hash = hash * 31 + _submissionId;
+            hash = hash * 31 + _nodeId;
+            hash = hash * 31 + _evaluationID;
+            hash = hash * 31 + _targetId;
+            hash = hash * 31 + _projectContextId;
+            hash = hash * 31 + _taskId;
+            hash = hash * 31 + _projectInstanceId;
 
             return hash;
         }
@@ -291,18 +243,18 @@ namespace Microsoft.Build.Framework
         public override bool Equals(object obj)
         {
             // If the references are the same no need to do any more comparing
-            if (object.ReferenceEquals(this, obj))
+            if (ReferenceEquals(this, obj))
             {
                 return true;
             }
 
-            if (object.ReferenceEquals(obj, null))
+            if (ReferenceEquals(obj, null))
             {
                 return false;
             }
 
             // The types do not match, they cannot be the same
-            if (this.GetType() != obj.GetType())
+            if (GetType() != obj.GetType())
             {
                 return false;
             }
@@ -318,12 +270,12 @@ namespace Microsoft.Build.Framework
         /// <returns>True if the object values are identical, false if they are not identical</returns>
         public static bool operator ==(BuildEventContext left, BuildEventContext right)
         {
-            if (Object.ReferenceEquals(left, right))
+            if (ReferenceEquals(left, right))
             {
                 return true;
             }
 
-            if (Object.ReferenceEquals(left, null))
+            if (ReferenceEquals(left, null))
             {
                 return false;
             }
@@ -350,12 +302,12 @@ namespace Microsoft.Build.Framework
         /// <returns>True if the value fields are the same, false if otherwise</returns>
         private bool InternalEquals(BuildEventContext buildEventContext)
         {
-            return nodeId == buildEventContext.NodeId
-                   && projectContextId == buildEventContext.ProjectContextId
-                   && targetId == buildEventContext.TargetId
-                   && taskId == buildEventContext.TaskId
-                   && evaluationID == buildEventContext.evaluationID;
-                   && projectInstanceId == buildEventContext.projectInstanceId;
+            return _nodeId == buildEventContext.NodeId
+                   && _projectContextId == buildEventContext.ProjectContextId
+                   && _targetId == buildEventContext.TargetId
+                   && _taskId == buildEventContext.TaskId
+                   && _evaluationID == buildEventContext._evaluationID
+                   && _projectInstanceId == buildEventContext._projectInstanceId;
         }
         #endregion
 

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -222,13 +222,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Retrieves the BuildRequest id.  Note that this is not the same as the global request id on a BuildRequest or BuildResult.
         /// </summary>
-        public long BuildRequestId
-        {
-            get
-            {
-                return ((long)nodeId << 32) + projectContextId;
-            }
-        }
+        public long BuildRequestId => GetHashCode();
 
         #endregion
 
@@ -272,7 +266,17 @@ namespace Microsoft.Build.Framework
         /// <returns></returns>
         public override int GetHashCode()
         {
-            return (ProjectContextId + (NodeId << 24));
+            var hash = 17;
+            // submission ID does not contribute to equality
+            //hash = hash * 31 + submissionId;
+            hash = hash * 31 + nodeId;
+            hash = hash * 31 + evaluationID;
+            hash = hash * 31 + targetId;
+            hash = hash * 31 + projectContextId;
+            hash = hash * 31 + taskId;
+            hash = hash * 31 + projectInstanceId;
+
+            return hash;
         }
 
         /// <summary>
@@ -351,6 +355,7 @@ namespace Microsoft.Build.Framework
                    && targetId == buildEventContext.TargetId
                    && taskId == buildEventContext.TaskId
                    && evaluationID == buildEventContext.evaluationID;
+                   && projectInstanceId == buildEventContext.projectInstanceId;
         }
         #endregion
 

--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -30,40 +30,15 @@ namespace Microsoft.Build.UnitTests
     internal sealed class MockLogger : ILogger
     {
         #region Properties
-        private int _errorCount = 0;
-        private int _warningCount = 0;
+
         private StringBuilder _fullLog = new StringBuilder();
-        private List<BuildErrorEventArgs> _errors = new List<BuildErrorEventArgs>();
-        private List<BuildWarningEventArgs> _warnings = new List<BuildWarningEventArgs>();
-        private List<ExternalProjectStartedEventArgs> _externalProjectStartedEvents = new List<ExternalProjectStartedEventArgs>();
-        private List<ExternalProjectFinishedEventArgs> _externalProjectFinishedEvents = new List<ExternalProjectFinishedEventArgs>();
-        private bool _logBuildFinishedEvent = true;
-        private List<ProjectStartedEventArgs> _projectStartedEvents = new List<ProjectStartedEventArgs>();
-        private List<ProjectFinishedEventArgs> _projectFinishedEvents = new List<ProjectFinishedEventArgs>();
-        private List<TargetStartedEventArgs> _targetStartedEvents = new List<TargetStartedEventArgs>();
-        private List<TargetFinishedEventArgs> _targetFinishedEvents = new List<TargetFinishedEventArgs>();
-        private List<TaskStartedEventArgs> _taskStartedEvents = new List<TaskStartedEventArgs>();
-        private List<TaskFinishedEventArgs> _taskFinishedEvents = new List<TaskFinishedEventArgs>();
-        private List<BuildMessageEventArgs> _buildMessageEvents = new List<BuildMessageEventArgs>();
-        private List<BuildStartedEventArgs> _buildStartedEvents = new List<BuildStartedEventArgs>();
-        private List<BuildFinishedEventArgs> _buildFinishedEvents = new List<BuildFinishedEventArgs>();
         private ITestOutputHelper _testOutputHelper;
 
         /// <summary>
         /// Should the build finished event be logged in the log file. This is to work around the fact we have different
         /// localized strings between env and xmake for the build finished event.
         /// </summary>
-        internal bool LogBuildFinished
-        {
-            get
-            {
-                return _logBuildFinishedEvent;
-            }
-            set
-            {
-                _logBuildFinishedEvent = value;
-            }
-        }
+        internal bool LogBuildFinished { get; set; } = true;
 
         /*
          * Method:  ErrorCount
@@ -71,10 +46,7 @@ namespace Microsoft.Build.UnitTests
          * The count of all errors seen so far.
          *
          */
-        internal int ErrorCount
-        {
-            get { return _errorCount; }
-        }
+        internal int ErrorCount { get; private set; } = 0;
 
         /*
          * Method:  WarningCount
@@ -82,32 +54,17 @@ namespace Microsoft.Build.UnitTests
          * The count of all warnings seen so far.
          *
          */
-        internal int WarningCount
-        {
-            get { return _warningCount; }
-        }
+        internal int WarningCount { get; private set; } = 0;
 
         /// <summary>
         /// Return the list of logged errors
         /// </summary>
-        internal List<BuildErrorEventArgs> Errors
-        {
-            get
-            {
-                return _errors;
-            }
-        }
+        internal List<BuildErrorEventArgs> Errors { get; } = new List<BuildErrorEventArgs>();
 
         /// <summary>
         /// Returns the list of logged warnings
         /// </summary>
-        internal List<BuildWarningEventArgs> Warnings
-        {
-            get
-            {
-                return _warnings;
-            }
-        }
+        internal List<BuildWarningEventArgs> Warnings { get; } = new List<BuildWarningEventArgs>();
 
         /// <summary>
         /// When set to true, allows task crashes to be logged without causing an assert.
@@ -121,90 +78,57 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// List of ExternalProjectStarted events
         /// </summary>
-        internal List<ExternalProjectStartedEventArgs> ExternalProjectStartedEvents
-        {
-            get { return _externalProjectStartedEvents; }
-        }
+        internal List<ExternalProjectStartedEventArgs> ExternalProjectStartedEvents { get; } = new List<ExternalProjectStartedEventArgs>();
 
         /// <summary>
         /// List of ExternalProjectFinished events
         /// </summary>
-        internal List<ExternalProjectFinishedEventArgs> ExternalProjectFinishedEvents
-        {
-            get { return _externalProjectFinishedEvents; }
-        }
+        internal List<ExternalProjectFinishedEventArgs> ExternalProjectFinishedEvents { get; } = new List<ExternalProjectFinishedEventArgs>();
 
         /// <summary>
         /// List of ProjectStarted events
         /// </summary>
-        internal List<ProjectStartedEventArgs> ProjectStartedEvents
-        {
-            get { return _projectStartedEvents; }
-        }
+        internal List<ProjectStartedEventArgs> ProjectStartedEvents { get; } = new List<ProjectStartedEventArgs>();
 
         /// <summary>
         /// List of ProjectFinished events
         /// </summary>
-        internal List<ProjectFinishedEventArgs> ProjectFinishedEvents
-        {
-            get { return _projectFinishedEvents; }
-        }
+        internal List<ProjectFinishedEventArgs> ProjectFinishedEvents { get; } = new List<ProjectFinishedEventArgs>();
 
         /// <summary>
         /// List of TargetStarted events
         /// </summary>
-        internal List<TargetStartedEventArgs> TargetStartedEvents
-        {
-            get { return _targetStartedEvents; }
-        }
+        internal List<TargetStartedEventArgs> TargetStartedEvents { get; } = new List<TargetStartedEventArgs>();
 
         /// <summary>
         /// List of TargetFinished events
         /// </summary>
-        internal List<TargetFinishedEventArgs> TargetFinishedEvents
-        {
-            get { return _targetFinishedEvents; }
-        }
+        internal List<TargetFinishedEventArgs> TargetFinishedEvents { get; } = new List<TargetFinishedEventArgs>();
 
         /// <summary>
         /// List of TaskStarted events
         /// </summary>
-        internal List<TaskStartedEventArgs> TaskStartedEvents
-        {
-            get { return _taskStartedEvents; }
-        }
+        internal List<TaskStartedEventArgs> TaskStartedEvents { get; } = new List<TaskStartedEventArgs>();
 
         /// <summary>
         /// List of TaskFinished events
         /// </summary>
-        internal List<TaskFinishedEventArgs> TaskFinishedEvents
-        {
-            get { return _taskFinishedEvents; }
-        }
+        internal List<TaskFinishedEventArgs> TaskFinishedEvents { get; } = new List<TaskFinishedEventArgs>();
 
         /// <summary>
         /// List of BuildMessage events
         /// </summary>
-        internal List<BuildMessageEventArgs> BuildMessageEvents
-        {
-            get { return _buildMessageEvents; }
-        }
+        internal List<BuildMessageEventArgs> BuildMessageEvents { get; } = new List<BuildMessageEventArgs>();
 
         /// <summary>
         /// List of BuildStarted events, thought we expect there to only be one, a valid check is to make sure this list is length 1
         /// </summary>
-        internal List<BuildStartedEventArgs> BuildStartedEvents
-        {
-            get { return _buildStartedEvents; }
-        }
+        internal List<BuildStartedEventArgs> BuildStartedEvents { get; } = new List<BuildStartedEventArgs>();
 
         /// <summary>
         /// List of BuildFinished events, thought we expect there to only be one, a valid check is to make sure this list is length 1
         /// </summary>
-        internal List<BuildFinishedEventArgs> BuildFinishedEvents
-        {
-            get { return _buildFinishedEvents; }
-        }
+        internal List<BuildFinishedEventArgs> BuildFinishedEvents { get; } = new List<BuildFinishedEventArgs>();
 
         internal List<BuildEventArgs> AllBuildEvents { get; } = new List<BuildEventArgs>();
 
@@ -324,8 +248,8 @@ namespace Microsoft.Build.UnitTests
                     _fullLog.AppendLine(logMessage);
                     _testOutputHelper?.WriteLine(logMessage);
 
-                    ++_warningCount;
-                    _warnings.Add(w);
+                    ++WarningCount;
+                    Warnings.Add(w);
                 }
             }
             else if (eventArgs is BuildErrorEventArgs)
@@ -342,14 +266,14 @@ namespace Microsoft.Build.UnitTests
                 _fullLog.AppendLine(logMessage);
                 _testOutputHelper?.WriteLine(logMessage);
 
-                ++_errorCount;
-                _errors.Add(e);
+                ++ErrorCount;
+                Errors.Add(e);
             }
             else
             {
                 // Log the message unless we are a build finished event and logBuildFinished is set to false.
                 bool logMessage = !(eventArgs is BuildFinishedEventArgs) ||
-                                  (eventArgs is BuildFinishedEventArgs && _logBuildFinishedEvent);
+                                  (eventArgs is BuildFinishedEventArgs && LogBuildFinished);
                 if (logMessage)
                 {
                     _fullLog.AppendLine(eventArgs.Message);
@@ -525,7 +449,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         internal void AssertNoErrors()
         {
-            Assert.Equal(0, _errorCount);
+            Assert.Equal(0, ErrorCount);
         }
 
         /// <summary>
@@ -533,7 +457,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         internal void AssertNoWarnings()
         {
-            Assert.Equal(0, _warningCount);
+            Assert.Equal(0, WarningCount);
         }
     }
 }

--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -206,6 +206,8 @@ namespace Microsoft.Build.UnitTests
             get { return _buildFinishedEvents; }
         }
 
+        internal List<BuildEventArgs> AllBuildEvents { get; } = new List<BuildEventArgs>();
+
         /*
          * Method:  FullLog
          *
@@ -301,6 +303,8 @@ namespace Microsoft.Build.UnitTests
          */
         internal void LoggerEventHandler(object sender, BuildEventArgs eventArgs)
         {
+            AllBuildEvents.Add(eventArgs);
+
             if (eventArgs is BuildWarningEventArgs)
             {
                 BuildWarningEventArgs w = (BuildWarningEventArgs) eventArgs;

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -492,6 +492,11 @@ namespace Microsoft.Build.UnitTests
             return projectFileContents;
         }
 
+        public static string Cleanup(this string aString)
+        {
+            return CleanupFileContents(aString);
+        }
+
         /// <summary>
         /// Normalizes all the whitespace in an xml string so that two documents that
         /// differ only in whitespace can be easily compared to each other for sameness.

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
@@ -153,6 +154,16 @@ namespace Microsoft.Build.Engine.UnitTests
         public TransientTestFolder CreateFolder()
         {
             return WithTransientTestState(new TransientTestFolder());
+        }
+
+        /// <summary>
+        ///     Creates a test variant that corresponds to a project collection which will have its projects unloaded,
+        ///     loggers unregistered, toolsets removed and disposed when the test completes
+        /// </summary>
+        /// <returns></returns>
+        public TransientProjectCollection CreateProjectCollection()
+        {
+            return WithTransientTestState(new TransientProjectCollection());
         }
 
         /// <summary>
@@ -452,6 +463,24 @@ namespace Microsoft.Build.Engine.UnitTests
                     ? factory.IndicateSuccess(_mapping[sdkReference.Name], null)
                     : factory.IndicateFailure(new[] {$"Not in {nameof(_mapping)}"});
             }
+        }
+    }
+
+    public class TransientProjectCollection : TransientTestState
+    {
+        public ProjectCollection Collection { get; }
+
+        public TransientProjectCollection()
+        {
+            Collection = new ProjectCollection();
+        }
+
+        public override void Revert()
+        {
+            Collection.UnloadAllProjects();
+            Collection.UnregisterAllLoggers();
+            Collection.RemoveAllToolsets();
+            Collection.Dispose();
         }
     }
 }


### PR DESCRIPTION
Implements part of #2032 by adding an evaluation ID to evaluations and exposing the ID via new APIs `Project.LastEvaluationID` and `ProjectInstance.EvaluationID`. The Evaluation ID is available to event consumers via `BuildEventContext.EvaluationID` (currently only for events triggered during evaluation).

I also updated the binary logger to serialize the extra `BuildEventContext.EvaluationID`. Since it's not released yet, it's "okay" to break the format.

This enables CPS to tie log messages to project objects.

Future work that will be covered in another PR: Find a way to pipe the evaluation ID everywhere. This would help @KirillOsenkov's MSBuildStructuredLogger better group evaluation messages.
