### PR TITLE
Query for OEMCP in core/Windows

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -15,11 +15,11 @@
     <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -15,11 +15,11 @@
     <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -51,6 +51,7 @@
         <dependency id="System.Security.Cryptography.Primitives" version="4.0.0" />
         <dependency id="System.Security.Cryptography.X509Certificates" version="4.1.0" />
         <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.Encoding.CodePages" version="4.0.1" />
         <dependency id="System.Text.Encoding.Extensions" version="4.0.11" />
         <dependency id="System.Text.RegularExpressions" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -43,6 +43,7 @@
         <dependency id="System.Runtime.Serialization.Primitives" version="4.1.1" />
         <dependency id="System.Runtime.Serialization.Xml" version="4.1.1" />
         <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.Encoding.CodePages" version="4.0.1" />
         <dependency id="System.Text.RegularExpressions" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Tasks" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -50,6 +50,7 @@
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" />
         <dependency id="System.Runtime.Loader" version="4.0.0" />
         <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.Encoding.CodePages" version="4.0.1" />
         <dependency id="System.Text.Encoding.Extensions" version="4.0.11" />
         <dependency id="System.Text.RegularExpressions" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/src/Build.OM.UnitTests/project.json
+++ b/src/Build.OM.UnitTests/project.json
@@ -27,6 +27,7 @@
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TraceSource": "4.0.0",
         "System.Security.Cryptography.X509Certificates": "4.1.0",
+        "System.Text.Encoding.CodePages" : "4.0.1",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",
         "System.Xml.XmlDocument": "4.0.1",

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -28,6 +28,7 @@
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Runtime.Loader": "4.0.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
+        "System.Text.Encoding.CodePages" : "4.0.1",
         "System.Threading.Tasks.Dataflow": "4.6.0.0",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",

--- a/src/Framework/project.json
+++ b/src/Framework/project.json
@@ -5,6 +5,7 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
+        "System.Text.Encoding.CodePages" : "4.0.1",
         "System.Threading.Thread": "4.0.0"
       }
     }

--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Build.Shared
                 {
                     if (NativeMethodsShared.IsWindows)
                     {
+                        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
                         // get the current OEM code page
                         s_currentOemEncoding = Encoding.GetEncoding(NativeMethodsShared.GetOEMCP());
                     }

--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -34,11 +34,14 @@ namespace Microsoft.Build.Shared
 #else
                 s_currentOemEncoding = Encoding.UTF8;
 #endif
-#if FEATURE_ENCODING_DEFAULT
+
                 try
                 {
-                    // get the current OEM code page
-                    s_currentOemEncoding = Encoding.GetEncoding(NativeMethodsShared.GetOEMCP());
+                    if (NativeMethodsShared.IsWindows)
+                    {
+                        // get the current OEM code page
+                        s_currentOemEncoding = Encoding.GetEncoding(NativeMethodsShared.GetOEMCP());
+                    }
                 }
                 // theoretically, GetEncoding may throw an ArgumentException or a NotSupportedException. This should never
                 // really happen, since the code page we pass in has just been returned from the "underlying platform", 
@@ -52,7 +55,7 @@ namespace Microsoft.Build.Shared
                 {
                     Debug.Assert(false, "GetEncoding(default OEM encoding) threw a NotSupportedException in EncodingUtilities.CurrentSystemOemEncoding! Please log a bug against MSBuild.", ex.Message);
                 }
-#endif
+
                 return s_currentOemEncoding;
             }
         }

--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Build.Shared
                 {
                     if (NativeMethodsShared.IsWindows)
                     {
+#if RUNTIME_TYPE_NETCORE
                         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+#endif
                         // get the current OEM code page
                         s_currentOemEncoding = Encoding.GetEncoding(NativeMethodsShared.GetOEMCP());
                     }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -665,15 +665,15 @@ namespace Microsoft.Build.Tasks
         /// </remarks>
         private Encoding BatchFileEncoding()
         {
-#if FEATURE_OSVERSION
             if (!NativeMethodsShared.IsWindows)
             {
                 return s_utf8WithoutBom;
             }
-            
+
             var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;
             string useUtf8 = string.IsNullOrEmpty(UseUtf8Encoding) ? UseUtf8Detect : UseUtf8Encoding;
 
+#if FEATURE_OSVERSION
             // UTF8 is only supposed in Windows 7 (6.1) or greater.
             var windows7 = new Version(6, 1);
 
@@ -681,6 +681,7 @@ namespace Microsoft.Build.Tasks
             {
                 useUtf8 = UseUtf8Never;
             }
+#endif
 
             switch (useUtf8.ToUpperInvariant())
             {
@@ -693,9 +694,6 @@ namespace Microsoft.Build.Tasks
                         ? defaultEncoding
                         : s_utf8WithoutBom;
             }
-#else
-            return s_utf8WithoutBom;
-#endif
         }
 
             /// <summary>

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -23,6 +23,7 @@
         "System.Runtime.Serialization.Xml": "4.1.1",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Security.Cryptography.Algorithms": "4.2.0",
+        "System.Text.Encoding.CodePages" : "4.0.1",
         "System.Threading.Thread": "4.0.0",
         "System.Xml.XmlDocument": "4.0.1",
         "System.Xml.XPath": "4.0.1",

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -17,6 +17,7 @@
         "System.Runtime.Serialization.Xml": "4.1.1",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Security.Cryptography.X509Certificates": "4.1.0",
+        "System.Text.Encoding.CodePages" : "4.0.1",
         "System.Threading.Thread": "4.0.0",
         "System.Xml.XmlDocument": "4.0.1"
       }


### PR DESCRIPTION
Fixes #2187 by fixing the broken assumption that .NET Core MSBuild is
always running under a Unicode-compatible codepage. That's not true on
.NET Core on Windows, for the same reason the original checks were
needed on full framework on Windows.

FYI @forki -- thanks for reporting the problem!