### PR TITLE
Bump up Binarry Logger file format version

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -16,7 +16,10 @@ namespace Microsoft.Build.Logging
     /// <remarks>The logger is public so that it can be instantiated from MSBuild.exe via command-line switch.</remarks>
     public sealed class BinaryLogger : ILogger
     {
-        internal const int FileFormatVersion = 1;
+        // version 2: 
+        //   - new BuildEventContext.EvaluationID
+        //   - new record kinds: ProjectEvaluationStarted, ProjectEvaluationFinished
+        internal const int FileFormatVersion = 2;
 
         private Stream stream;
         private BinaryWriter binaryWriter;


### PR DESCRIPTION
Due to new BuildEventContext.EvaluationID

It is okay to break people because the binary logger has not RTMed yet. After 15.3, each version bump needs to introduce some dispatching code so that the current version is backwards compatible. Worst case design is forking the reader / writer for each version number.