### PR TITLE
[WIP] add F# WriteCodeFragment

### DIFF
--- a/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/Tasks.UnitTests/WriteCodeFragment_Tests.cs
@@ -641,6 +641,32 @@ namespace Microsoft.Build.UnitTests
             File.Delete(task.OutputFile.ItemSpec);
         }
 
+        /// <summary>
+        /// Test with the VB language
+        /// </summary>
+        [Fact]
+        [Trait("Category", "mono-osx-failing")]
+        [Trait("Category", "fsharp")]
+        public void OneAttributeNoParamsFSharp()
+        {
+            WriteCodeFragment task = new WriteCodeFragment();
+            MockEngine engine = new MockEngine(true);
+            task.BuildEngine = engine;
+            TaskItem attribute = new TaskItem("System.AssemblyTrademarkAttribute");
+            task.AssemblyAttributes = new TaskItem[] { attribute };
+            task.Language = "f#";
+            task.OutputDirectory = new TaskItem(Path.GetTempPath());
+            bool result = task.Execute();
+
+            Assert.Equal(true, result);
+
+            string content = File.ReadAllText(task.OutputFile.ItemSpec);
+            Console.WriteLine(content);
+
+            CheckContentFSharp(content, "[<assembly: System.AssemblyTrademarkAttribute()>]");
+        }
+
+
         private static void CheckContentCSharp(string actualContent, params string[] expectedAttributes)
         {
             CheckContent(
@@ -661,6 +687,16 @@ namespace Microsoft.Build.UnitTests
                 "Option Explicit On",
                 "Imports System",
                 "Imports System.Reflection");
+        }
+
+        private static void CheckContentFSharp(string actualContent, params string[] expectedAttributes)
+        {
+            CheckContent(
+                actualContent,
+                expectedAttributes,
+                "//",
+                "open System",
+                "open System.Reflection");
         }
 
         private static void CheckContent(string actualContent, string[] expectedAttributes, string commentStart, params string[] expectedHeader)

--- a/src/Tasks/WriteCodeFragment.cs
+++ b/src/Tasks/WriteCodeFragment.cs
@@ -152,6 +152,12 @@ namespace Microsoft.Build.Tasks
         [SuppressMessage("Microsoft.Globalization", "CA1305:SpecifyIFormatProvider", MessageId = "System.IO.StringWriter.#ctor(System.Text.StringBuilder)", Justification = "Reads fine to me")]
         private string GenerateCode(out string extension)
         {
+            if (Language.ToLowerInvariant() == "f#")
+            {
+                //no codedoom for F#, fallback to coreclr version
+                return GenerateCodeCoreClr(out extension);
+            }
+
             extension = null;
             bool haveGeneratedContent = false;
 

--- a/src/Tasks/WriteCodeFragment.cs
+++ b/src/Tasks/WriteCodeFragment.cs
@@ -340,6 +340,32 @@ namespace Microsoft.Build.Tasks
                         haveGeneratedContent = true;
                     }
                     break;
+                case "f#":
+                    if (AssemblyAttributes == null) return string.Empty;
+
+                    extension = "fs";
+                    code.AppendLine("// " + ResourceUtilities.FormatResourceString("WriteCodeFragment.Comment"));
+                    code.AppendLine();
+                    code.AppendLine("open System");
+                    code.AppendLine("open System.Reflection");
+                    code.AppendLine();
+
+                    foreach (ITaskItem attributeItem in AssemblyAttributes)
+                    {
+                        string args = GetAttributeArguments(attributeItem, "=", QuoteSnippetStringCSharp);
+                        if (args == null) return null;
+
+                        code.AppendLine(string.Format($"[<assembly: {attributeItem.ItemSpec}({args})>]"));
+                        haveGeneratedContent = true;
+                    }
+
+                    if (haveGeneratedContent)
+                    {
+                        code.AppendLine("()");
+                        code.AppendLine();
+                    }
+
+                    break;
                 default:
                     Log.LogErrorWithCodeFromResources("WriteCodeFragment.CouldNotCreateProvider", Language, string.Empty);
                     return null;


### PR DESCRIPTION
ref https://github.com/dotnet/netcorecli-fsc/issues/93

to generate the `assemblyinfo.fs` from fsproj properties.

@KevinRansom the plan is to do it like c# does for coreclr (where codedom doesnt exists anyway), like [here in src/Tasks/WriteCodeFragment.cs#L294-L313](https://github.com/Microsoft/msbuild/blob/2e302ddec9dab44f5f71993b2e5eaa67d7a58310/src/Tasks/WriteCodeFragment.cs#L294-L313) 

/cc @rainersigwald
