### PR TITLE
Use ref assemblies in more locations

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3028,7 +3028,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="CompileLicxFiles"
       Condition="'@(_LicxFile)'!=''"
       DependsOnTargets="$(CompileLicxFilesDependsOn)"
-      Inputs="$(MSBuildAllProjects);@(_LicxFile);@(ReferencePath);@(ReferenceDependencyPaths)"
+      Inputs="$(MSBuildAllProjects);@(_LicxFile);@(ReferencePathWithRefAssemblies);@(ReferenceDependencyPaths)"
       Outputs="$(IntermediateOutputPath)$(TargetFileName).licenses">
 
     <PropertyGroup>
@@ -3040,7 +3040,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         LicenseTarget="$(TargetFileName)"
         OutputDirectory="$(IntermediateOutputPath)"
         OutputLicense="$(IntermediateOutputPath)$(TargetFileName).licenses"
-        ReferencedAssemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
+        ReferencedAssemblies="@(ReferencePathWithRefAssemblies);@(ReferenceDependencyPaths)"
         NoLogo="$(NoLogo)"
         ToolPath="$(LCToolPath)"
         SdkToolsPath="$(TargetFrameworkSDKToolsDirectory)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2397,7 +2397,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Target Name="ExportWindowsMDFile"
           DependsOnTargets="Compile"
           Condition="'$(ExportWinMDFile)' == 'true'"
-          Inputs="@(IntermediateAssembly);@(DocFileItem);@(_DebugSymbolsIntermediatePath);@(ReferencePath);$(MSBuildAllProjects)"
+          Inputs="@(IntermediateAssembly);@(DocFileItem);@(_DebugSymbolsIntermediatePath);@(ReferencePathWithRefAssemblies);$(MSBuildAllProjects)"
           Outputs="$(_IntermediateWindowsMetadataPath);$(WinMDExpOutputPdb);$(WinMDOutputDocumentationFile)"
   >
 
@@ -2411,7 +2411,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </PropertyGroup>
 
       <WinMDExp WinMDModule="@(IntermediateAssembly)"
-                References="@(ReferencePath)"
+                References="@(ReferencePathWithRefAssemblies)"
                 DisabledWarnings="$(WinMdExpNoWarn)"
                 InputDocumentationFile="@(DocFileItem)"
                 OutputDocumentationFile="$(WinMDOutputDocumentationFile)"


### PR DESCRIPTION
Need to confirm these changes with owners of:

- [x] `WinMDExp`
- [ ] `LC`

Continuation of #2167 for the post-15.3 timeframe.