### PR TITLE
Use LazyFormattedBuildEventArgs in ProjectImportedEventArgs

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Build.Framework
     public partial class ProjectImportedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public ProjectImportedEventArgs() { }
-        public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message) { }
+        public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message, params object[] messageArgs) { }
         public string ImportedProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string UnexpandedProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Build.Framework
     public partial class ProjectImportedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public ProjectImportedEventArgs() { }
-        public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message) { }
+        public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message, params object[] messageArgs) { }
         public string ImportedProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string UnexpandedProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2385,16 +2385,16 @@ namespace Microsoft.Build.Evaluation
                     // Expand the expression for the Log.
                     string expanded = _expander.ExpandIntoStringAndUnescape(importElement.Condition, ExpanderOptions.ExpandProperties, importElement.ConditionLocation);
 
-                    string message = ResourceUtilities.FormatResourceString(
-                        "ProjectImportSkippedFalseCondition",
+                    ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
+                        importElement.Location.Line,
+                        importElement.Location.Column,
+                        ResourceUtilities.GetResourceString("ProjectImportSkippedFalseCondition"),
                         importElement.Project,
                         importElement.ContainingProject.FullPath,
                         importElement.Location.Line,
                         importElement.Location.Column,
                         importElement.Condition,
-                        expanded);
-
-                    ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(importElement.Location.Line, importElement.Location.Column, message)
+                        expanded)
                     {
                         BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                         UnexpandedProject = importElement.Project,
@@ -2484,17 +2484,14 @@ namespace Microsoft.Build.Evaluation
 
                     if (_logProjectImportedEvents)
                     {
-                        string message = ResourceUtilities.FormatResourceString(
-                            "ProjectImportSkippedNoMatches",
-                            importExpressionEscapedItem,
-                            importElement.ContainingProject.FullPath,
-                            importElement.Location.Line,
-                            importElement.Location.Column);
-
                         ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
                             importElement.Location.Line,
                             importElement.Location.Column,
-                            message)
+                            ResourceUtilities.GetResourceString("ProjectImportSkippedNoMatches"),
+                            importExpressionEscapedItem,
+                            importElement.ContainingProject.FullPath,
+                            importElement.Location.Line,
+                            importElement.Location.Column)
                         {
                             BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                             UnexpandedProject = importElement.Project,
@@ -2621,17 +2618,14 @@ namespace Microsoft.Build.Evaluation
 
                             if (_logProjectImportedEvents)
                             {
-                                string message = ResourceUtilities.FormatResourceString(
-                                    "ProjectImported",
-                                    importedProjectElement.FullPath,
-                                    importElement.ContainingProject.FullPath,
-                                    importElement.Location.Line,
-                                    importElement.Location.Column);
-
                                 ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
                                     importElement.Location.Line,
                                     importElement.Location.Column,
-                                    message)
+                                    ResourceUtilities.GetResourceString("ProjectImported"),
+                                    importedProjectElement.FullPath,
+                                    importElement.ContainingProject.FullPath,
+                                    importElement.Location.Line,
+                                    importElement.Location.Column)
                                 {
                                     BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                                     ImportedProjectFile = importedProjectElement.FullPath,

--- a/src/Framework/ProjectImportedEventArgs.cs
+++ b/src/Framework/ProjectImportedEventArgs.cs
@@ -27,9 +27,10 @@ namespace Microsoft.Build.Framework
         (
             int lineNumber,
             int columnNumber,
-            string message
+            string message,
+            params object[] messageArgs
         )
-            : base(null, null, null, lineNumber, columnNumber, 0, 0, message, null, null, MessageImportance.Low)
+            : base(null, null, null, lineNumber, columnNumber, 0, 0, message, null, null, MessageImportance.Low, DateTime.UtcNow, messageArgs)
         {
         }
 


### PR DESCRIPTION
This ensures that as few strings are allocated as possible