### PR TITLE
Don't force Verbosity to Diag with /bl

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2738,11 +2738,6 @@ namespace Microsoft.Build.CommandLine
             BinaryLogger logger = new BinaryLogger();
             logger.Parameters = arguments;
 
-            // If we have a binary logger, force verbosity to diagnostic.
-            // The only place where verbosity is used downstream is to determine whether to log task inputs.
-            // Since we always want task inputs for a binary logger, set it to diagnostic.
-            verbosity = LoggerVerbosity.Diagnostic;
-
             loggers.Add(logger);
         }
 


### PR DESCRIPTION
It turns out that some tasks log a ridiculous amount of information as part of log task inputs. We see upwards of 5GB of strings logged as task inputs to Nuget.

To alleviate this pressure let's remove this, since the users will always have the easy option to manually add /v:diag to force logging task inputs.

For now not having this option is better since otherwise binary logger can crash people's builds.