### PR TITLE
Fix issue where targets are executed after an error.

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -609,10 +609,16 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
 
-                // Mark our parent for error execution
+                // Mark our parent for error execution when it is not Completed (e.g. Executing)
                 if (topEntry.ParentEntry != null && topEntry.ParentEntry.State != TargetEntryState.Completed)
                 {
                     topEntry.ParentEntry.MarkForError();
+                }
+                // In cases where we need to indicate a failure but the ParentEntry was Skipped (due to condition) it must be
+                // marked stop to prevent other targets from executing.
+                else if (topEntry.ParentEntry?.Result?.ResultCode == TargetResultCode.Skipped)
+                {
+                    topEntry.ParentEntry.MarkForStop();
                 }
             }
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -753,6 +753,20 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// This method is used by the Target Builder to indicate that a child of this target has failed and that work should not
+        /// continue in Completed / Skipped mode. We do not want to mark the state to run in ErrorExecution mode so that the
+        /// OnError targets do not run (the target was skipped due to condition so OnError targets should not run).
+        /// </summary>
+        internal void MarkForStop()
+        {
+            ErrorUtilities.VerifyThrow(_state == TargetEntryState.Completed, "State must be Completed. State is {0}.", _state);
+            ErrorUtilities.VerifyThrow(_targetResult.ResultCode == TargetResultCode.Skipped, "ResultCode must be Skipped. ResultCode is {0}.", _state);
+            ErrorUtilities.VerifyThrow(_targetResult.WorkUnitResult.ActionCode == WorkUnitActionCode.Continue, "ActionCode must be Continue. ActionCode is {0}.", _state);
+
+            _targetResult.WorkUnitResult.ActionCode = WorkUnitActionCode.Stop;
+        }
+
+        /// <summary>
         /// Leaves all the call target scopes in the order they were entered.
         /// </summary>
         internal void LeaveLegacyCallTargetScopes()

--- a/src/Build/BackEnd/Shared/WorkUnitResult.cs
+++ b/src/Build/BackEnd/Shared/WorkUnitResult.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Build.BackEnd
         internal WorkUnitActionCode ActionCode
         {
             get { return _actionCode; }
+            set { _actionCode = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
First attempt, looking for feedback. It works and fixes the error, but it scares me a bit!

This issue occurs when two targets are scheduled to be built (e.g.
ProduceError1 and ProduceError2) and the condition of the first target
causes it to not execute and a dependent target
(BeforeTargets='ProduceError1') fails. In this example, ProduceError2
still executes.

Fixes #2116