### PR TITLE
Include evaluation performance in performance summary

### DIFF
--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -223,6 +223,16 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal void ShowPerfSummary()
         {
+            if (projectEvaluationPerformanceCounters != null)
+            {
+                setColor(ConsoleColor.Green);
+                WriteNewLine();
+                WriteLinePrettyFromResource("ProjectEvaluationPerformanceSummary");
+
+                setColor(ConsoleColor.Gray);
+                DisplayCounters(projectEvaluationPerformanceCounters);
+            }
+
             // Show project performance summary.
             if (projectPerformanceCounters != null)
             {
@@ -938,6 +948,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 eventSource.WarningRaised += WarningHandler;
                 eventSource.MessageRaised += MessageHandler;
                 eventSource.CustomEventRaised += CustomEventHandler;
+                eventSource.StatusEventRaised += StatusEventHandler;
             }
         }
 
@@ -1066,6 +1077,8 @@ namespace Microsoft.Build.BackEnd.Logging
 
         public abstract void CustomEventHandler(object sender, CustomBuildEventArgs e);
 
+        public abstract void StatusEventHandler(object sender, BuildStatusEventArgs e);
+
         #endregion
 
         #region Internal member data
@@ -1193,6 +1206,11 @@ namespace Microsoft.Build.BackEnd.Logging
         /// Accumulated task performance information.
         /// </summary>
         internal Dictionary<string, PerformanceCounter> taskPerformanceCounters;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        internal Dictionary<string, PerformanceCounter> projectEvaluationPerformanceCounters;
 
         #endregion
 

--- a/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
+++ b/src/Build/Logging/DistributedLoggers/ConfigurableForwardingLogger.cs
@@ -82,6 +82,8 @@ namespace Microsoft.Build.Logging
             _forwardingTable[BuildFinishedEventDescription] = 0;
             _forwardingTable[ProjectStartedEventDescription] = 0;
             _forwardingTable[ProjectFinishedEventDescription] = 0;
+            _forwardingTable[ProjectEvaluationStartedEventDescription] = 0;
+            _forwardingTable[ProjectEvaluationFinishedEventDescription] = 0;
             _forwardingTable[TargetStartedEventDescription] = 0;
             _forwardingTable[TargetFinishedEventDescription] = 0;
             _forwardingTable[TaskStartedEventDescription] = 0;
@@ -181,6 +183,7 @@ namespace Microsoft.Build.Logging
             eventSource.WarningRaised += new BuildWarningEventHandler(WarningHandler);
             eventSource.MessageRaised += new BuildMessageEventHandler(MessageHandler);
             eventSource.CustomEventRaised += new CustomBuildEventHandler(CustomEventHandler);
+            eventSource.StatusEventRaised += new BuildStatusEventHandler(BuildStatusHandler);
         }
 
         /// <summary>
@@ -229,6 +232,8 @@ namespace Microsoft.Build.Logging
             if (IsVerbosityAtLeast(LoggerVerbosity.Diagnostic))
             {
                 _forwardingTable[CustomEventDescription] = 1;
+                _forwardingTable[ProjectEvaluationStartedEventDescription] = 1;
+                _forwardingTable[ProjectEvaluationFinishedEventDescription] = 1;
             }
 
             if (_showSummary)
@@ -247,6 +252,8 @@ namespace Microsoft.Build.Logging
                 _forwardingTable[TargetFinishedEventDescription] = 1;
                 _forwardingTable[ProjectStartedEventDescription] = 1;
                 _forwardingTable[ProjectFinishedEventDescription] = 1;
+                _forwardingTable[ProjectEvaluationStartedEventDescription] = 1;
+                _forwardingTable[ProjectEvaluationFinishedEventDescription] = 1;
             }
 
             if (_showCommandLine)
@@ -443,6 +450,19 @@ namespace Microsoft.Build.Logging
             }
         }
 
+        private void BuildStatusHandler(object sender, BuildStatusEventArgs e)
+        {
+            if (_forwardingTable[ProjectEvaluationStartedEventDescription] == 1 && e is ProjectEvaluationStartedEventArgs)
+            {
+                ForwardToCentralLogger(e);
+            }
+
+            if (_forwardingTable[ProjectEvaluationFinishedEventDescription] == 1 && e is ProjectEvaluationFinishedEventArgs)
+            {
+                ForwardToCentralLogger(e);
+            }
+        }
+
         /// <summary>
         /// Forwards the specified event.
         /// </summary>
@@ -487,6 +507,8 @@ namespace Microsoft.Build.Logging
         private const string BuildFinishedEventDescription = "BUILDFINISHEDEVENT";
         private const string ProjectStartedEventDescription = "PROJECTSTARTEDEVENT";
         private const string ProjectFinishedEventDescription = "PROJECTFINISHEDEVENT";
+        private const string ProjectEvaluationStartedEventDescription = "PROJECTEVALUATIONSTARTEDEVENT";
+        private const string ProjectEvaluationFinishedEventDescription = "PROJECTEVALUATIONFINISHEDEVENT";
         private const string TargetStartedEventDescription = "TARGETSTARTEDEVENT";
         private const string TargetFinishedEventDescription = "TARGETFINISHEDEVENT";
         private const string TaskStartedEventDescription = "TASKSTARTEDEVENT";

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -1071,6 +1071,30 @@ namespace Microsoft.Build.BackEnd.Logging
             }
         }
 
+        public override void StatusEventHandler(object sender, BuildStatusEventArgs e)
+        {
+            if (showPerfSummary)
+            {
+                ProjectEvaluationStartedEventArgs projectEvaluationStarted = e as ProjectEvaluationStartedEventArgs;
+
+                if (projectEvaluationStarted != null)
+                {
+                    MPPerformanceCounter counter = GetPerformanceCounter(projectEvaluationStarted.ProjectFile, ref projectEvaluationPerformanceCounters);
+                    counter.AddEventStarted(null, e.BuildEventContext, e.Timestamp, s_compareContextNodeId);
+
+                    return;
+                }
+
+                ProjectEvaluationFinishedEventArgs projectEvaluationFinished = e as ProjectEvaluationFinishedEventArgs;
+
+                if (projectEvaluationFinished != null)
+                {
+                    MPPerformanceCounter counter = GetPerformanceCounter(projectEvaluationFinished.ProjectFile, ref projectEvaluationPerformanceCounters);
+                    counter.AddEventFinished(null, e.BuildEventContext, e.Timestamp);
+                }
+            }
+        }
+
         private void DisplayDeferredStartedEvents(BuildEventContext e)
         {
             if (showOnlyErrors || showOnlyWarnings) return;

--- a/src/Build/Logging/SerialConsoleLogger.cs
+++ b/src/Build/Logging/SerialConsoleLogger.cs
@@ -573,6 +573,30 @@ namespace Microsoft.Build.BackEnd.Logging
             }
         }
 
+        public override void StatusEventHandler(object sender, BuildStatusEventArgs e)
+        {
+            if (showPerfSummary)
+            {
+                ProjectEvaluationStartedEventArgs projectEvaluationStarted = e as ProjectEvaluationStartedEventArgs;
+
+                if (projectEvaluationStarted != null)
+                {
+                    PerformanceCounter counter = GetPerformanceCounter(projectEvaluationStarted.ProjectFile, ref projectEvaluationPerformanceCounters);
+                    counter.InScope = true;
+
+                    return;
+                }
+
+                ProjectEvaluationFinishedEventArgs projectEvaluationFinished = e as ProjectEvaluationFinishedEventArgs;
+
+                if (projectEvaluationFinished != null)
+                {
+                    PerformanceCounter counter = GetPerformanceCounter(projectEvaluationFinished.ProjectFile, ref projectEvaluationPerformanceCounters);
+                    counter.InScope = false;
+                }
+            }
+        }
+
         /// <summary>
         /// Writes project started messages.
         /// </summary>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1123,6 +1123,9 @@
   <data name="TaskPerformanceSummary" UESanitized="false" Visibility="Public">
     <value>Task Performance Summary:</value>
   </data>
+  <data name="ProjectEvaluationPerformanceSummary" UESanitized="false" Visibility="Public">
+    <value>Project Evaluation Performance Summary:</value>
+  </data>
   <data name="TaskSkippedFalseCondition" UESanitized="false" Visibility="Public">
     <value>Task "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</value>
   </data>


### PR DESCRIPTION
1. Additional counters for project evaluation.
2. Update ConfigurableForwardingLogger to forward BuildStatusEvents
a. This ensures that project evaluation started/finished events are piped through in multi-proc builds so the performance summary can correctly contain evaluation numbers.  The events are only forwarded if the verbosity is diagnostic or the performance summary will be shown.

Summary looks like this:

```
Project Evaluation Performance Summary:
       25 ms  D:\CommonBuildToolset\Examples\src\CSharp\Windows\dirs.proj   1 calls
       29 ms  D:\CommonBuildToolset\Examples\src\CSharp\Windows\UnitTests.MSTest\UnitTests.MSTest.csproj   1 calls
       30 ms  D:\CommonBuildToolset\Examples\src\CSharp\Windows\UnitTests.NUnit\UnitTests.NUnit.csproj   1 calls
       74 ms  D:\CommonBuildToolset\Examples\src\CSharp\Windows\ClassLibrary\ClassLibrary.csproj   2 calls
      138 ms  D:\CommonBuildToolset\Examples\src\CSharp\Windows\ClassLibrary.Package\ClassLibrary.Package.nuproj   1 calls
      220 ms  D:\CommonBuildToolset\Examples\src\dirs.proj   1 calls
```