### PR TITLE
Ignore missing imports

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -759,6 +759,7 @@ namespace Microsoft.Build.Evaluation
     public enum ProjectLoadSettings
     {
         Default = 0,
+        IgnoreEmptyImports = 16,
         IgnoreMissingImports = 1,
         RecordDuplicateButNotCircularImports = 2,
         RecordEvaluatedItemElements = 8,

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -747,6 +747,7 @@ namespace Microsoft.Build.Evaluation
     public enum ProjectLoadSettings
     {
         Default = 0,
+        IgnoreEmptyImports = 16,
         IgnoreMissingImports = 1,
         RecordDuplicateButNotCircularImports = 2,
         RecordEvaluatedItemElements = 8,

--- a/src/Build.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Construction;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.Construction
+{
+    /// <summary>
+    /// Tests for the ElementLocation class
+    /// </summary>
+    public class ProjectRootElement_Tests
+    {
+        [Theory]
+        [InlineData("", true)]
+        [InlineData("", false)]
+        [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>", true)]
+        [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>", false)]
+        [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>
+", true)]
+        [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>
+", false)]
+        public void IsEmptyXmlFileReturnsTrue(string contents, bool useByteOrderMark)
+        {
+            string path = useByteOrderMark ?
+                ObjectModelHelpers.CreateFileInTempProjectDirectory(Guid.NewGuid().ToString("N"), contents, Encoding.UTF8) :
+                ObjectModelHelpers.CreateFileInTempProjectDirectory(Guid.NewGuid().ToString("N"), contents);
+
+            Assert.True(ProjectRootElement.IsEmptyXmlFile(path));
+        }
+
+        [Theory]
+        [InlineData("<Foo/>", true)]
+        [InlineData("Foo/>", false)]
+        [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Foo/>", true)]
+        [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Foo/>", false)]
+        [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>
+bar", true)]
+        [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>
+bar", false)]
+        public void IsEmptyXmlFileReturnsFalse(string contents, bool useByteOrderMark)
+        {
+            string path = useByteOrderMark ?
+                ObjectModelHelpers.CreateFileInTempProjectDirectory(Guid.NewGuid().ToString("N"), contents, Encoding.UTF8) :
+                ObjectModelHelpers.CreateFileInTempProjectDirectory(Guid.NewGuid().ToString("N"), contents);
+
+            Assert.False(ProjectRootElement.IsEmptyXmlFile(path));
+        }
+    }
+}

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 projColln.RegisterLogger(logger);
 
                 Assert.Throws<InvalidProjectFileException>(() => projColln.LoadProject(mainProjectPath));
-                logger.AssertLogContains("MSB4025");
+                logger.AssertLogContains("MSB4024");
             } finally {
                 if (mainProjectPath != null)
                 {

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="BackEnd\TaskHostTaskCancelled_Tests.cs" />
     <Compile Include="BackEnd\TaskHostTaskComplete_Tests.cs" />
     <Compile Include="BackEnd\TaskHost_Tests.cs" />
+    <Compile Include="Construction\ProjectRootElement_Tests.cs" />
     <Compile Include="Evaluation\EvaluationLogging_Tests.cs" />
     <Compile Include="MockLoggingContext.cs" />
     <Compile Include="TestComparers\TaskRegistryComparers.cs" />

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1959,7 +1959,7 @@ namespace Microsoft.Build.Construction
             //
             // And this should also be treated as if the file is empty.
             //
-            const int maxCharsToRead = 100;
+            const int maxSizeToConsiderEmpty = 100;
 
             if (!File.Exists(path))
             {
@@ -1979,32 +1979,14 @@ namespace Microsoft.Build.Construction
                     return true;
                 }
 
-                if (fileInfo.Length > maxCharsToRead)
+                if (fileInfo.Length > maxSizeToConsiderEmpty)
                 {
                     // Files greater than the minimum to bytes to check are not empty
                     //
                     return false;
                 }
 
-                // Create a buffer that is as big as the file
-                //
-                char[] chars = new char[fileInfo.Length];
-
-                using (StreamReader streamReader = new StreamReader(new FileStream(path, FileMode.Open), Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: chars.Length, leaveOpen: false))
-                {
-                    // If the file only contains a preamble byte order mark (BOM) then the stream is already at the end and the file is empty
-                    //
-                    if (streamReader.EndOfStream)
-                    {
-                        return true;
-                    }
-
-                    streamReader.Read(chars, 0, chars.Length);
-                }
-
-                // Copy the char[] to a string and trim and trailing \0 because the BOM adds some bytes so we read past the file end
-                //
-                string contents = new String(chars).Trim('\0');
+                string contents = File.ReadAllText(path);
 
                 // If the file is only whitespace or the XML declaration then it empty
                 //

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml;
 using Microsoft.Build.BackEnd.Logging;
@@ -63,6 +64,11 @@ namespace Microsoft.Build.Construction
         private static readonly ProjectRootElementCache.OpenProjectRootElement s_openLoaderDelegate = OpenLoader;
 
         private static readonly ProjectRootElementCache.OpenProjectRootElement s_openLoaderPreserveFormattingDelegate = OpenLoaderPreserveFormatting;
+
+        /// <summary>
+        /// Used to determine if a file is an empty XML file if it ONLY contains an XML declaration like &lt;?xml version="1.0" encoding="utf-8"?&gt;.
+        /// </summary>
+        private static readonly Lazy<Regex> XmlDeclarationRegEx = new Lazy<Regex>(() => new Regex(@"\A\s*\<\?\s*xml.*\?\>\s*\Z"), isThreadSafe: true);
 
         /// <summary>
         /// The default encoding to use / assume for a new project.
@@ -1936,6 +1942,80 @@ namespace Microsoft.Build.Construction
 
                 yield return sdkReference;
             }
+        }
+
+        /// <summary>
+        /// Determines if the specified file is an empty XML file meaning it has no contents, contains only whitespace, or
+        /// only an XML declaration.  If the file does not exist, it is not considered empty.
+        /// </summary>
+        /// <param name="path">The full path to a file to check.</param>
+        /// <returns><code>true</code> if the file is an empty XML file, otherwise <code>false</code>.</returns>
+        internal static bool IsEmptyXmlFile(string path)
+        {
+            // The maximum number of characters of the file to read to check if its empty or not.  Ideally we
+            // would only look at zero-length files but empty XML files can contain just an xml declaration:
+            //
+            //   <? xml version="1.0" encoding="utf-8" standalone="yes" ?>
+            //
+            // And this should also be treated as if the file is empty.
+            //
+            const int maxCharsToRead = 100;
+
+            if (!File.Exists(path))
+            {
+                // Non-existent files are not treated as empty
+                //
+                return false;
+            }
+
+            try
+            {
+                FileInfo fileInfo = new FileInfo(path);
+
+                if (fileInfo.Length == 0)
+                {
+                    // Zero length files are empty
+                    //
+                    return true;
+                }
+
+                if (fileInfo.Length > maxCharsToRead)
+                {
+                    // Files greater than the minimum to bytes to check are not empty
+                    //
+                    return false;
+                }
+
+                // Create a buffer that is as big as the file
+                //
+                char[] chars = new char[fileInfo.Length];
+
+                using (StreamReader streamReader = new StreamReader(new FileStream(path, FileMode.Open), Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: chars.Length, leaveOpen: false))
+                {
+                    // If the file only contains a preamble byte order mark (BOM) then the stream is already at the end and the file is empty
+                    //
+                    if (streamReader.EndOfStream)
+                    {
+                        return true;
+                    }
+
+                    streamReader.Read(chars, 0, chars.Length);
+                }
+
+                // Copy the char[] to a string and trim and trailing \0 because the BOM adds some bytes so we read past the file end
+                //
+                string contents = new String(chars).Trim('\0');
+
+                // If the file is only whitespace or the XML declaration then it empty
+                //
+                return String.IsNullOrEmpty(contents) || XmlDeclarationRegEx.Value.IsMatch(contents);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1981,7 +1981,7 @@ namespace Microsoft.Build.Construction
 
                 if (fileInfo.Length > maxSizeToConsiderEmpty)
                 {
-                    // Files greater than the minimum to bytes to check are not empty
+                    // Files greater than the maximum bytes to check are not empty
                     //
                     return false;
                 }

--- a/src/Build/Definition/ProjectLoadSettings.cs
+++ b/src/Build/Definition/ProjectLoadSettings.cs
@@ -37,6 +37,11 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Record the item elements that got evaluated
         /// </summary>
-        RecordEvaluatedItemElements = 8
+        RecordEvaluatedItemElements = 8,
+
+        /// <summary>
+        /// Ignore empty targets files when evaluating the project
+        /// </summary>
+        IgnoreEmptyImports = 16,
     }
 }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2438,7 +2438,7 @@ namespace Microsoft.Build.Execution
                 }
             }
 
-            if (Evaluator<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.DebugEvaluation)
+            if (Traits.Instance.EscapeHatches.DebugEvaluation)
             {
                 Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Creating a ProjectInstance from an unevaluated state [{0}]", FullPath));
             }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1613,6 +1613,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="ProjectImportSkippedNoMatches">
     <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to no matching files.</value>
   </data>
+
+  <data name="ProjectImportSkippedEmptyFile">
+    <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to the file being empty.</value>
+  </data>
   
   <data name="ProjectImported">
     <value>Importing project &quot;{0}&quot; into project &quot;{1}&quot; at ({2},{3}).</value>

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -39,6 +39,26 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool UseSymlinkTimeInsteadOfTargetTime = Environment.GetEnvironmentVariable("MSBUILDUSESYMLINKTIMESTAMP") == "1";
 
+        /// <summary>
+        /// Whether or not to ignore imports that are considered empty.  See ProjectRootElement.IsEmptyXmlFile() for more info.
+        /// </summary>
+        public readonly bool IgnoreEmptyImports = Environment.GetEnvironmentVariable("MSBUILDIGNOREEMPTYIMPORTS") == "1";
+
+        /// <summary>
+        /// Whether to to respect the TreatAsLocalProperty parameter on the Project tag. 
+        /// </summary>
+        public readonly bool IgnoreTreatAsLocalProperty = Environment.GetEnvironmentVariable("MSBUILDIGNORETREATASLOCALPROPERTY") != null;
+
+        /// <summary>
+        /// Whether to write information about why we evaluate to debug output.
+        /// </summary>
+        public readonly bool DebugEvaluation = Environment.GetEnvironmentVariable("MSBUILDDEBUGEVALUATION") != null;
+
+        /// <summary>
+        /// Whether to warn when we set a property for the first time, after it was previously used.
+        /// </summary>
+        public readonly bool WarnOnUninitializedProperty = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY"));
+
         private static ProjectInstanceTranslationMode? ComputeProjectInstanceTranslation()
         {
             var mode = Environment.GetEnvironmentVariable("MSBUILD_PROJECTINSTANCE_TRANSLATION_MODE");

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -792,9 +792,7 @@ namespace Microsoft.Build.UnitTests
         /// up the file contents (replacing single-back-quote with double-quote, etc.).
         /// Silently OVERWRITES existing file.
         /// </summary>
-        /// <param name="fileRelativePath"></param>
-        /// <param name="fileContents"></param>
-        internal static string CreateFileInTempProjectDirectory(string fileRelativePath, string fileContents)
+        internal static string CreateFileInTempProjectDirectory(string fileRelativePath, string fileContents, Encoding encoding = null)
         {
             Assert.False(String.IsNullOrEmpty(fileRelativePath));
             string fullFilePath = Path.Combine(TempProjectDir, fileRelativePath);
@@ -805,7 +803,18 @@ namespace Microsoft.Build.UnitTests
             {
                 try
                 {
-                    File.WriteAllText(fullFilePath, CleanupFileContents(fileContents));
+                    if (encoding == null)
+                    {
+                        // This method uses UTF-8 encoding without a Byte-Order Mark (BOM)
+                        // https://msdn.microsoft.com/en-us/library/ms143375(v=vs.110).aspx#Remarks
+                        File.WriteAllText(fullFilePath, CleanupFileContents(fileContents));
+                    }
+                    else
+                    {
+                        // If it is necessary to include a UTF-8 identifier, such as a byte order mark, at the beginning of a file,
+                        // use the WriteAllText(String,?String,?Encoding) method overload with UTF8 encoding.
+                        File.WriteAllText(fullFilePath, CleanupFileContents(fileContents), encoding);
+                    }
                     break;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
New ProjectLoadSetting to control the feature

New code only runs after the project fails to load and the file existence is checked which should not impact performance.

Closes #1727