### PR TITLE
Revert "Always use response file for winmdexp (#2177)"

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1166,7 +1166,7 @@ namespace Microsoft.Build.Tasks
         public bool UTF8Output { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public string WinMDModule { get { throw null; } set { } }
-        protected internal override void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override string GenerateFullPathToTool() { throw null; }
         protected override bool SkipTaskExecution() { throw null; }
         protected override bool ValidateParameters() { throw null; }

--- a/src/Tasks.UnitTests/WinMDExp_Tests.cs
+++ b/src/Tasks.UnitTests/WinMDExp_Tests.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Build.UnitTests
             CommandLine.ValidateHasParameter(
                 t,
                 "/reference:mscorlib.dll",
-                useResponseFile: true);
+                false);
             CommandLine.ValidateHasParameter(
                 t,
                 "/reference:Windows.Foundation.winmd",
-                useResponseFile: true);
+                false);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.DisabledWarnings = "41999,42016";
-            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", false);
         }
 
 
@@ -61,8 +61,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputDocumentationFile = "output.xml";
             t.InputDocumentationFile = "input.xml";
 
-            CommandLine.ValidateHasParameter(t, "/d:output.xml", useResponseFile: true);
-            CommandLine.ValidateHasParameter(t, "/md:input.xml", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/d:output.xml", false);
+            CommandLine.ValidateHasParameter(t, "/md:input.xml", false);
         }
 
         [Fact]
@@ -74,8 +74,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputPDBFile = "output.pdb";
             t.InputPDBFile = "input.pdb";
 
-            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", useResponseFile: true);
-            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", false);
+            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", false);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
 
             t.WinMDModule = "Foo.dll";
-            CommandLine.ValidateContains(t, "Foo.dll", useResponseFile: true);
+            CommandLine.ValidateContains(t, "Foo.dll", false);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Bob.winmd";
-            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", false);
         }
 
         [Fact]
@@ -103,7 +103,12 @@ namespace Microsoft.Build.UnitTests
 
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Foo.winmd";
-            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", false);
         }
     }
 }
+
+
+
+
+

--- a/src/Tasks/WinMDExp.cs
+++ b/src/Tasks/WinMDExp.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Tasks
         /// executing this tool
         /// </summary>
         /// <param name="commandLine">Gets filled with command line commands</param>
-        protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
+        protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
         {
             commandLine.AppendSwitchIfNotNull("/d:", OutputDocumentationFile);
             commandLine.AppendSwitchIfNotNull("/md:", InputDocumentationFile);


### PR DESCRIPTION
This reverts commit 184da1a84e1aaa3b2e4c0198154c66fa8858e0cd.

That commit compiled and produced reasonable output but the output is not accepted by (the current version of?) `winmdexp.exe`, which expects that arguments in the response file are newline rather than space separated.

@yizhang82 @AndyGerlicher 