### PR TITLE
🔖 Move to release version numbering for 15.3

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "15.3-preview",
+  "version": "15.3",
   "buildNumberOffset": "300",
   "assemblyVersion": "15.1",
   "publicReleaseRefSpec": [


### PR DESCRIPTION
We probably DO NOT want to take this right now.

Just getting it out so it's one click away from done when we decide to drop `-preview` from our 15.3 packages.