### PR TITLE
Find ref asms after ResolveReferences

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1372,14 +1372,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ResolveReferencesDependsOn>
   </PropertyGroup>
 
-  <!-- FindReferenceAssembliesForReferences needs to see a fully-populated @(ReferencePath),
-       so it should run after all of the subcomponents of ResolveReferences, including
-       user overrides of AfterResolveReferences and targets added by appending to
-       $(ResolveReferencesDependsOn) (like ImplicitlyExpandDesignTimeFacades). So list it
-       last explicitly, rather than adding it to the property.   -->
   <Target
       Name="ResolveReferences"
-      DependsOnTargets="$(ResolveReferencesDependsOn);FindReferenceAssembliesForReferences"/>
+      DependsOnTargets="$(ResolveReferencesDependsOn)"/>
 
   <!--
     ============================================================
@@ -2055,7 +2050,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <Target Name="FindReferenceAssembliesForReferences"
-          DependsOnTargets="$(ResolveReferencesDependsOn)">
+          DependsOnTargets="ResolveReferences">
     <ItemGroup>
       <ReferencePathWithRefAssemblies Include="@(ReferencePath->'%(ReferenceAssembly)')"
                                       Condition="'$(CompileUsingReferenceAssemblies)' != 'false'">
@@ -3130,6 +3125,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       ResolveReferences;
       ResolveKeySource;
       SetWin32ManifestProperties;
+      FindReferenceAssembliesForReferences;
       _GenerateCompileInputs;
       BeforeCompile;
       _TimeStampBeforeCompile;


### PR DESCRIPTION
e3a3d69 added a new FindReferenceAssembliesForReferences target, which
ran just before ResolveReferences. Dogfooding this revealed targets in
the VS SDK (at least) that manipulate @(ReferencePath) and are hooked in
as AfterTargets of ResolveReferences. That was silently ignored,
corrupting the user's build.

Fixes #2134 by moving FindReferenceAssembliesForReferences later in the
process, so anyone hooking ResolveReferences will see the changes they
make in the compiler.

This is not a fully general solution to the problem that someone might
hook an arbitrary point and manipulate @(ReferencePath), but it unbreaks
an obvious hook point.