### PR TITLE
Use newline-delimited response file for winmdexp

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1166,8 +1166,9 @@ namespace Microsoft.Build.Tasks
         public bool UTF8Output { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public string WinMDModule { get { throw null; } set { } }
-        protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected internal override void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override string GenerateFullPathToTool() { throw null; }
+        protected override string GenerateResponseFileCommands() { throw null; }
         protected override bool SkipTaskExecution() { throw null; }
         protected override bool ValidateParameters() { throw null; }
     }

--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Build.Utilities
         public void AppendFileNamesIfNotNull(string[] fileNames, string delimiter) { }
         protected void AppendFileNameWithQuoting(string fileName) { }
         protected void AppendQuotedTextToBuffer(System.Text.StringBuilder buffer, string unquotedTextToAppend) { }
-        protected void AppendSpaceIfNotEmpty() { }
+        protected virtual void AppendSpaceIfNotEmpty() { }
         public void AppendSwitch(string switchName) { }
         public void AppendSwitchIfNotNull(string switchName, Microsoft.Build.Framework.ITaskItem parameter) { }
         public void AppendSwitchIfNotNull(string switchName, Microsoft.Build.Framework.ITaskItem[] parameters, string delimiter) { }

--- a/src/Tasks.UnitTests/WinMDExp_Tests.cs
+++ b/src/Tasks.UnitTests/WinMDExp_Tests.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Build.UnitTests
             CommandLine.ValidateHasParameter(
                 t,
                 "/reference:mscorlib.dll",
-                false);
+                useResponseFile: true);
             CommandLine.ValidateHasParameter(
                 t,
                 "/reference:Windows.Foundation.winmd",
-                false);
+                useResponseFile: true);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.DisabledWarnings = "41999,42016";
-            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", false);
+            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", useResponseFile: true);
         }
 
 
@@ -61,8 +61,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputDocumentationFile = "output.xml";
             t.InputDocumentationFile = "input.xml";
 
-            CommandLine.ValidateHasParameter(t, "/d:output.xml", false);
-            CommandLine.ValidateHasParameter(t, "/md:input.xml", false);
+            CommandLine.ValidateHasParameter(t, "/d:output.xml", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/md:input.xml", useResponseFile: true);
         }
 
         [Fact]
@@ -74,8 +74,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputPDBFile = "output.pdb";
             t.InputPDBFile = "input.pdb";
 
-            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", false);
-            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", false);
+            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", useResponseFile: true);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
 
             t.WinMDModule = "Foo.dll";
-            CommandLine.ValidateContains(t, "Foo.dll", false);
+            CommandLine.ValidateContains(t, "Foo.dll", useResponseFile: true);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Bob.winmd";
-            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", false);
+            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", useResponseFile: true);
         }
 
         [Fact]
@@ -103,12 +103,7 @@ namespace Microsoft.Build.UnitTests
 
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Foo.winmd";
-            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", false);
+            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", useResponseFile: true);
         }
     }
 }
-
-
-
-
-

--- a/src/Tasks/WinMDExp.cs
+++ b/src/Tasks/WinMDExp.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Tasks
         /// executing this tool
         /// </summary>
         /// <param name="commandLine">Gets filled with command line commands</param>
-        protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
+        protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
             commandLine.AppendSwitchIfNotNull("/d:", OutputDocumentationFile);
             commandLine.AppendSwitchIfNotNull("/md:", InputDocumentationFile);
@@ -277,6 +277,24 @@ namespace Microsoft.Build.Tasks
             commandLine.AppendFileNameIfNotNull(WinMDModule);
 
             base.AddCommandLineCommands(commandLine);
+        }
+
+        private class NewlineCommandLineBuilder : CommandLineBuilderExtension
+        {
+            override protected void AppendSpaceIfNotEmpty()
+            {
+                if (CommandLine.Length != 0)
+                {
+                    CommandLine.Append(Environment.NewLine);
+                }
+            }
+        }
+
+        override protected string GenerateResponseFileCommands()
+        {
+            CommandLineBuilderExtension commandLineBuilder = new NewlineCommandLineBuilder();
+            AddResponseFileCommands(commandLineBuilder);
+            return commandLineBuilder.ToString();
         }
 
         /// <summary>

--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Utilities
         /// <remarks>
         /// This is a pretty obscure method and so it's only available to inherited classes.
         /// </remarks>
-        protected void AppendSpaceIfNotEmpty()
+        protected virtual void AppendSpaceIfNotEmpty()
         {
             if (CommandLine.Length != 0 && CommandLine[CommandLine.Length - 1] != ' ')
             {


### PR DESCRIPTION
Winmdexp requires response files with one argument per line, and can't
handle ToolTask's default one-long-line-with-spaces response files. So
create a new CommandLineBuilderExtension that appends newlines instead
of spaces between arguments and use it in winmdexp.

Reverts 0174f995. Fixes #2140.