### PR TITLE
Add ability to use newline separators in response files and update WinMDExp task to use it

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Build.Tasks
     public partial class CommandLineBuilderExtension : Microsoft.Build.Utilities.CommandLineBuilder
     {
         public CommandLineBuilderExtension() { }
+        public CommandLineBuilderExtension(bool quoteHyphensOnCommandLine, bool useNewLineSeparator) { }
         protected string GetQuotedText(string unquotedText) { throw null; }
     }
     public partial class ConvertToAbsolutePath : Microsoft.Build.Tasks.TaskExtension
@@ -1095,6 +1096,7 @@ namespace Microsoft.Build.Tasks
         protected internal System.Collections.Hashtable Bag { get { throw null; } }
         protected override bool HasLoggedErrors { get { throw null; } }
         public new Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
+        protected virtual bool UseNewLineSeparatorInResponseFile { get { throw null; } }
         protected internal virtual void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected internal virtual void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override string GenerateCommandLineCommands() { throw null; }

--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1165,10 +1165,11 @@ namespace Microsoft.Build.Tasks
         protected override System.Text.Encoding StandardOutputEncoding { get { throw null; } }
         protected override string ToolName { get { throw null; } }
         public bool TreatWarningsAsErrors { get { throw null; } set { } }
+        protected override bool UseNewLineSeparatorInResponseFile { get { throw null; } }
         public bool UTF8Output { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public string WinMDModule { get { throw null; } set { } }
-        protected internal override void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
+        protected internal override void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override string GenerateFullPathToTool() { throw null; }
         protected override bool SkipTaskExecution() { throw null; }
         protected override bool ValidateParameters() { throw null; }

--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Build.Utilities
     {
         public CommandLineBuilder() { }
         public CommandLineBuilder(bool quoteHyphensOnCommandLine) { }
+        public CommandLineBuilder(bool quoteHyphensOnCommandLine, bool useNewLineSeparator) { }
         protected System.Text.StringBuilder CommandLine { get { throw null; } }
         public int Length { get { throw null; } }
         public void AppendFileNameIfNotNull(Microsoft.Build.Framework.ITaskItem fileItem) { }

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Build.Tasks
     public partial class CommandLineBuilderExtension : Microsoft.Build.Utilities.CommandLineBuilder
     {
         public CommandLineBuilderExtension() { }
+        public CommandLineBuilderExtension(bool quoteHyphensOnCommandLine, bool useNewLineSeparator) { }
         protected string GetQuotedText(string unquotedText) { throw null; }
     }
     public partial class ConvertToAbsolutePath : Microsoft.Build.Tasks.TaskExtension
@@ -600,6 +601,7 @@ namespace Microsoft.Build.Tasks
         protected internal System.Collections.Hashtable Bag { get { throw null; } }
         protected override bool HasLoggedErrors { get { throw null; } }
         public new Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }
+        protected virtual bool UseNewLineSeparatorInResponseFile { get { throw null; } }
         protected internal virtual void AddCommandLineCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected internal virtual void AddResponseFileCommands(Microsoft.Build.Tasks.CommandLineBuilderExtension commandLine) { }
         protected override string GenerateCommandLineCommands() { throw null; }

--- a/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Build.Utilities
     {
         public CommandLineBuilder() { }
         public CommandLineBuilder(bool quoteHyphensOnCommandLine) { }
+        public CommandLineBuilder(bool quoteHyphensOnCommandLine, bool useNewLineSeparator) { }
         protected System.Text.StringBuilder CommandLine { get { throw null; } }
         public int Length { get { throw null; } }
         public void AppendFileNameIfNotNull(Microsoft.Build.Framework.ITaskItem fileItem) { }

--- a/src/Tasks.UnitTests/WinMDExp_Tests.cs
+++ b/src/Tasks.UnitTests/WinMDExp_Tests.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Build.UnitTests
             CommandLine.ValidateHasParameter(
                 t,
                 "/reference:mscorlib.dll",
-                false);
+                useResponseFile: true);
             CommandLine.ValidateHasParameter(
                 t,
                 "/reference:Windows.Foundation.winmd",
-                false);
+                useResponseFile: true);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.DisabledWarnings = "41999,42016";
-            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", false);
+            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", useResponseFile: true);
         }
 
 
@@ -61,8 +61,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputDocumentationFile = "output.xml";
             t.InputDocumentationFile = "input.xml";
 
-            CommandLine.ValidateHasParameter(t, "/d:output.xml", false);
-            CommandLine.ValidateHasParameter(t, "/md:input.xml", false);
+            CommandLine.ValidateHasParameter(t, "/d:output.xml", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/md:input.xml", useResponseFile: true);
         }
 
         [Fact]
@@ -74,8 +74,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputPDBFile = "output.pdb";
             t.InputPDBFile = "input.pdb";
 
-            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", false);
-            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", false);
+            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", useResponseFile: true);
+            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", useResponseFile: true);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
 
             t.WinMDModule = "Foo.dll";
-            CommandLine.ValidateContains(t, "Foo.dll", false);
+            CommandLine.ValidateContains(t, "Foo.dll", useResponseFile: true);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Bob.winmd";
-            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", false);
+            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", useResponseFile: true);
         }
 
         [Fact]
@@ -103,7 +103,45 @@ namespace Microsoft.Build.UnitTests
 
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Foo.winmd";
-            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", false);
+            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", useResponseFile: true);
+        }
+
+        [Fact]
+        public void ArgumentsAreUnquoted()
+        {
+            WinMDExp t = new WinMDExp
+            {
+                AssemblyUnificationPolicy = "sp ace",
+                InputDocumentationFile = "sp ace",
+                InputPDBFile = "sp ace",
+                References = new ITaskItem[]
+                {
+                    new TaskItem(@"sp ace"),
+                },
+                OutputDocumentationFile = "sp ace",
+                OutputPDBFile = "sp ace",
+                OutputWindowsMetadataFile = "sp ace",
+                WinMDModule = "sp ace",
+            };
+
+            CommandLineBuilderExtension c = new CommandLineBuilderExtension(quoteHyphensOnCommandLine: false, useNewLineSeparator: true);
+
+            t.AddResponseFileCommands(c);
+
+            string[] actual = c.ToString().Split(new [] { Environment.NewLine }, StringSplitOptions.None);
+            string[] expected =
+            {
+                "/d:sp ace",
+                "/md:sp ace",
+                "/mp:sp ace",
+                "/pdb:sp ace",
+                "/assemblyunificationpolicy:sp ace",
+                "/out:sp ace",
+                "/reference:sp ace",
+                "sp ace",
+            };
+
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/Tasks/CommandLineBuilderExtension.cs
+++ b/src/Tasks/CommandLineBuilderExtension.cs
@@ -17,6 +17,23 @@ namespace Microsoft.Build.Tasks
     public class CommandLineBuilderExtension : CommandLineBuilder
     {
         /// <summary>
+        /// Initializes a new instance of the CommandLineBuilderExtension class.
+        /// </summary>
+        public CommandLineBuilderExtension()
+        {
+            
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the CommandLineBuilderExtension class.
+        /// </summary>
+        public CommandLineBuilderExtension(bool quoteHyphensOnCommandLine, bool useNewLineSeparator)
+            : base(quoteHyphensOnCommandLine, useNewLineSeparator)
+        {
+            
+        }
+
+        /// <summary>
         /// Set a boolean switch iff its value exists and its value is 'true'.
         /// </summary>
         /// <param name="switchName"></param>

--- a/src/Tasks/ToolTaskExtension.cs
+++ b/src/Tasks/ToolTaskExtension.cs
@@ -78,6 +78,17 @@ namespace Microsoft.Build.Tasks
 
         private Hashtable _bag = new Hashtable();
 
+        /// <summary>
+        /// When set to true, the response file will use new lines instead of spaces to separate arguments.
+        /// </summary>
+        protected virtual bool UseNewLineSeparatorInResponseFile
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         #endregion
 
         #region Methods
@@ -119,7 +130,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         override protected string GenerateResponseFileCommands()
         {
-            CommandLineBuilderExtension commandLineBuilder = new CommandLineBuilderExtension();
+            CommandLineBuilderExtension commandLineBuilder = new CommandLineBuilderExtension(quoteHyphensOnCommandLine: false, useNewLineSeparator: UseNewLineSeparatorInResponseFile);
             AddResponseFileCommands(commandLineBuilder);
             return commandLineBuilder.ToString();
         }

--- a/src/Tasks/WinMDExp.cs
+++ b/src/Tasks/WinMDExp.cs
@@ -238,29 +238,32 @@ namespace Microsoft.Build.Tasks
             }
         }
 
+        protected override bool UseNewLineSeparatorInResponseFile
+        {
+            get
+            {
+                return true;
+            }
+        }
+
         #endregion
 
         #region Tool Members
 
-        /// <summary>
-        /// Fills the provided CommandLineBuilderExtension with all the command line options used when
-        /// executing this tool
-        /// </summary>
-        /// <param name="commandLine">Gets filled with command line commands</param>
-        protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
+        protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)
         {
-            commandLine.AppendSwitchIfNotNull("/d:", OutputDocumentationFile);
-            commandLine.AppendSwitchIfNotNull("/md:", InputDocumentationFile);
-            commandLine.AppendSwitchIfNotNull("/mp:", InputPDBFile);
-            commandLine.AppendSwitchIfNotNull("/pdb:", OutputPDBFile);
-            commandLine.AppendSwitchIfNotNull("/assemblyunificationpolicy:", AssemblyUnificationPolicy);
+            commandLine.AppendSwitchUnquotedIfNotNull("/d:", OutputDocumentationFile);
+            commandLine.AppendSwitchUnquotedIfNotNull("/md:", InputDocumentationFile);
+            commandLine.AppendSwitchUnquotedIfNotNull("/mp:", InputPDBFile);
+            commandLine.AppendSwitchUnquotedIfNotNull("/pdb:", OutputPDBFile);
+            commandLine.AppendSwitchUnquotedIfNotNull("/assemblyunificationpolicy:", AssemblyUnificationPolicy);
 
             if (String.IsNullOrEmpty(OutputWindowsMetadataFile))
             {
                 OutputWindowsMetadataFile = Path.ChangeExtension(WinMDModule, ".winmd");
             }
 
-            commandLine.AppendSwitchIfNotNull("/out:", OutputWindowsMetadataFile);
+            commandLine.AppendSwitchUnquotedIfNotNull("/out:", OutputWindowsMetadataFile);
             commandLine.AppendSwitchWithSplitting("/nowarn:", DisabledWarnings, ",", ';', ',');
             commandLine.AppendWhenTrue("/warnaserror+", this.Bag, "TreatWarningsAsErrors");
             commandLine.AppendWhenTrue("/utf8output", this.Bag, "UTF8Output");
@@ -270,13 +273,14 @@ namespace Microsoft.Build.Tasks
                 // Loop through all the references passed in.  We'll be adding separate
                 foreach (ITaskItem reference in this.References)
                 {
-                    commandLine.AppendSwitchIfNotNull("/reference:", reference.ItemSpec);
+                    commandLine.AppendSwitchUnquotedIfNotNull("/reference:", reference.ItemSpec);
                 }
             }
 
-            commandLine.AppendFileNameIfNotNull(WinMDModule);
-
-            base.AddCommandLineCommands(commandLine);
+            // There is no public method to add unquoted text that includes a separator.  Calling this method with String.Empty adds a separator
+            // and the unquoted text and no parameter.
+            commandLine.AppendSwitchUnquotedIfNotNull(WinMDModule, String.Empty);
+            base.AddResponseFileCommands(commandLine);
         }
 
         /// <summary>

--- a/src/Utilities.UnitTests/CommandLineBuilder_Tests.cs
+++ b/src/Utilities.UnitTests/CommandLineBuilder_Tests.cs
@@ -442,6 +442,28 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(@"/D""A='\""'""", c.ToString()); //   /D"A='\"'"
         }
 
+        [Fact]
+        public void UseNewLineSeparators()
+        {
+            CommandLineBuilder c = new CommandLineBuilder(quoteHyphensOnCommandLine: false, useNewLineSeparator: true);
+
+            c.AppendSwitchIfNotNull("/foo:", "bar");
+            c.AppendFileNameIfNotNull("18056896847C4FFC9706F1D585C077B4");
+            c.AppendSwitch("/D:");
+            c.AppendTextUnquoted("C7E1720B16E5477D8D15733006E68278");
+
+
+            string[] actual = c.ToString().Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+            string[] expected = 
+            {
+                "/foo:bar",
+                "18056896847C4FFC9706F1D585C077B4",
+                "/D:C7E1720B16E5477D8D15733006E68278"
+            };
+
+            Assert.Equal(expected, actual);
+        }
+
         internal class TestCommandLineBuilder : CommandLineBuilder
         {
             internal void TestVerifyThrow(string switchName, string parameter)

--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -76,6 +76,15 @@ namespace Microsoft.Build.Utilities
             _quoteHyphens = quoteHyphensOnCommandLine;
         }
 
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public CommandLineBuilder(bool quoteHyphensOnCommandLine, bool useNewLineSeparator)
+            : this(quoteHyphensOnCommandLine)
+        {
+            _useNewLineSeparator = useNewLineSeparator;
+        }
+
         #endregion
 
         #region Properties
@@ -136,7 +145,12 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         ///  Should hyphens be quoted or not
         /// </summary>
-        private bool _quoteHyphens = false;
+        private readonly bool _quoteHyphens = false;
+
+        /// <summary>
+        /// Should use new line separators instead of spaces to separate arguments.
+        /// </summary>
+        private readonly bool _useNewLineSeparator = false;
 
         /// <summary>
         /// Instead of defining which characters must be quoted, define 
@@ -242,16 +256,23 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        /// Add a space to the specified string if and only if it's not empty. 
+        /// Add a space or newline to the specified string if and only if it's not empty.
         /// </summary>
         /// <remarks>
         /// This is a pretty obscure method and so it's only available to inherited classes.
         /// </remarks>
         protected void AppendSpaceIfNotEmpty()
         {
-            if (CommandLine.Length != 0 && CommandLine[CommandLine.Length - 1] != ' ')
+            if (CommandLine.Length != 0)
             {
-                CommandLine.Append(" ");
+                if (_useNewLineSeparator)
+                {
+                    CommandLine.Append(Environment.NewLine);
+                }
+                else if(CommandLine[CommandLine.Length - 1] != ' ')
+                {
+                    CommandLine.Append(" ");
+                }
             }
         }
 


### PR DESCRIPTION
Update WinMDExp task to use a response file with new line separators

Add new property to CommandLineBuilder and CommandLineBuilderExtension class to use newlines instead of spaces

Add new property to ToolTaskExtension to use newlines in response files instead of spaces.

Update WinMDExp task to use a response file with newline separators and unquoted arguments

WinMDExp fails if there are quotes anywhere in the response file passed
to it, but correctly understands spaces in paths passed to /reference:
when the arguments are newline separated. Avoid ToolTask's default
quoting rules when populating the response file.

Reverts 0174f995. Fixes #2140.