### PR TITLE
Differentiate version for System.IO.Compression

### DIFF
--- a/setup/files.swr
+++ b/setup/files.swr
@@ -22,6 +22,7 @@ folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.IO.Compression.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
@@ -150,6 +151,7 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.IO.Compression.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -774,7 +774,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Threading.Tasks">
       <HintPath>$(FrameworkPathOverride)\System.Threading.Tasks.dll</HintPath>
     </Reference>

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -4,6 +4,7 @@
       "dependencies": {
         "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
         "System.Collections.Immutable": "1.3.1",
+        "System.IO.Compression": "4.3.0",
         "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
         "System.Threading.Tasks.Dataflow": "4.5.24.0"
       }
@@ -17,6 +18,7 @@
         "System.Diagnostics.FileVersionInfo": "4.0.0",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TraceSource": "4.0.0",
+        "System.IO.Compression": "4.1.0",
         "System.IO.FileSystem": "4.0.1",
         "System.IO.Pipes": "4.0.0",
         "System.Linq.Parallel": "4.0.1",

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -149,6 +149,7 @@
 
   <!-- The VSIX installer manifest references
         System.Collections.Immutable,
+        System.IO.Compression,
         System.Threading.Tasks.Dataflow,
         System.Runtime.InteropServices.RuntimeInformation
         from the Output folder, but they won't be placed there
@@ -167,6 +168,7 @@
           SkipUnchangedFiles="true"
           Condition=
           "'%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Collections.Immutable' or
+          '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.IO.Compression' or
           '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Threading.Tasks.Dataflow' or
           '%(ResolvedRuntimeFiles.NuGetPackageId)' == 'System.Runtime.InteropServices.RuntimeInformation'"
           />

--- a/targets/runtimeDependencies/project.json
+++ b/targets/runtimeDependencies/project.json
@@ -10,14 +10,14 @@
   "dependencies": {
     "xunit": "2.1.0",
     "microsoft.xunit.netcore.extensions": "1.0.0-prerelease-00629-09",
-    "System.IO.FileSystem": "4.0.1",
-    "System.IO.Compression": "4.1.0"
+    "System.IO.FileSystem": "4.0.1"
   },
   "frameworks": {
     "net46": {
       "dependencies": {
         "xunit.runner.visualstudio": "2.1.0",
         "System.Collections.Immutable": "1.3.1",
+        "System.IO.Compression": "4.3.0",
         "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
         "System.Threading.Tasks.Dataflow": "4.5.24.0",
         "Microsoft.DotNet.BuildTools.TestSuite": "1.0.0-prerelease-00508-01"
@@ -32,6 +32,7 @@
         "Microsoft.NETCore.Platforms": "1.0.1",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Console": "4.0.0",
+        "System.IO.Compression": "4.1.0",
         "System.IO.FileSystem.Watcher": "4.0.0",
         "System.IO.FileSystem.DriveInfo": "4.0.0",
         "System.IO.Pipes": "4.0.0",


### PR DESCRIPTION
VS is using 4.1.2.0 (nuget 4.3.0) whereas we were accidentally using 4.1.0.0 (nuget 4.1.0). This caused the loader to not use NGENed assemblies.