### PR TITLE
Embed projects and imports in binary log

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -1419,10 +1419,17 @@ namespace Microsoft.Build.Logging
     public sealed partial class BinaryLogger : Microsoft.Build.Framework.ILogger
     {
         public BinaryLogger() { }
+        public Microsoft.Build.Logging.BinaryLogger.ProjectImportsCollectionMode CollectProjectImports { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Build.Framework.LoggerVerbosity Verbosity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Shutdown() { }
+        public enum ProjectImportsCollectionMode
+        {
+            Embed = 1,
+            None = 0,
+            ZipFile = 2,
+        }
     }
     public sealed partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
     {

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -1396,10 +1396,17 @@ namespace Microsoft.Build.Logging
     public sealed partial class BinaryLogger : Microsoft.Build.Framework.ILogger
     {
         public BinaryLogger() { }
+        public Microsoft.Build.Logging.BinaryLogger.ProjectImportsCollectionMode CollectProjectImports { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Build.Framework.LoggerVerbosity Verbosity { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void Initialize(Microsoft.Build.Framework.IEventSource eventSource) { }
         public void Shutdown() { }
+        public enum ProjectImportsCollectionMode
+        {
+            Embed = 1,
+            None = 0,
+            ZipFile = 2,
+        }
     }
     public sealed partial class BinaryLogReplayEventSource : Microsoft.Build.Logging.EventArgsDispatcher
     {

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -18,6 +18,7 @@
         CriticalBuildMessage,
         ProjectEvaluationStarted,
         ProjectEvaluationFinished,
-        ProjectImported
+        ProjectImported,
+        ProjectImportArchive
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -152,11 +152,14 @@ namespace Microsoft.Build.Logging
                     eventArgsWriter.Write(e);
                 }
 
-                IncludeSourceFilesFrom(e);
+                if (projectImportsCollector != null)
+                {
+                    CollectImports(e);
+                }
             }
         }
 
-        private void IncludeSourceFilesFrom(BuildEventArgs e)
+        private void CollectImports(BuildEventArgs e)
         {
             ProjectImportedEventArgs importArgs = e as ProjectImportedEventArgs;
             if (importArgs != null && importArgs.ImportedProjectFile != null)

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -24,6 +24,34 @@ namespace Microsoft.Build.Logging
         private Stream stream;
         private BinaryWriter binaryWriter;
         private BuildEventArgsWriter eventArgsWriter;
+        private ProjectImportsCollector projectImportsCollector;
+
+        /// <summary>
+        /// Describes whether to collect the project files (including imported project files) used during the build.
+        /// If the project files are collected they can be embedded in the log file or as a separate zip archive.
+        /// </summary>
+        public enum ProjectImportsCollectionMode
+        {
+            /// <summary>
+            /// Don't collect any files during the build.
+            /// </summary>
+            None,
+
+            /// <summary>
+            /// Embed all project files directly in the log file.
+            /// </summary>
+            Embed,
+
+            /// <summary>
+            /// Create an external .ProjectImports.zip archive for the project files.
+            /// </summary>
+            ZipFile
+        }
+
+        /// <summary>
+        /// Gets or sets whether to capture and embed project and target source files used during the build.
+        /// </summary>
+        public ProjectImportsCollectionMode CollectProjectImports { get; set; } = ProjectImportsCollectionMode.Embed;
 
         private string FilePath { get; set; }
 
@@ -50,6 +78,11 @@ namespace Microsoft.Build.Logging
             try
             {
                 stream = new FileStream(FilePath, FileMode.Create);
+
+                if (CollectProjectImports != ProjectImportsCollectionMode.None)
+                {
+                    projectImportsCollector = new ProjectImportsCollector(FilePath);
+                }
             }
             catch (Exception e)
             {
@@ -73,6 +106,26 @@ namespace Microsoft.Build.Logging
         /// </summary>
         public void Shutdown()
         {
+            if (projectImportsCollector != null)
+            {
+                projectImportsCollector.Close();
+
+                if (CollectProjectImports == ProjectImportsCollectionMode.Embed)
+                {
+                    var archiveFilePath = projectImportsCollector.ArchiveFilePath;
+
+                    // It is possible that the archive couldn't be created for some reason.
+                    // Only embed it if it actually exists.
+                    if (File.Exists(archiveFilePath))
+                    {
+                        eventArgsWriter.WriteBlob(BinaryLogRecordKind.ProjectImportArchive, File.ReadAllBytes(archiveFilePath));
+                        File.Delete(archiveFilePath);
+                    }
+                }
+
+                projectImportsCollector = null;
+            }
+
             if (stream != null)
             {
                 // It's hard to determine whether we're at the end of decoding GZipStream
@@ -98,6 +151,24 @@ namespace Microsoft.Build.Logging
                 {
                     eventArgsWriter.Write(e);
                 }
+
+                IncludeSourceFilesFrom(e);
+            }
+        }
+
+        private void IncludeSourceFilesFrom(BuildEventArgs e)
+        {
+            ProjectImportedEventArgs importArgs = e as ProjectImportedEventArgs;
+            if (importArgs != null && importArgs.ImportedProjectFile != null)
+            {
+                projectImportsCollector.AddFile(importArgs.ImportedProjectFile);
+                return;
+            }
+
+            ProjectStartedEventArgs projectArgs = e as ProjectStartedEventArgs;
+            if (projectArgs != null)
+            {
+                projectImportsCollector.AddFile(projectArgs.ProjectFile);
             }
         }
 
@@ -110,17 +181,44 @@ namespace Microsoft.Build.Logging
         {
             if (Parameters == null)
             {
-                throw new LoggerException(ResourceUtilities.FormatResourceString("InvalidBinaryLoggerParameters", 0, Parameters));
+                throw new LoggerException(ResourceUtilities.FormatResourceString("InvalidBinaryLoggerParameters", ""));
             }
 
-            string[] parameters = Parameters.Split(';');
-
-            if (parameters.Length != 1)
+            var parameters = Parameters.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var parameter in parameters)
             {
-                throw new LoggerException(ResourceUtilities.FormatResourceString("InvalidBinaryLoggerParameters", parameters.Length, Parameters));
+                if (string.Equals(parameter, "ProjectImports=None", StringComparison.OrdinalIgnoreCase))
+                {
+                    CollectProjectImports = ProjectImportsCollectionMode.None;
+                }
+                else if (string.Equals(parameter, "ProjectImports=Embed", StringComparison.OrdinalIgnoreCase))
+                {
+                    CollectProjectImports = ProjectImportsCollectionMode.Embed;
+                }
+                else if (string.Equals(parameter, "ProjectImports=ZipFile", StringComparison.OrdinalIgnoreCase))
+                {
+                    CollectProjectImports = ProjectImportsCollectionMode.ZipFile;
+                }
+                else if (parameter.EndsWith(".binlog", StringComparison.OrdinalIgnoreCase))
+                {
+                    FilePath = parameter;
+                    if (FilePath.StartsWith("LogFile=", StringComparison.OrdinalIgnoreCase))
+                    {
+                        FilePath = FilePath.Substring("LogFile=".Length);
+                    }
+
+                    FilePath = parameter.TrimStart('"').TrimEnd('"');
+                }
+                else
+                {
+                    throw new LoggerException(ResourceUtilities.FormatResourceString("InvalidBinaryLoggerParameters", parameter));
+                }
             }
 
-            FilePath = parameters[0].TrimStart('"').TrimEnd('"');
+            if (FilePath == null)
+            {
+                FilePath = "msbuild.binlog";
+            }
 
             try
             {

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -33,11 +33,24 @@ namespace Microsoft.Build.Logging
         }
 
         /// <summary>
+        /// Raised when the log reader encounters a binary blob embedded in the stream.
+        /// The arguments include the blob kind and the byte buffer with the contents.
+        /// </summary>
+        internal event Action<BinaryLogRecordKind, byte[]> OnBlobRead;
+
+        /// <summary>
         /// Reads the next log record from the binary reader. If there are no more records, returns null.
         /// </summary>
         public BuildEventArgs Read()
         {
             BinaryLogRecordKind recordKind = (BinaryLogRecordKind)ReadInt32();
+
+            while (IsBlob(recordKind))
+            {
+                ReadBlob(recordKind);
+
+                recordKind = (BinaryLogRecordKind)ReadInt32();
+            }
 
             BuildEventArgs result = null;
             switch (recordKind)
@@ -97,6 +110,21 @@ namespace Microsoft.Build.Logging
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// For now it's just the ProjectImportArchive.
+        /// </summary>
+        private static bool IsBlob(BinaryLogRecordKind recordKind)
+        {
+            return recordKind == BinaryLogRecordKind.ProjectImportArchive;
+        }
+
+        private void ReadBlob(BinaryLogRecordKind kind)
+        {
+            int length = ReadInt32();
+            byte[] bytes = binaryReader.ReadBytes(length);
+            OnBlobRead?.Invoke(kind, bytes);
         }
 
         private BuildEventArgs ReadProjectImportedEventArgs()

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -94,6 +94,13 @@ namespace Microsoft.Build.Logging
             }
         }
 
+        public void WriteBlob(BinaryLogRecordKind kind, byte[] bytes)
+        {
+            Write(kind);
+            Write(bytes.Length);
+            Write(bytes);
+        }
+
         private void Write(BuildStartedEventArgs e)
         {
             Write(BinaryLogRecordKind.BuildStarted);
@@ -576,6 +583,11 @@ namespace Microsoft.Build.Logging
                 v >>= 7;
             }
             writer.Write((byte)v);
+        }
+
+        private void Write(byte[] bytes)
+        {
+            binaryWriter.Write(bytes);
         }
 
         private void Write(bool boolean)

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Logging
+{
+    /// <summary>
+    /// Creates a zip archive with all the .csproj and .targets encountered during the build.
+    /// The internal .zip file structure matches closely the layout of the original sources on disk.
+    /// The .zip file can be used to correlate the file names and positions in the build log file with the
+    /// actual sources.
+    /// </summary>
+    internal class ProjectImportsCollector
+    {
+        private FileStream _fileStream;
+        private ZipArchive _zipArchive;
+
+        public string ArchiveFilePath { get; set; }
+
+        /// <summary>
+        /// Avoid visiting each file more than once.
+        /// </summary>
+        private readonly HashSet<string> _processedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // this will form a chain of file write tasks, running sequentially on a background thread
+        private Task _currentTask = Task.CompletedTask;
+
+        public ProjectImportsCollector(string logFilePath, string sourcesArchiveExtension = ".ProjectImports.zip")
+        {
+            ArchiveFilePath = Path.ChangeExtension(logFilePath, sourcesArchiveExtension);
+
+            try
+            {
+                _fileStream = new FileStream(ArchiveFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Delete);
+                _zipArchive = new ZipArchive(_fileStream, ZipArchiveMode.Create);
+            }
+            catch
+            {
+                // For some reason we weren't able to create a file for the archive.
+                // Disable the file collector.
+                _fileStream = null;
+                _zipArchive = null;
+            }
+        }
+
+        public void AddFile(string filePath)
+        {
+            if (filePath == null || _fileStream == null)
+            {
+                return;
+            }
+
+            lock (_fileStream)
+            {
+                // enqueue the task to add a file and return quickly
+                // to avoid holding up the current thread
+                _currentTask = _currentTask.ContinueWith(t =>
+                {
+                    try
+                    {
+                        AddFileCore(filePath);
+                    }
+                    catch
+                    {
+                    }
+                }, TaskScheduler.Default);
+            }
+        }
+
+        /// <remarks>
+        /// This method doesn't need locking/synchronization because it's only called
+        /// from a task that is chained linearly
+        /// </remarks>
+        private void AddFileCore(string filePath)
+        {
+            // quick check to avoid repeated disk access for Exists etc.
+            if (_processedFiles.Contains(filePath))
+            {
+                return;
+            }
+
+            var fileInfo = new FileInfo(filePath);
+            if (!fileInfo.Exists || fileInfo.Length == 0)
+            {
+                _processedFiles.Add(filePath);
+                return;
+            }
+
+            filePath = Path.GetFullPath(filePath);
+
+            // if the file is already included, don't include it again
+            if (!_processedFiles.Add(filePath))
+            {
+                return;
+            }
+
+            string archivePath = CalculateArchivePath(filePath);
+
+            ZipArchiveEntry archiveEntry = _zipArchive.CreateEntry(archivePath);
+            archiveEntry.LastWriteTime = fileInfo.LastWriteTime;
+
+            using (Stream entryStream = archiveEntry.Open())
+            using (FileStream content = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
+            {
+                content.CopyTo(entryStream);
+            }
+        }
+
+        private static string CalculateArchivePath(string filePath)
+        {
+            string archivePath = filePath;
+
+            archivePath = archivePath.Replace(":", "");
+            archivePath = archivePath.Replace("\\\\", "\\");
+            archivePath = archivePath.Replace("/", "\\");
+
+            return archivePath;
+        }
+
+        public void Close()
+        {
+            // wait for all pending file writes to complete
+            _currentTask.Wait();
+
+            if (_zipArchive != null)
+            {
+                _zipArchive.Dispose();
+                _zipArchive = null;
+            }
+
+            if (_fileStream != null)
+            {
+                _fileStream.Dispose();
+                _fileStream = null;
+            }
+        }
+    }
+}

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -572,6 +572,7 @@
     <Compile Include="Logging\BinaryLogger\BuildEventArgsFields.cs" />
     <Compile Include="Logging\BinaryLogger\BuildEventArgsReader.cs" />
     <Compile Include="Logging\BinaryLogger\BuildEventArgsWriter.cs" />
+    <Compile Include="Logging\BinaryLogger\ProjectImportsCollector.cs" />
     <Compile Include="Logging\ConsoleLogger.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -773,6 +774,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Threading.Tasks">
       <HintPath>$(FrameworkPathOverride)\System.Threading.Tasks.dll</HintPath>
     </Reference>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -451,8 +451,7 @@
         attributes. At the end of the message we show the exception text we got trying to use the value.</comment>
   </data>
   <data name="InvalidBinaryLoggerParameters" UESanitized="false" Visibility="Public">
-    <value>MSB4234: The binary logger expects a single parameter (the output file name). {0} parameters were passed: "{1}".</value>
-    <comment>{StrBegin="MSB4234: "}This is shown when the Binary Logger is passed zero or more than one parameter.</comment>
+    <value>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</value>
   </data>
   <data name="InvalidContinueOnErrorAttribute" UESanitized="false" Visibility="Public">
     <value>MSB4021: The "ContinueOnError" attribute of the "{0}" task is not valid. {1}</value>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -621,7 +621,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </comment>
   </data>
   <data name="HelpMessage_30_BinaryLoggerSwitch" UESanitized="false" Visibility="Public">
-    <value>  /binaryLogger[:output.binlog]
+    <value>  /binaryLogger[:[LogFile=]output.binlog[;ProjectImports={None,Embed,ZipFile}]]
                      Serializes all build events to a compressed binary file.
                      By default the file is in the current directory and named
                      "msbuild.binlog". The binary log is a detailed description
@@ -631,9 +631,29 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      diagnostic-level log, but it contains more information.
                      (Short form: /bl)
 
+                     The binary logger by default collects the source text of
+                     project files, including all imported projects and target
+                     files encountered during the build. The optional 
+                     ProjectImports switch controls this behavior:
+
+                      ProjectImports=None     - Don't collect the project
+                                                imports.
+                      ProjectImports=Embed    - Embed project imports in the
+                                                log file.
+                      ProjectImports=ZipFile  - Save project files to 
+                                                output.projectimports.zip
+                                                where output is the same name
+                                                as the binary log file name.
+
+                     The default setting for ProjectImports is Embed.
+                     Note: the logger does not collect non-MSBuild source files
+                     such as .cs, .cpp etc.
+
                      Examples:
                        /bl
                        /bl:output.binlog
+                       /bl:output.binlog;ProjectImports=None
+                       /bl:output.binlog;ProjectImports=ZipFile
                        /bl:..\..\custom.binlog
                        /binaryLogger
     </value>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2733,10 +2733,10 @@ namespace Microsoft.Build.CommandLine
                 return;
             }
 
-            string outputLogFilePath = binaryLoggerParameters[binaryLoggerParameters.Length - 1];
+            string arguments = binaryLoggerParameters[binaryLoggerParameters.Length - 1];
 
             BinaryLogger logger = new BinaryLogger();
-            logger.Parameters = outputLogFilePath;
+            logger.Parameters = arguments;
 
             // If we have a binary logger, force verbosity to diagnostic.
             // The only place where verbosity is used downstream is to determine whether to log task inputs.


### PR DESCRIPTION
To improve the diagnosability of build logs a new option is added to collect project files and all imported projects used during the build.

There are three options: don't capture sources, capture to a standalone .ProjectImports.zip archive and embed the zip archive directly into the binary log. The last option (embed) is the default.