### PR TITLE
Revert RAR AssemblyInformation caching

### DIFF
--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -32,11 +32,6 @@ namespace Microsoft.Build.Utilities
 
         public readonly bool DoNotLogProjectImports = Environment.GetEnvironmentVariable("MSBUILDDONOTLOGIMPORTS") == "1";
 
-        /// <summary>
-        /// Read information only once per file per ResolveAssemblyReference invocation.
-        /// </summary>
-        public readonly bool CacheAssemblyInformation = Environment.GetEnvironmentVariable("MSBUILDDONOTCACHERARASSEMBLYINFORMATION") != "1";
-
         public readonly ProjectInstanceTranslationMode? ProjectInstanceTranslation = ComputeProjectInstanceTranslation();
 
         /// <summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3263,7 +3263,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <returns></returns>
         private ReferenceTable GenerateTableWithAssemblyFromTheGlobalLocation(string location)
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false, null);
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false);
 
             AssemblyNameExtension assemblyNameExtension = new AssemblyNameExtension(new AssemblyName("Microsoft.VisualStudio.Interopt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"));
             TaskItem taskItem = new TaskItem("Microsoft.VisualStudio.Interopt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
@@ -6903,7 +6903,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ReferenceTableDependentItemsInBlackList4()
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false, null);
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false);
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
             Hashtable blackList;
@@ -7079,7 +7079,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
         private static ReferenceTable MakeEmptyReferenceTable(TaskLoggingHelper log)
         {
-            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, log, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false, null);
+            ReferenceTable referenceTable = new ReferenceTable(null, false, false, false, false, new string[0], null, null, null, null, null, null, SystemProcessorArchitecture.None, fileExists, null, null, null, null, null, null, null, null, null, new Version("4.0"), null, log, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false);
             return referenceTable;
         }
 

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -11,7 +11,6 @@ using Microsoft.Win32;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 using Xunit;
-using System.Collections.Concurrent;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -1719,7 +1718,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         internal static void GetAssemblyMetadata
         (
             string path,
-            ConcurrentDictionary<string, AssemblyInformation> cache,
             out AssemblyNameExtension[] dependencies,
             out string[] scatterFiles,
             out FrameworkNameVersioning frameworkName

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -160,8 +159,6 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private WarnOrErrorOnTargetArchitectureMismatchBehavior _warnOrErrorOnTargetArchitectureMismatch = WarnOrErrorOnTargetArchitectureMismatchBehavior.Warning;
 
-        private ConcurrentDictionary<string, AssemblyInformation> _assemblyInformationCache;
-
         /// <summary>
         /// When we exclude an assembly from resolution because it is part of out exclusion list we need to let the user know why this is. 
         /// There can be a number of reasons each for un-resolving a reference, these reasons are encapsulated by a different black list. We need to log a specific message 
@@ -179,10 +176,9 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Construct.
         /// </summary>
-        /// <param name="buildEngine"></param>
         /// <param name="findDependencies">If true, then search for dependencies.</param>
         /// <param name="findSatellites">If true, then search for satellite files.</param>
-        /// <param name="findSerializationAssemblies">If true, then search for serialization assembly files.</param>
+        /// <param name="findSerializatoinAssemblies">If true, then search for serialization assembly files.</param>
         /// <param name="findRelatedFiles">If true, then search for related files.</param>
         /// <param name="searchPaths">Paths to search for dependent assemblies on.</param>
         /// <param name="candidateAssemblyFiles">List of literal assembly file names to be considered when SearchPaths has {CandidateAssemblyFiles}.</param>
@@ -236,8 +232,7 @@ namespace Microsoft.Build.Tasks
             ReadMachineTypeFromPEHeader readMachineTypeFromPEHeader,
             WarnOrErrorOnTargetArchitectureMismatchBehavior warnOrErrorOnTargetArchitectureMismatch,
             bool ignoreFrameworkAttributeVersionMismatch,
-            bool unresolveFrameworkAssembliesFromHigherFrameworks,
-            ConcurrentDictionary<string, AssemblyInformation> assemblyInformationCache
+            bool unresolveFrameworkAssembliesFromHigherFrameworks
         )
         {
             _buildEngine = buildEngine;
@@ -271,8 +266,6 @@ namespace Microsoft.Build.Tasks
             _readMachineTypeFromPEHeader = readMachineTypeFromPEHeader;
             _warnOrErrorOnTargetArchitectureMismatch = warnOrErrorOnTargetArchitectureMismatch;
             _ignoreFrameworkAttributeVersionMismatch = ignoreFrameworkAttributeVersionMismatch;
-
-            _assemblyInformationCache = assemblyInformationCache;
 
             // Set condition for when to check assembly version against the target framework version 
             _checkAssemblyVersionAgainstTargetFrameworkVersion = unresolveFrameworkAssembliesFromHigherFrameworks || ((_projectTargetFramework ?? ReferenceTable.s_targetFrameworkVersion_40) <= ReferenceTable.s_targetFrameworkVersion_40);
@@ -1013,7 +1006,6 @@ namespace Microsoft.Build.Tasks
             _getAssemblyMetadata
             (
                 reference.FullPath,
-                _assemblyInformationCache,
                 out dependentAssemblies,
                 out scatterFiles,
                 out frameworkName

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Diagnostics;
 using System.Reflection;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 using Microsoft.Build.Framework;
@@ -55,10 +54,6 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public ResolveAssemblyReference()
         {
-            if (Traits.Instance.EscapeHatches.CacheAssemblyInformation)
-            {
-                _assemblyInformationCache = new ConcurrentDictionary<string, AssemblyInformation>();
-            }
         }
 
         #region Properties
@@ -864,8 +859,6 @@ namespace Microsoft.Build.Tasks
         /// Storage for names of all files writen to disk.
         /// </summary>
         private ArrayList _filesWritten = new ArrayList();
-
-        private readonly ConcurrentDictionary<string, AssemblyInformation> _assemblyInformationCache;
 
         /// <summary>
         /// The names of all files written to disk.
@@ -2130,8 +2123,8 @@ namespace Microsoft.Build.Tasks
                         readMachineTypeFromPEHeader,
                         _warnOrErrorOnTargetArchitectureMismatch,
                         _ignoreTargetFrameworkAttributeVersionMismatch,
-                        _unresolveFrameworkAssembliesFromHigherFrameworks,
-                        _assemblyInformationCache);
+                        _unresolveFrameworkAssembliesFromHigherFrameworks
+                        );
 
                     // If AutoUnify, then compute the set of assembly remappings.
                     ArrayList generalResolutionExceptions = new ArrayList();
@@ -2386,7 +2379,7 @@ namespace Microsoft.Build.Tasks
                     // in case of P2P that have not build the reference can be resolved but file does not exist on disk. 
                     if (fileExists(resolvedReference.FullPath))
                     {
-                        getAssemblyMetadata(resolvedReference.FullPath, _assemblyInformationCache, out result, out scatterFiles, out frameworkName);
+                        getAssemblyMetadata(resolvedReference.FullPath, out result, out scatterFiles, out frameworkName);
                     }
                 }
                 catch (Exception e)

--- a/src/Tasks/Delegate.cs
+++ b/src/Tasks/Delegate.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.IO;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
@@ -86,7 +85,6 @@ namespace Microsoft.Build.Tasks
     internal delegate void GetAssemblyMetadata
     (
         string path,
-        ConcurrentDictionary<string, AssemblyInformation> cache,
         out AssemblyNameExtension[] dependencies,
         out string[] scatterFiles,
         out FrameworkName frameworkNameAttribute

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -469,7 +469,6 @@ namespace Microsoft.Build.Tasks
         private void GetAssemblyMetadata
         (
             string path,
-            ConcurrentDictionary<string, AssemblyInformation> cache,
             out AssemblyNameExtension[] dependencies,
             out string[] scatterFiles,
             out FrameworkName frameworkName
@@ -481,7 +480,6 @@ namespace Microsoft.Build.Tasks
                 getAssemblyMetadata
                 (
                     path,
-                    cache,
                     out fileState.dependencies,
                     out fileState.scatterFiles,
                     out fileState.frameworkName


### PR DESCRIPTION
In .NET Core, it's safe to use an AssemblyInformation object without
disposing it, but that's not true in full framework because of the use
of COM objects to extract information from the assembly. Backing out the
cache until we can test a fix that correctly disposes the objects
(including for RAR failures and exceptions).

This reverts commit be56bc33a441ec97d91861a44d63c52a489e747f.

This reverts commit 55f846e7c290828f798fcba4c148708ad2d4510b.