### PR TITLE
Add binding redirect for System.IO.Compression to 4.1.2.0.

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -46,7 +46,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.IO.Compression" culture="neutral" publicKeyToken="b77a5c561934e089" />
-          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.2.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
           <codeBase version="4.1.2.0" href="..\System.IO.Compression.dll"/>
         </dependentAssembly>
         <dependentAssembly>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -45,6 +45,11 @@
           <codeBase version="15.1.0.0" href="..\Microsoft.Build.Conversion.Core.dll"/>
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="System.IO.Compression" culture="neutral" publicKeyToken="b77a5c561934e089" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.2.0" />
+          <codeBase version="4.1.2.0" href="..\System.IO.Compression.dll"/>
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
         </dependentAssembly>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -39,6 +39,10 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
         </dependentAssembly>
         <dependentAssembly>
+          <assemblyIdentity name="System.IO.Compression" culture="neutral" publicKeyToken="b77a5c561934e089" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.2.0" />
+        </dependentAssembly>
+        <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
           <codeBase version="15.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -40,7 +40,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.IO.Compression" culture="neutral" publicKeyToken="b77a5c561934e089" />
-          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.2.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />


### PR DESCRIPTION
If a code task factory uses System.IO.Compression it will pick up 4.0.0.0 from the GAC and since we load our local 4.1.2.0 we end up with two versions of the .dll loaded side-by-side, causing havoc.