### PR TITLE
Add ProjectEvaluationStartedEventArgs and ProjectEvaluationFinishedEventArgs

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -335,6 +335,16 @@ namespace Microsoft.Build.Framework
     {
         public OutputAttribute() { }
     }
+    public sealed partial class ProjectEvaluationFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        public ProjectEvaluationFinishedEventArgs(string message) { }
+        public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public partial class ProjectEvaluationStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        public ProjectEvaluationStartedEventArgs(string message) { }
+        public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
     public partial class ProjectFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         protected ProjectFinishedEventArgs() { }

--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -337,11 +337,13 @@ namespace Microsoft.Build.Framework
     }
     public sealed partial class ProjectEvaluationFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
+        public ProjectEvaluationFinishedEventArgs() { }
         public ProjectEvaluationFinishedEventArgs(string message) { }
         public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectEvaluationStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
+        public ProjectEvaluationStartedEventArgs() { }
         public ProjectEvaluationStartedEventArgs(string message) { }
         public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -332,6 +332,16 @@ namespace Microsoft.Build.Framework
     {
         public OutputAttribute() { }
     }
+    public sealed partial class ProjectEvaluationFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        public ProjectEvaluationFinishedEventArgs(string message) { }
+        public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
+    public partial class ProjectEvaluationStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    {
+        public ProjectEvaluationStartedEventArgs(string message) { }
+        public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
     public partial class ProjectFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         protected ProjectFinishedEventArgs() { }

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -334,11 +334,13 @@ namespace Microsoft.Build.Framework
     }
     public sealed partial class ProjectEvaluationFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
+        public ProjectEvaluationFinishedEventArgs() { }
         public ProjectEvaluationFinishedEventArgs(string message) { }
         public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectEvaluationStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
+        public ProjectEvaluationStartedEventArgs() { }
         public ProjectEvaluationStartedEventArgs(string message) { }
         public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Number of nodes after the build has to be greater than the original number
             int numberProcsAfterBuild = (new List<Process>(Process.GetProcessesByName("MSBuild"))).Count;
             _output.WriteLine($"numberProcsAfterBuild = {numberProcsAfterBuild}");
-            Assert.True(numberProcsOriginally < numberProcsAfterBuild);
+            Assert.True(numberProcsOriginally < numberProcsAfterBuild, $"Expected '{numberProcsOriginally}' < '{numberProcsAfterBuild}'");
 
             // Shutdown all nodes
             shutdownManager.ShutdownAllNodes();

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -306,6 +306,34 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void RoundtripProjectEvaluationStartedEventArgs()
+        {
+            var args = new ProjectEvaluationStartedEventArgs("Message")
+            {
+                BuildEventContext = BuildEventContext.Invalid,
+                ProjectFile = @"C:\foo\bar.proj",
+            };
+
+            Roundtrip(args,
+                e => e.Message,
+                e => e.ProjectFile);
+        }
+
+        [Fact]
+        public void RoundtripProjectEvaluationFinishedEventArgs()
+        {
+            var args = new ProjectEvaluationFinishedEventArgs("Message")
+            {
+                BuildEventContext = BuildEventContext.Invalid,
+                ProjectFile = @"C:\foo\bar.proj",
+            };
+
+            Roundtrip(args,
+                e => e.Message,
+                e => e.ProjectFile);
+        }
+
+        [Fact]
         public void ReadingCorruptedStreamThrows()
         {
             var memoryStream = new MemoryStream();

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -786,7 +786,11 @@ namespace Microsoft.Build.Evaluation
 #endif
             string projectFile = String.IsNullOrEmpty(_projectRootElement.ProjectFileLocation.File) ? "(null)" : _projectRootElement.ProjectFileLocation.File;
 
-            _evaluationLoggingContext.LogComment(MessageImportance.Low, "EvaluationStarted", projectFile);
+            _evaluationLoggingContext.LogBuildEvent(new ProjectEvaluationStartedEventArgs(ResourceUtilities.FormatResourceString("EvaluationStarted", projectFile))
+            {
+                BuildEventContext = _evaluationLoggingContext.BuildEventContext,
+                ProjectFile = projectFile
+            });
 
 #if MSBUILDENABLEVSPROFILING 
             string endPass0 = String.Format(CultureInfo.CurrentCulture, "Evaluate Project {0} - End Pass 0 (Initial properties)", projectFile);
@@ -940,7 +944,11 @@ namespace Microsoft.Build.Evaluation
 
             _data.FinishEvaluation();
 
-            _evaluationLoggingContext.LogComment(MessageImportance.Low, "EvaluationFinished", projectFile);
+            _evaluationLoggingContext.LogBuildEvent(new ProjectEvaluationFinishedEventArgs(ResourceUtilities.FormatResourceString("EvaluationFinished", projectFile))
+            {
+                BuildEventContext = _evaluationLoggingContext.BuildEventContext,
+                ProjectFile = projectFile
+            });
 
 #if FEATURE_MSBUILD_DEBUGGER
             return _projectLevelLocalsForBuild;

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -15,6 +15,8 @@
         Warning,
         Message,
         TaskCommandLine,
-        CriticalBuildMessage
+        CriticalBuildMessage,
+        ProjectEvaluationStarted,
+        ProjectEvaluationFinished
     }
 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -83,6 +83,12 @@ namespace Microsoft.Build.Logging
                 case BinaryLogRecordKind.TaskCommandLine:
                     result = ReadTaskCommandLineEventArgs();
                     break;
+                case BinaryLogRecordKind.ProjectEvaluationStarted:
+                    result = ReadProjectEvaluationStartedEventArgs();
+                    break;
+                case BinaryLogRecordKind.ProjectEvaluationFinished:
+                    result = ReadProjectEvaluationFinishedEventArgs();
+                    break;
                 default:
                     break;
             }
@@ -113,6 +119,32 @@ namespace Microsoft.Build.Logging
                 fields.HelpKeyword,
                 succeeded,
                 fields.Timestamp);
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadProjectEvaluationStartedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var projectFile = ReadString();
+
+            var e = new ProjectEvaluationStartedEventArgs(fields.Message)
+            {
+                ProjectFile = projectFile
+            };
+            SetCommonFields(e, fields);
+            return e;
+        }
+
+        private BuildEventArgs ReadProjectEvaluationFinishedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var projectFile = ReadString();
+
+            var e = new ProjectEvaluationFinishedEventArgs(fields.Message)
+            {
+                ProjectFile = projectFile
+            };
             SetCommonFields(e, fields);
             return e;
         }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -73,6 +73,14 @@ namespace Microsoft.Build.Logging
             {
                 Write((BuildFinishedEventArgs)e);
             }
+            else if (e is ProjectEvaluationStartedEventArgs)
+            {
+                Write((ProjectEvaluationStartedEventArgs)e);
+            }
+            else if (e is ProjectEvaluationFinishedEventArgs)
+            {
+                Write((ProjectEvaluationFinishedEventArgs)e);
+            }
             else
             {
                 // convert all unrecognized objects to message
@@ -98,6 +106,20 @@ namespace Microsoft.Build.Logging
             Write(BinaryLogRecordKind.BuildFinished);
             WriteBuildEventArgsFields(e);
             Write(e.Succeeded);
+        }
+
+        private void Write(ProjectEvaluationStartedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.ProjectEvaluationStarted);
+            WriteBuildEventArgsFields(e);
+            Write(e.ProjectFile);
+        }
+
+        private void Write(ProjectEvaluationFinishedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.ProjectEvaluationFinished);
+            WriteBuildEventArgsFields(e);
+            Write(e.ProjectFile);
         }
 
         private void Write(ProjectStartedEventArgs e)

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -115,6 +115,8 @@
     <Compile Include="OutputAttribute.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="ProjectEvaluationFinishedEventArgs.cs" />
+    <Compile Include="ProjectEvaluationStartedEventArgs.cs" />
     <Compile Include="ProjectFinishedEventArgs.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Framework/ProjectEvaluationFinishedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationFinishedEventArgs.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Arguments for the project evaluation finished event.
+    /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+    [Serializable]
+#endif
+    public sealed class ProjectEvaluationFinishedEventArgs : BuildStatusEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the ProjectEvaluationFinishedEventArgs class.
+        /// </summary>
+        public ProjectEvaluationFinishedEventArgs(string message)
+            : base(message, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the full path of the project that started evaluation.
+        /// </summary>
+        public string ProjectFile { get; set; }
+    }
+}

--- a/src/Framework/ProjectEvaluationFinishedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationFinishedEventArgs.cs
@@ -16,6 +16,14 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Initializes a new instance of the ProjectEvaluationFinishedEventArgs class.
         /// </summary>
+        public ProjectEvaluationFinishedEventArgs()
+        {
+            
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ProjectEvaluationFinishedEventArgs class.
+        /// </summary>
         public ProjectEvaluationFinishedEventArgs(string message)
             : base(message, null, null)
         {

--- a/src/Framework/ProjectEvaluationStartedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationStartedEventArgs.cs
@@ -16,6 +16,14 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Initializes a new instance of the ProjectEvaluationStartedEventArgs class.
         /// </summary>
+        public ProjectEvaluationStartedEventArgs()
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ProjectEvaluationStartedEventArgs class.
+        /// </summary>
         public ProjectEvaluationStartedEventArgs(string message)
             : base(message, null, null)
         {

--- a/src/Framework/ProjectEvaluationStartedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationStartedEventArgs.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Arguments for the project evaluation started event.
+    /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+    [Serializable]
+#endif
+    public class ProjectEvaluationStartedEventArgs : BuildStatusEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the ProjectEvaluationStartedEventArgs class.
+        /// </summary>
+        public ProjectEvaluationStartedEventArgs(string message)
+            : base(message, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the full path of the project that started evaluation.
+        /// </summary>
+        public string ProjectFile { get; set; }
+    }
+}


### PR DESCRIPTION
Also updated binary log serialization to support it.  Loggers will receive the message through the `IEventSource.StatusEventRaised` event.  The messages will no longer show up in the text log.

An upcoming change will look at these events so that project evaluation can be displayed in the performance summary.