### PR TITLE
Do not mark EvaluationCounter as obsolete

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -564,7 +564,6 @@ namespace Microsoft.Build.Evaluation
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.List<string>> ConditionedProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public string DirectoryPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public bool DisableMarkDirty { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        [System.ObsoleteAttribute("Use Project.LastEvaluationID instead")]
         public int EvaluationCounter { get { throw null; } }
         public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -552,7 +552,6 @@ namespace Microsoft.Build.Evaluation
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.List<string>> ConditionedProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public string DirectoryPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public bool DisableMarkDirty { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        [System.ObsoleteAttribute("Use Project.LastEvaluationID instead")]
         public int EvaluationCounter { get { throw null; } }
         public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } [System.Diagnostics.DebuggerStepThroughAttribute]set { } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -1003,17 +1003,9 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// An arbitrary number that changes when this project reevaluates.
-        /// Hosts don't know whether an evaluation actually happened in an interval, but they can compare this number to
-        /// their previously stored value to find out, and if so perhaps decide to update their own state.
-        /// Note that the number may not increase monotonically.
-        /// Unloading a project does not reset the number, so it does not break the guarantee.
-        /// 
-        /// This number corresponds to the <seealso cref="BuildEventContext.EvaluationId"/> and can be used to connect
-        /// evaluation logging events back to the Project instance.
-        /// 
+        /// Obsolete. Use <see cref="LastEvaluationId"/> instead.
         /// </summary>
-        [Obsolete("Use Project.LastEvaluationID instead")] // deprecated added in 15.3
+        // marked as obsolete in 15.3
         public int EvaluationCounter => LastEvaluationId;
 
         /// <summary>


### PR DESCRIPTION
As its a breaking change because most official builds treat warnings as errors.