### PR TITLE
Use LazyFormattedBuildEventArgs for messages of project evaluation started/finished

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -338,13 +338,13 @@ namespace Microsoft.Build.Framework
     public sealed partial class ProjectEvaluationFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public ProjectEvaluationFinishedEventArgs() { }
-        public ProjectEvaluationFinishedEventArgs(string message) { }
+        public ProjectEvaluationFinishedEventArgs(string message, params object[] messageArgs) { }
         public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectEvaluationStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public ProjectEvaluationStartedEventArgs() { }
-        public ProjectEvaluationStartedEventArgs(string message) { }
+        public ProjectEvaluationStartedEventArgs(string message, params object[] messageArgs) { }
         public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -335,13 +335,13 @@ namespace Microsoft.Build.Framework
     public sealed partial class ProjectEvaluationFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public ProjectEvaluationFinishedEventArgs() { }
-        public ProjectEvaluationFinishedEventArgs(string message) { }
+        public ProjectEvaluationFinishedEventArgs(string message, params object[] messageArgs) { }
         public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectEvaluationStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public ProjectEvaluationStartedEventArgs() { }
-        public ProjectEvaluationStartedEventArgs(string message) { }
+        public ProjectEvaluationStartedEventArgs(string message, params object[] messageArgs) { }
         public string ProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -791,7 +791,7 @@ namespace Microsoft.Build.Evaluation
 #endif
             string projectFile = String.IsNullOrEmpty(_projectRootElement.ProjectFileLocation.File) ? "(null)" : _projectRootElement.ProjectFileLocation.File;
 
-            _evaluationLoggingContext.LogBuildEvent(new ProjectEvaluationStartedEventArgs(ResourceUtilities.FormatResourceString("EvaluationStarted", projectFile))
+            _evaluationLoggingContext.LogBuildEvent(new ProjectEvaluationStartedEventArgs(ResourceUtilities.GetResourceString("EvaluationStarted"), projectFile)
             {
                 BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                 ProjectFile = projectFile
@@ -949,7 +949,7 @@ namespace Microsoft.Build.Evaluation
 
             _data.FinishEvaluation();
 
-            _evaluationLoggingContext.LogBuildEvent(new ProjectEvaluationFinishedEventArgs(ResourceUtilities.FormatResourceString("EvaluationFinished", projectFile))
+            _evaluationLoggingContext.LogBuildEvent(new ProjectEvaluationFinishedEventArgs(ResourceUtilities.GetResourceString("EvaluationFinished"), projectFile)
             {
                 BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                 ProjectFile = projectFile

--- a/src/Framework/ProjectEvaluationFinishedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationFinishedEventArgs.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Initializes a new instance of the ProjectEvaluationFinishedEventArgs class.
         /// </summary>
-        public ProjectEvaluationFinishedEventArgs(string message)
-            : base(message, null, null)
+        public ProjectEvaluationFinishedEventArgs(string message, params object[] messageArgs)
+            : base(message, null, null, DateTime.UtcNow, messageArgs)
         {
         }
 

--- a/src/Framework/ProjectEvaluationStartedEventArgs.cs
+++ b/src/Framework/ProjectEvaluationStartedEventArgs.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Initializes a new instance of the ProjectEvaluationStartedEventArgs class.
         /// </summary>
-        public ProjectEvaluationStartedEventArgs(string message)
-            : base(message, null, null)
+        public ProjectEvaluationStartedEventArgs(string message, params object[] messageArgs)
+            : base(message, null, null, DateTime.UtcNow, messageArgs)
         {
         }
 


### PR DESCRIPTION
Should clean up a few more string allocations.