### PR TITLE
Late bind CopyUpToDateMarker

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -348,11 +348,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup>
     <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
     <_GenerateBindingRedirectsIntermediateAppConfig>$(IntermediateOutputPath)$(MSBuildProjectFile).$(TargetFileName).config</_GenerateBindingRedirectsIntermediateAppConfig>
-    <CopyUpToDateMarker>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', '$(MSBuildProjectFile).CopyComplete'))</CopyUpToDateMarker>
   </PropertyGroup>
   <ItemGroup>
     <IntermediateAssembly Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt)"/>
     <FinalDocFile Include="@(DocFileItem->'$(OutDir)%(Filename)%(Extension)')"/>
+    <CopyUpToDateMarker Include="$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', '$(MSBuildProjectFile).CopyComplete'))" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ProduceReferenceAssembly)' == 'true'">
@@ -1835,7 +1835,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
         <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
         <ReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == 'true'">$(TargetRefPath)</ReferenceAssembly>
-        <CopyUpToDateMarker>$(CopyUpToDateMarker)</CopyUpToDateMarker>
+        <CopyUpToDateMarker>@(CopyUpToDateMarker)</CopyUpToDateMarker>
       </TargetPathWithTargetPlatformMoniker>
     </ItemGroup>
   </Target>
@@ -4237,7 +4237,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          references on this build, subsequent builds of projects that depend on it must
          not be considered up to date, so touch this marker file that is considered an
          input to projects that reference this one. -->
-    <Touch Files="$(CopyUpToDateMarker)"
+    <Touch Files="@(CopyUpToDateMarker)"
            AlwaysCreate="true"
            Condition="'@(ReferencesCopiedInThisBuild)' != ''" />
 


### PR DESCRIPTION
PR #2180 caused a performance-test scenario internal to Microsoft to
start failing. The root cause was that the projects in the test
customized `$(IntermediateOutputPath)` _very_ late, after importing
CSharp.targets (and transitively Common.targets). That meant that the
path stored in `$(CopyOutOfDateMarker)` was no longer under
`$(IntermediateOutputPath)`, and that the directory wasn't created before
the new code attempted to touch the marker file.

Ideally, projects would set `IntermediateOutputPath` _before_ importing
common.targets, but that hasn't been strictly required in all cases
before so requiring it now is an unacceptable regression.

The late customization was handled for other intermediate outputs by
defining their paths with items (expanded after all properties are
expanded) rather than properties (expanded in order).

There are other properties defined by using `$(IntermediateOutputPath)`,
`$(_GenerateBindingRedirectsIntermediateAppConfig)` and
`$(WinMDExpOutputPdb)`. This PR doesn't change those since they weren't
recently regressed.