### PR TITLE
Copy task assemblies from installed extensions

### DIFF
--- a/targets/BootStrapMSBuild.proj
+++ b/targets/BootStrapMSBuild.proj
@@ -44,6 +44,7 @@
 
       <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.props" />
       <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.targets" />
+      <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.dll" />
 
       <InstalledNuGetFiles Include="$(MSBuildExtensionsPath)\Microsoft\NuGet\*" />
 


### PR DESCRIPTION
Without this change, I got failures like

```
S:\msbuild\bin\Bootstrap\MSBuild\Microsoft\Microsoft.NET.Build.Extensions\Microsoft.NET.Build.Extensions.ConflictResolution.targets(30,5): error MSB4062: The "ResolvePackageFileConflicts" task could not be loaded from the assembly S:\msbuild\bin\Bootstrap\MSBuild\Microsoft\Microsoft.NET.Build.Extensions\\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll.  Could not load file or assembly 'file:///S:\msbuild\bin\Bootstrap\MSBuild\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll' or one of its dependencies. The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.  [S:\msbuild\src\Framework\Microsoft.Build.Framework.csproj]
```

on the latest internal preview build.