### PR TITLE
Always use response file for winmdexp

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1166,7 +1166,7 @@ namespace Microsoft.Build.Tasks
         public bool UTF8Output { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public string WinMDModule { get { throw null; } set { } }
-        protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected internal override void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override string GenerateFullPathToTool() { throw null; }
         protected override bool SkipTaskExecution() { throw null; }
         protected override bool ValidateParameters() { throw null; }

--- a/src/Tasks.UnitTests/WinMDExp_Tests.cs
+++ b/src/Tasks.UnitTests/WinMDExp_Tests.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Build.UnitTests
             CommandLine.ValidateHasParameter(
                 t,
                 "/reference:mscorlib.dll",
-                false);
+                useResponseFile: true);
             CommandLine.ValidateHasParameter(
                 t,
                 "/reference:Windows.Foundation.winmd",
-                false);
+                useResponseFile: true);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.DisabledWarnings = "41999,42016";
-            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", false);
+            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", useResponseFile: true);
         }
 
 
@@ -61,8 +61,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputDocumentationFile = "output.xml";
             t.InputDocumentationFile = "input.xml";
 
-            CommandLine.ValidateHasParameter(t, "/d:output.xml", false);
-            CommandLine.ValidateHasParameter(t, "/md:input.xml", false);
+            CommandLine.ValidateHasParameter(t, "/d:output.xml", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/md:input.xml", useResponseFile: true);
         }
 
         [Fact]
@@ -74,8 +74,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputPDBFile = "output.pdb";
             t.InputPDBFile = "input.pdb";
 
-            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", false);
-            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", false);
+            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", useResponseFile: true);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
 
             t.WinMDModule = "Foo.dll";
-            CommandLine.ValidateContains(t, "Foo.dll", false);
+            CommandLine.ValidateContains(t, "Foo.dll", useResponseFile: true);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Bob.winmd";
-            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", false);
+            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", useResponseFile: true);
         }
 
         [Fact]
@@ -103,12 +103,7 @@ namespace Microsoft.Build.UnitTests
 
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Foo.winmd";
-            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", false);
+            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", useResponseFile: true);
         }
     }
 }
-
-
-
-
-

--- a/src/Tasks/WinMDExp.cs
+++ b/src/Tasks/WinMDExp.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Tasks
         /// executing this tool
         /// </summary>
         /// <param name="commandLine">Gets filled with command line commands</param>
-        protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
+        protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
             commandLine.AppendSwitchIfNotNull("/d:", OutputDocumentationFile);
             commandLine.AppendSwitchIfNotNull("/md:", InputDocumentationFile);


### PR DESCRIPTION
Fixes #2140 by always using a response file for winmdexp, avoiding
issues with too-long calls to CreateProcess.

Concerns:

- [x] Are there any arguments that _cannot_ go in the response file?
- [x] Do we need an option to go back to the old/well-tested way?
- [x] Or should this be opt-in instead?
- [x] Do all versions of `winmdexp.exe` support the response file? If not, should support be detected somehow?
