### PR TITLE
Reorder nuspec dependencies

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -15,11 +15,11 @@
     <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />


### PR DESCRIPTION
The Nuspec reference generator wants it that way, and the CI is failing
if there are any diffs