### PR TITLE
Rename EvaluationID to EvaluationId to maintain consistency

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Framework
     }
     public partial class BuildEventContext
     {
-        public const int InvalidEvaluationID = -1;
+        public const int InvalidEvaluationId = -1;
         public const int InvalidNodeId = -2;
         public const int InvalidProjectContextId = -2;
         public const int InvalidProjectInstanceId = -1;
@@ -48,9 +48,9 @@ namespace Microsoft.Build.Framework
         public BuildEventContext(int nodeId, int targetId, int projectContextId, int taskId) { }
         public BuildEventContext(int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
         public BuildEventContext(int submissionId, int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
-        public BuildEventContext(int submissionId, int nodeId, int evaluationID, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+        public BuildEventContext(int submissionId, int nodeId, int evaluationId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
         public long BuildRequestId { get { throw null; } }
-        public int EvaluationID { get { throw null; } }
+        public int EvaluationId { get { throw null; } }
         public static Microsoft.Build.Framework.BuildEventContext Invalid { get { throw null; } }
         public int NodeId { get { throw null; } }
         public int ProjectContextId { get { throw null; } }

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -576,7 +576,7 @@ namespace Microsoft.Build.Evaluation
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> Items { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> ItemsIgnoringCondition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.ICollection<string> ItemTypes { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
-        public int LastEvaluationID { get { throw null; } }
+        public int LastEvaluationId { get { throw null; } }
         public Microsoft.Build.Evaluation.ProjectCollection ProjectCollection { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectProperty> Properties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
@@ -1084,7 +1084,7 @@ namespace Microsoft.Build.Execution
         public System.Collections.Generic.List<string> DefaultTargets { get { throw null; } }
         public string Directory { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.List<Microsoft.Build.Construction.ProjectItemElement> EvaluatedItemElements { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public int EvaluationID { get { throw null; } set { } }
+        public int EvaluationId { get { throw null; } set { } }
         public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.List<string> InitialTargets { get { throw null; } }

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Framework
     }
     public partial class BuildEventContext
     {
-        public const int InvalidEvaluationID = -1;
+        public const int InvalidEvaluationId = -1;
         public const int InvalidNodeId = -2;
         public const int InvalidProjectContextId = -2;
         public const int InvalidProjectInstanceId = -1;
@@ -48,9 +48,9 @@ namespace Microsoft.Build.Framework
         public BuildEventContext(int nodeId, int targetId, int projectContextId, int taskId) { }
         public BuildEventContext(int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
         public BuildEventContext(int submissionId, int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
-        public BuildEventContext(int submissionId, int nodeId, int evaluationID, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+        public BuildEventContext(int submissionId, int nodeId, int evaluationId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
         public long BuildRequestId { get { throw null; } }
-        public int EvaluationID { get { throw null; } }
+        public int EvaluationId { get { throw null; } }
         public static Microsoft.Build.Framework.BuildEventContext Invalid { get { throw null; } }
         public int NodeId { get { throw null; } }
         public int ProjectContextId { get { throw null; } }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Build.Evaluation
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> Items { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> ItemsIgnoringCondition { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.ICollection<string> ItemTypes { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
-        public int LastEvaluationID { get { throw null; } }
+        public int LastEvaluationId { get { throw null; } }
         public Microsoft.Build.Evaluation.ProjectCollection ProjectCollection { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation ProjectFileLocation { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectProperty> Properties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
@@ -1061,7 +1061,7 @@ namespace Microsoft.Build.Execution
         public System.Collections.Generic.List<string> DefaultTargets { get { throw null; } }
         public string Directory { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.List<Microsoft.Build.Construction.ProjectItemElement> EvaluatedItemElements { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public int EvaluationID { get { throw null; } set { } }
+        public int EvaluationId { get { throw null; } set { } }
         public string FullPath { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { [System.Diagnostics.DebuggerStepThroughAttribute]get { throw null; } }
         public System.Collections.Generic.List<string> InitialTargets { get { throw null; } }

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -1357,25 +1357,25 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         /// Reevaluation should update the evaluation counter.
         /// </summary>
         [Fact]
-        public void LastEvaluationID()
+        public void LastEvaluationId()
         {
             Project project = new Project();
-            int last = project.LastEvaluationID;
+            int last = project.LastEvaluationId;
 
             project.ReevaluateIfNecessary();
-            Assert.Equal(project.LastEvaluationID, last);
-            last = project.LastEvaluationID;
+            Assert.Equal(project.LastEvaluationId, last);
+            last = project.LastEvaluationId;
 
             project.SetProperty("p", "v");
             project.ReevaluateIfNecessary();
-            Assert.NotEqual(project.LastEvaluationID, last);
+            Assert.NotEqual(project.LastEvaluationId, last);
         }
 
         /// <summary>
         /// Unload should not reset the evaluation counter.
         /// </summary>
         [Fact]
-        public void LastEvaluationIDAndUnload()
+        public void LastEvaluationIdAndUnload()
         {
             string path = null;
 
@@ -1385,12 +1385,12 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 ProjectRootElement.Create().Save(path);
 
                 Project project = new Project(path);
-                int last = project.LastEvaluationID;
+                int last = project.LastEvaluationId;
 
                 project.ProjectCollection.UnloadAllProjects();
 
                 project = new Project(path);
-                Assert.NotEqual(project.LastEvaluationID, last);
+                Assert.NotEqual(project.LastEvaluationId, last);
             }
             finally
             {
@@ -1414,25 +1414,25 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 import.Save();
 
                 Project project = new Project();
-                int last = project.LastEvaluationID;
+                int last = project.LastEvaluationId;
 
                 project.Xml.AddImport(path);
                 project.ReevaluateIfNecessary();
-                Assert.NotEqual(project.LastEvaluationID, last);
-                last = project.LastEvaluationID;
+                Assert.NotEqual(project.LastEvaluationId, last);
+                last = project.LastEvaluationId;
 
                 project.ReevaluateIfNecessary();
-                Assert.Equal(project.LastEvaluationID, last);
+                Assert.Equal(project.LastEvaluationId, last);
 
                 import.AddProperty("p", "v");
                 Assert.Equal(true, project.IsDirty);
                 project.ReevaluateIfNecessary();
-                Assert.NotEqual(project.LastEvaluationID, last);
-                last = project.LastEvaluationID;
+                Assert.NotEqual(project.LastEvaluationId, last);
+                last = project.LastEvaluationId;
                 Assert.Equal("v", project.GetPropertyValue("p"));
 
                 project.ReevaluateIfNecessary();
-                Assert.Equal(project.LastEvaluationID, last);
+                Assert.Equal(project.LastEvaluationId, last);
             }
             finally
             {
@@ -3809,29 +3809,29 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Fact]
-        public void ProjectInstanceShouldInitiallyHaveSameEvaluationIDAsTheProjectItCameFrom()
+        public void ProjectInstanceShouldInitiallyHaveSameEvaluationIdAsTheProjectItCameFrom()
         {
             using (var env = TestEnvironment.Create())
             {
                 var projectCollection = env.CreateProjectCollection().Collection;
 
                 var project = new Project(null, null, projectCollection);
-                var initialEvaluationID = project.LastEvaluationID;
+                var initialEvaluationId = project.LastEvaluationId;
 
                 var projectInstance = project.CreateProjectInstance();
 
-                Assert.NotEqual(BuildEventContext.InvalidEvaluationID, initialEvaluationID);
-                Assert.Equal(initialEvaluationID, projectInstance.EvaluationID);
+                Assert.NotEqual(BuildEventContext.InvalidEvaluationId, initialEvaluationId);
+                Assert.Equal(initialEvaluationId, projectInstance.EvaluationId);
 
                 // trigger a new evaluation which increments the evaluation ID in the Project
                 project.AddItem("foo", "bar");
                 project.ReevaluateIfNecessary();
 
-                Assert.NotEqual(initialEvaluationID, project.LastEvaluationID);
-                Assert.Equal(initialEvaluationID, projectInstance.EvaluationID);
+                Assert.NotEqual(initialEvaluationId, project.LastEvaluationId);
+                Assert.Equal(initialEvaluationId, projectInstance.EvaluationId);
 
                 var newProjectInstance = project.CreateProjectInstance();
-                Assert.Equal(project.LastEvaluationID, newProjectInstance.EvaluationID);
+                Assert.Equal(project.LastEvaluationId, newProjectInstance.EvaluationId);
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/EvaluationLogging_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationLogging_Tests.cs
@@ -92,18 +92,18 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
-        public void AllEvaluationEventsShouldHaveAnEvaluationID()
+        public void AllEvaluationEventsShouldHaveAnEvaluationId()
         {
             AssertLoggingEvents(
                 (project, mockLogger) =>
                 {
-                    var evaluationID = project.LastEvaluationID;
+                    var evaluationId = project.LastEvaluationId;
 
-                    Assert.NotEqual(BuildEventContext.InvalidEvaluationID, evaluationID);
+                    Assert.NotEqual(BuildEventContext.InvalidEvaluationId, evaluationId);
 
                     foreach (var buildEvent in mockLogger.AllBuildEvents)
                     {
-                        Assert.Equal(evaluationID, buildEvent.BuildEventContext.EvaluationID);
+                        Assert.Equal(evaluationId, buildEvent.BuildEventContext.EvaluationId);
                     }
                 });
         }

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -684,7 +684,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
         public delegate ProjectInstance ProjectInstanceFactory(string file, ProjectRootElement xml, ProjectCollection collection);
 
-        public static IEnumerable<object[]> ProjectInstanceHasEvaluationIDTestData()
+        public static IEnumerable<object[]> ProjectInstanceHasEvaluationIdTestData()
         {
             // from file
             yield return new ProjectInstanceFactory[]
@@ -728,8 +728,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         }
 
         [Theory]
-        [MemberData(nameof(ProjectInstanceHasEvaluationIDTestData))]
-        public void ProjectInstanceHasEvaluationID(ProjectInstanceFactory projectInstanceFactory)
+        [MemberData(nameof(ProjectInstanceHasEvaluationIdTestData))]
+        public void ProjectInstanceHasEvaluationId(ProjectInstanceFactory projectInstanceFactory)
         {
             using (var env = TestEnvironment.Create())
             {
@@ -740,7 +740,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 xml.Save(file);
 
                 var projectInstance = projectInstanceFactory.Invoke(file, xml, projectCollection);
-                Assert.NotEqual(BuildEventContext.InvalidEvaluationID, projectInstance.EvaluationID);
+                Assert.NotEqual(BuildEventContext.InvalidEvaluationId, projectInstance.EvaluationId);
             }
         }
 

--- a/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Build.BackEnd.Components.Logging
     /// </summary>
     internal class EvaluationLoggingContext : LoggingContext
     {
-        public EvaluationLoggingContext(ILoggingService loggingService, BuildEventContext eventContext, int evaluationID) : base(
+        public EvaluationLoggingContext(ILoggingService loggingService, BuildEventContext eventContext, int evaluationId) : base(
             loggingService,
             new BuildEventContext(
                 eventContext.SubmissionId,
                 eventContext.NodeId,
-                evaluationID,
+                evaluationId,
                 eventContext.ProjectInstanceId,
                 eventContext.ProjectContextId,
                 eventContext.TargetId,

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -1009,12 +1009,12 @@ namespace Microsoft.Build.Evaluation
         /// Note that the number may not increase monotonically.
         /// Unloading a project does not reset the number, so it does not break the guarantee.
         /// 
-        /// This number corresponds to the <seealso cref="BuildEventContext.EvaluationID"/> and can be used to connect
+        /// This number corresponds to the <seealso cref="BuildEventContext.EvaluationId"/> and can be used to connect
         /// evaluation logging events back to the Project instance.
         /// 
         /// </summary>
         [Obsolete("Use Project.LastEvaluationID instead")] // deprecated added in 15.3
-        public int EvaluationCounter => LastEvaluationID;
+        public int EvaluationCounter => LastEvaluationId;
 
         /// <summary>
         /// The ID of the last evaluation for this Project.
@@ -1026,10 +1026,10 @@ namespace Microsoft.Build.Evaluation
         /// their previously stored value to find out, and if so perhaps decide to update their own state.
         /// Note that the number may not increase monotonically.
         /// 
-        /// This number corresponds to the <seealso cref="BuildEventContext.EvaluationID"/> and can be used to connect
+        /// This number corresponds to the <seealso cref="BuildEventContext.EvaluationId"/> and can be used to connect
         /// evaluation logging events back to the Project instance.
         /// </summary>
-        public int LastEvaluationID => _data.EvaluationID;
+        public int LastEvaluationId => _data.EvaluationId;
 
         /// <summary>
         /// List of names of the properties that, while global, are still treated as overridable 
@@ -2696,11 +2696,11 @@ namespace Microsoft.Build.Evaluation
 
             _loadSettings = loadSettings;
 
-            ErrorUtilities.VerifyThrow(LastEvaluationID == BuildEventContext.InvalidEvaluationID, "This is the first evaluation therefore the last evaluation id is invalid");
+            ErrorUtilities.VerifyThrow(LastEvaluationId == BuildEventContext.InvalidEvaluationId, "This is the first evaluation therefore the last evaluation id is invalid");
 
             ReevaluateIfNecessary();
 
-            ErrorUtilities.VerifyThrow(LastEvaluationID != BuildEventContext.InvalidEvaluationID, "Last evaluation ID must be valid after the first evaluation");
+            ErrorUtilities.VerifyThrow(LastEvaluationId != BuildEventContext.InvalidEvaluationId, "Last evaluation ID must be valid after the first evaluation");
 
             // Cause the project to be actually loaded into the collection, and register for
             // rename notifications so we can subsequently update the collection.
@@ -3116,7 +3116,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             /// <inheritdoc />
-            public int EvaluationID { get; set; } = BuildEventContext.InvalidEvaluationID;
+            public int EvaluationId { get; set; } = BuildEventContext.InvalidEvaluationId;
 
             /// <summary>
             /// The root directory for this project
@@ -3303,7 +3303,7 @@ namespace Microsoft.Build.Evaluation
                 this.AllEvaluatedItemDefinitionMetadata = new List<ProjectMetadata>();
                 this.AllEvaluatedItems = new List<ProjectItem>();
                 this.EvaluatedItemElements = new List<ProjectItemElement>();
-                this.EvaluationID = BuildEventContext.InvalidEvaluationID;
+                this.EvaluationId = BuildEventContext.InvalidEvaluationId;
 
                 if (_globalPropertiesToTreatAsLocal != null)
                 {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Each evaluation has a unique ID.
         /// </summary>
-        private static int s_evaluationID = BuildEventContext.InvalidEvaluationID;
+        private static int s_evaluationId = BuildEventContext.InvalidEvaluationId;
 
         /// <summary>
         /// Expander for evaluating conditions
@@ -727,10 +727,10 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private IDictionary<string, object> Evaluate(ILoggingService loggingService, BuildEventContext buildEventContext)
         {
-            ErrorUtilities.VerifyThrow(_data.EvaluationID == BuildEventContext.InvalidEvaluationID, "There is no prior evaluation ID. The evaluator data needs to be reset at this point");
+            ErrorUtilities.VerifyThrow(_data.EvaluationId == BuildEventContext.InvalidEvaluationId, "There is no prior evaluation ID. The evaluator data needs to be reset at this point");
 
-            _data.EvaluationID = NextEvaluationID();
-            _evaluationLoggingContext = new EvaluationLoggingContext(loggingService, buildEventContext, _data.EvaluationID);
+            _data.EvaluationId = NextEvaluationId();
+            _evaluationLoggingContext = new EvaluationLoggingContext(loggingService, buildEventContext, _data.EvaluationId);
 
 #if FEATURE_MSBUILD_DEBUGGER
             InitializeForDebugging();
@@ -2841,7 +2841,7 @@ namespace Microsoft.Build.Evaluation
             return sb.ToString();
         }
 
-        private static int NextEvaluationID() => Interlocked.Increment(ref s_evaluationID);
+        private static int NextEvaluationId() => Interlocked.Increment(ref s_evaluationId);
     }
 
     /// <summary>

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// The ID of this evaluation
         /// </summary>
-        int EvaluationID
+        int EvaluationId
         {
             get;
             set;

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -92,10 +92,10 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            public int EvaluationID
+            public int EvaluationId
             {
-                get { return _wrappedData.EvaluationID; }
-                set { _wrappedData.EvaluationID = value; }
+                get { return _wrappedData.EvaluationId; }
+                set { _wrappedData.EvaluationId = value; }
             }
 
             public string Directory

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Build.Execution
         private string _subToolsetVersion;
         private TaskRegistry _taskRegistry;
         private bool _translateEntireState;
-        private int _evaluationID = BuildEventContext.InvalidEvaluationID;
+        private int _evaluationId = BuildEventContext.InvalidEvaluationId;
 
 
         /// <summary>
@@ -419,7 +419,7 @@ namespace Microsoft.Build.Execution
             _projectFileLocation = ElementLocation.Create(fullPath);
             _hostServices = hostServices;
 
-            EvaluationID = data.EvaluationID;
+            EvaluationId = data.EvaluationId;
 
             var immutable = (settings & ProjectInstanceSettings.Immutable) == ProjectInstanceSettings.Immutable;
             this.CreatePropertiesSnapshot(data, immutable);
@@ -477,7 +477,7 @@ namespace Microsoft.Build.Execution
             _projectFileLocation = that._projectFileLocation;
             _hostServices = that._hostServices;
             _isImmutable = isImmutable;
-            _evaluationID = that.EvaluationID;
+            _evaluationId = that.EvaluationId;
 
             TranslateEntireState = that.TranslateEntireState;
 
@@ -648,12 +648,12 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The ID of the evaluation that produced this ProjectInstance.
         /// 
-        /// See <see cref="Project.LastEvaluationID"/>.
+        /// See <see cref="Project.LastEvaluationId"/>.
         /// </summary>
-        public int EvaluationID
+        public int EvaluationId
         {
-            get { return _evaluationID; }
-            set { _evaluationID = value; }
+            get { return _evaluationId; }
+            set { _evaluationId = value; }
         }
 
         /// <summary>
@@ -1779,7 +1779,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _projectFileLocation, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _taskRegistry, TaskRegistry.FactoryForDeserialization);
             translator.Translate(ref _isImmutable);
-            translator.Translate(ref _evaluationID);
+            translator.Translate(ref _evaluationId);
 
             translator.TranslateDictionary(
                 ref _itemDefinitions,
@@ -2443,11 +2443,11 @@ namespace Microsoft.Build.Execution
                 Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Creating a ProjectInstance from an unevaluated state [{0}]", FullPath));
             }
 
-            ErrorUtilities.VerifyThrow(EvaluationID == BuildEventContext.InvalidEvaluationID, "Evaluation ID is invalid prior to evaluation");
+            ErrorUtilities.VerifyThrow(EvaluationId == BuildEventContext.InvalidEvaluationId, "Evaluation ID is invalid prior to evaluation");
 
             _initialGlobalsForDebugging = Evaluator<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.Evaluate(this, xml, ProjectLoadSettings.Default, buildParameters.MaxNodeCount, buildParameters.EnvironmentPropertiesInternal, loggingService, new ProjectItemInstanceFactory(this), buildParameters.ToolsetProvider, ProjectRootElementCache, buildEventContext, this /* for debugging only */, sdkResolution);
 
-            ErrorUtilities.VerifyThrow(EvaluationID != BuildEventContext.InvalidEvaluationID, "Evaluation should produce an evaluation ID");
+            ErrorUtilities.VerifyThrow(EvaluationId != BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");
         }
 
         /// <summary>

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Logging
     public sealed class BinaryLogger : ILogger
     {
         // version 2: 
-        //   - new BuildEventContext.EvaluationID
+        //   - new BuildEventContext.EvaluationId
         //   - new record kinds: ProjectEvaluationStarted, ProjectEvaluationFinished
         internal const int FileFormatVersion = 2;
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -525,12 +525,12 @@ namespace Microsoft.Build.Logging
             int taskId = ReadInt32();
             int submissionId = ReadInt32();
             int projectInstanceId = ReadInt32();
-            int evaluationID = ReadInt32();
+            int evaluationId = ReadInt32();
 
             var result = new BuildEventContext(
                 submissionId,
                 nodeId,
-                evaluationID,
+                evaluationId,
                 projectInstanceId,
                 projectContextId,
                 targetId,

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -520,7 +520,7 @@ namespace Microsoft.Build.Logging
             Write(buildEventContext.TaskId);
             Write(buildEventContext.SubmissionId);
             Write(buildEventContext.ProjectInstanceId);
-            Write(buildEventContext.EvaluationID);
+            Write(buildEventContext.EvaluationId);
         }
 
         private void Write<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs)

--- a/src/Framework.UnitTests/EventArgs_Tests.cs
+++ b/src/Framework.UnitTests/EventArgs_Tests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.SubmissionId);
             Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.NodeId);
-            Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.EvaluationID);
+            Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.EvaluationId);
             Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.ProjectInstanceId);
             Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.ProjectContextId);
             Assert.Equal(0, startedEvent.ParentProjectBuildEventContext.TargetId);
@@ -143,7 +143,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.Equal(0, startedEvent.BuildEventContext.SubmissionId);
             Assert.Equal(1, startedEvent.BuildEventContext.NodeId);
-            Assert.Equal(2, startedEvent.BuildEventContext.EvaluationID);
+            Assert.Equal(2, startedEvent.BuildEventContext.EvaluationId);
             Assert.Equal(3, startedEvent.BuildEventContext.ProjectInstanceId);
             Assert.Equal(4, startedEvent.BuildEventContext.ProjectContextId);
             Assert.Equal(5, startedEvent.BuildEventContext.TargetId);

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// The id of the evaluation
         /// </summary>
-        private readonly int _evaluationID;
+        private readonly int _evaluationId;
 
         #endregion
 
@@ -68,7 +68,7 @@ namespace Microsoft.Build.Framework
             int projectContextId,
             int taskId
         )
-            : this(InvalidSubmissionId, nodeId, InvalidEvaluationID, InvalidProjectInstanceId, projectContextId, targetId, taskId)
+            : this(InvalidSubmissionId, nodeId, InvalidEvaluationId, InvalidProjectInstanceId, projectContextId, targetId, taskId)
         {
             // UNDONE: This is obsolete.
         }
@@ -84,7 +84,7 @@ namespace Microsoft.Build.Framework
             int targetId,
             int taskId
         )
-            : this(InvalidSubmissionId, nodeId, InvalidEvaluationID, projectInstanceId, projectContextId, targetId, taskId)
+            : this(InvalidSubmissionId, nodeId, InvalidEvaluationId, projectInstanceId, projectContextId, targetId, taskId)
         {
         }
 
@@ -100,7 +100,7 @@ namespace Microsoft.Build.Framework
             int targetId,
             int taskId
         )
-            :this(submissionId, nodeId, InvalidEvaluationID, projectInstanceId, projectContextId, targetId, taskId)
+            :this(submissionId, nodeId, InvalidEvaluationId, projectInstanceId, projectContextId, targetId, taskId)
         {
         }
 
@@ -111,7 +111,7 @@ namespace Microsoft.Build.Framework
         (
             int submissionId,
             int nodeId,
-            int evaluationID,
+            int evaluationId,
             int projectInstanceId,
             int projectContextId,
             int targetId,
@@ -120,7 +120,7 @@ namespace Microsoft.Build.Framework
         {
             _submissionId = submissionId;
             _nodeId = nodeId;
-            _evaluationID = evaluationID;
+            _evaluationId = evaluationId;
             _targetId = targetId;
             _projectContextId = projectContextId;
             _taskId = taskId;
@@ -139,7 +139,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Retrieves the Evaluation id.
         /// </summary>
-        public int EvaluationID => _evaluationID;
+        public int EvaluationId => _evaluationId;
 
         /// <summary>
         /// NodeId where event took place
@@ -206,7 +206,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Indicates an invalid evaluation identifier.
         /// </summary>
-        public const int InvalidEvaluationID = -1;
+        public const int InvalidEvaluationId = -1;
 
         #endregion
 
@@ -222,7 +222,7 @@ namespace Microsoft.Build.Framework
             // submission ID does not contribute to equality
             //hash = hash * 31 + _submissionId;
             hash = hash * 31 + _nodeId;
-            hash = hash * 31 + _evaluationID;
+            hash = hash * 31 + _evaluationId;
             hash = hash * 31 + _targetId;
             hash = hash * 31 + _projectContextId;
             hash = hash * 31 + _taskId;
@@ -306,7 +306,7 @@ namespace Microsoft.Build.Framework
                    && _projectContextId == buildEventContext.ProjectContextId
                    && _targetId == buildEventContext.TargetId
                    && _taskId == buildEventContext.TaskId
-                   && _evaluationID == buildEventContext._evaluationID
+                   && _evaluationId == buildEventContext._evaluationId
                    && _projectInstanceId == buildEventContext._projectInstanceId;
         }
         #endregion


### PR DESCRIPTION
Rename EvaluationID to EvaluationId to maintain consistency