### PR TITLE
Use base IsOSPlatform implementation.

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2637,7 +2637,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
-        public void IsOsPlatformShouldBeCaseSensitiveToParameter()
+        public void IsOsPlatformShouldBeCaseInsensitiveToParameter()
         {
             var pg = new PropertyDictionary<ProjectPropertyInstance>();
             var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
@@ -2646,7 +2646,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             var result = expander.ExpandIntoStringLeaveEscaped($"$([MSBuild]::IsOsPlatform({osPlatformLowerCase}))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
-            Assert.Equal("False", result);
+            Assert.Equal("True", result);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2612,7 +2612,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             "$$architecture$$"
         )]
         [InlineData(
-            "$([MSBuild]::IsOsPlatform($$platform$$))",
+            "$([MSBuild]::IsOSPlatform($$platform$$))",
             "True"
         )]
         public void PropertyFunctionRuntimeInformation(string propertyFunction, string expectedExpansion)
@@ -2637,19 +2637,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
-        public void InvalidIsOsPlatformArgumentShouldPrintAvailablePlatforms()
-        {
-            var pg = new PropertyDictionary<ProjectPropertyInstance>();
-            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
-
-            var exception = Assert.Throws<InvalidProjectFileException>(
-                () => expander.ExpandIntoStringLeaveEscaped("$([MSBuild]::IsOsPlatform(Foo))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
-
-            Assert.Contains("Linux, OSX, Windows", exception.Message);
-        }
-
-        [Fact]
-        public void IsOsPlatformShouldBeCaseInsensitiveToParameter()
+        public void IsOsPlatformShouldBeCaseSensitiveToParameter()
         {
             var pg = new PropertyDictionary<ProjectPropertyInstance>();
             var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
@@ -2658,7 +2646,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             var result = expander.ExpandIntoStringLeaveEscaped($"$([MSBuild]::IsOsPlatform({osPlatformLowerCase}))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
-            Assert.Equal("True", result);
+            Assert.Equal("False", result);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -435,7 +435,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns></returns>
         internal static bool IsOSPlatform(string platformString)
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Create(platformString));
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Create(platformString.ToUpperInvariant()));
         }
 
         /// <summary>

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -433,22 +433,9 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="platformString">The platform string. Must be a member of <see cref="OSPlatform"/>. Case Insensitive</param>
         /// <returns></returns>
-        internal static bool IsOsPlatform(string platformString)
+        internal static bool IsOSPlatform(string platformString)
         {
-            var typeInfo = typeof(OSPlatform).GetTypeInfo();
-            var propertyInfo = typeInfo.GetProperty(platformString, BindingFlags.Static | BindingFlags.Public | BindingFlags.IgnoreCase);
-
-            if (propertyInfo == null || propertyInfo.PropertyType != typeof(OSPlatform))
-            {
-
-                ErrorUtilities.ThrowArgument("UnsupportedOSPlatformString", platformString, _validOsPlatforms.Value);
-
-                return false;
-            }
-
-            var platform = (OSPlatform) propertyInfo.GetValue(typeof(OSPlatform));
-
-            return RuntimeInformation.IsOSPlatform(platform);
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Create(platformString));
         }
 
         /// <summary>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1604,18 +1604,13 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <comment>{StrBegin="MSB4231: "}</comment>
   </data>
 
-  <data name="UnsupportedOSPlatformString">
-    <value>MSB4239: The provided argument {0} for [MSBuild]::IsOsPlatform is not supported. Supported values are: {1}</value>
-    <comment>{StrBegin="MSB4231: "} {0} is the name of an OS platform, like Windows, Linux, OSX; {1} is a comma separated enumeration of OS platforms</comment>
-  </data>
-
   <!--
         The engine message bucket is: MSB4001 - MSB4999
         
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4240.
+        Next message code should be MSB4239.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1035,11 +1035,11 @@ namespace Microsoft.Build.UnitTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                currentPlatformString = "Windows";
+                currentPlatformString = "WINDOWS";
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                currentPlatformString = "Linux";
+                currentPlatformString = "LINUX";
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {


### PR DESCRIPTION
We lose the ability to give a nicer error message when a platform
doesn't exist and case insensitivity, but ultimately not having a
diverged method of checking for what OS we're on is preferable.

Closes #2127