### PR TITLE
RAR performance improvements on Core

### DIFF
--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -32,6 +32,15 @@ namespace Microsoft.Build.Utilities
 
         public readonly bool DoNotLogProjectImports = Environment.GetEnvironmentVariable("MSBUILDDONOTLOGIMPORTS") == "1";
 
+        public readonly bool CacheAssemblyInformation =
+#if FEATURE_ASSEMBLY_LOADFROM
+            // On full framework, default to old/well-tested/known-good behavior, but allow an opt in.
+            Environment.GetEnvironmentVariable("MSBUILDCACHERARASSEMBLYINFORMATION") == "1";
+#else
+            // On .NET Core, go for speed, but allow an opt out.
+            Environment.GetEnvironmentVariable("MSBUILDDONOTCACHERARASSEMBLYINFORMATION") != "1";
+#endif
+
         public readonly ProjectInstanceTranslationMode? ProjectInstanceTranslation = ComputeProjectInstanceTranslation();
 
         /// <summary>

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -32,14 +32,10 @@ namespace Microsoft.Build.Utilities
 
         public readonly bool DoNotLogProjectImports = Environment.GetEnvironmentVariable("MSBUILDDONOTLOGIMPORTS") == "1";
 
-        public readonly bool CacheAssemblyInformation =
-#if FEATURE_ASSEMBLY_LOADFROM
-            // On full framework, default to old/well-tested/known-good behavior, but allow an opt in.
-            Environment.GetEnvironmentVariable("MSBUILDCACHERARASSEMBLYINFORMATION") == "1";
-#else
-            // On .NET Core, go for speed, but allow an opt out.
-            Environment.GetEnvironmentVariable("MSBUILDDONOTCACHERARASSEMBLYINFORMATION") != "1";
-#endif
+        /// <summary>
+        /// Read information only once per file per ResolveAssemblyReference invocation.
+        /// </summary>
+        public readonly bool CacheAssemblyInformation = Environment.GetEnvironmentVariable("MSBUILDDONOTCACHERARASSEMBLYINFORMATION") != "1";
 
         public readonly ProjectInstanceTranslationMode? ProjectInstanceTranslation = ComputeProjectInstanceTranslation();
 

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3263,7 +3263,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <returns></returns>
         private ReferenceTable GenerateTableWithAssemblyFromTheGlobalLocation(string location)
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false);
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false, null);
 
             AssemblyNameExtension assemblyNameExtension = new AssemblyNameExtension(new AssemblyName("Microsoft.VisualStudio.Interopt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"));
             TaskItem taskItem = new TaskItem("Microsoft.VisualStudio.Interopt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
@@ -6903,7 +6903,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ReferenceTableDependentItemsInBlackList4()
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false);
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false, null);
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
             Hashtable blackList;
@@ -7079,7 +7079,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
         private static ReferenceTable MakeEmptyReferenceTable(TaskLoggingHelper log)
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, log, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false);
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, log, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false, null);
             return referenceTable;
         }
 

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -11,6 +11,7 @@ using Microsoft.Win32;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 using Xunit;
+using System.Collections.Concurrent;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -1718,6 +1719,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         internal static void GetAssemblyMetadata
         (
             string path,
+            ConcurrentDictionary<string, AssemblyInformation> cache,
             out AssemblyNameExtension[] dependencies,
             out string[] scatterFiles,
             out FrameworkNameVersioning frameworkName

--- a/src/Tasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyInformation.cs
@@ -337,6 +337,12 @@ namespace Microsoft.Build.Tasks
 
             return frameworkAttribute;
 #else
+            return CoreGetFrameworkName();
+#endif
+        }
+
+        private FrameworkName CoreGetFrameworkName()
+        {
             using (var stream = File.OpenRead(_sourceFile))
             using (var peFile = new PEReader(stream))
             {
@@ -353,8 +359,8 @@ namespace Microsoft.Build.Tasks
                         continue;
                     }
 
-                    var container = metadataReader.GetMemberReference((MemberReferenceHandle)ctorHandle).Parent;
-                    var name = metadataReader.GetTypeReference((TypeReferenceHandle)container).Name;
+                    var container = metadataReader.GetMemberReference((MemberReferenceHandle) ctorHandle).Parent;
+                    var name = metadataReader.GetTypeReference((TypeReferenceHandle) container).Name;
                     if (!string.Equals(metadataReader.GetString(name), "TargetFrameworkAttribute"))
                     {
                         continue;
@@ -365,11 +371,9 @@ namespace Microsoft.Build.Tasks
                     {
                         return new FrameworkName(arguments[0]);
                     }
-
                 }
             }
             return null;
-#endif
         }
 
 // Enabling this for MONO, because it's required by GetFrameworkName.
@@ -588,6 +592,12 @@ namespace Microsoft.Build.Tasks
             return (AssemblyNameExtension[])asmRefs.ToArray(typeof(AssemblyNameExtension));
 #else
 
+            return CoreImportAssemblyDependencies();
+#endif
+        }
+
+        private AssemblyNameExtension[] CoreImportAssemblyDependencies()
+        {
             List<AssemblyNameExtension> ret = new List<AssemblyNameExtension>();
 
             using (var stream = File.OpenRead(_sourceFile))
@@ -615,14 +625,13 @@ namespace Microsoft.Build.Tasks
                             assemblyName.SetPublicKey(publicKeyOrToken);
                         }
                     }
-                    assemblyName.Flags = (AssemblyNameFlags)(int)entry.Flags;
+                    assemblyName.Flags = (AssemblyNameFlags) (int) entry.Flags;
 
                     ret.Add(new AssemblyNameExtension(assemblyName));
                 }
             }
 
             return ret.ToArray();
-#endif
         }
 
         /// <summary>

--- a/src/Tasks/Delegate.cs
+++ b/src/Tasks/Delegate.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
@@ -85,6 +86,7 @@ namespace Microsoft.Build.Tasks
     internal delegate void GetAssemblyMetadata
     (
         string path,
+        ConcurrentDictionary<string, AssemblyInformation> cache,
         out AssemblyNameExtension[] dependencies,
         out string[] scatterFiles,
         out FrameworkName frameworkNameAttribute

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -469,6 +469,7 @@ namespace Microsoft.Build.Tasks
         private void GetAssemblyMetadata
         (
             string path,
+            ConcurrentDictionary<string, AssemblyInformation> cache,
             out AssemblyNameExtension[] dependencies,
             out string[] scatterFiles,
             out FrameworkName frameworkName
@@ -480,6 +481,7 @@ namespace Microsoft.Build.Tasks
                 getAssemblyMetadata
                 (
                     path,
+                    cache,
                     out fileState.dependencies,
                     out fileState.scatterFiles,
                     out fileState.frameworkName


### PR DESCRIPTION
I recommend going through this commit-by-commit; a couple of commits are straightforward refactors that look complicated in the final diff.

There are two improvements here:
* When using the non-Full Framework `AssemblyInformation` extraction, read a file only once, populating `Dependencies` and `FrameworkName` with a single `FileStream`
* Read `AssemblyInformation` from a given path exactly once (instead of twice).

This chips away at #2015.