### PR TITLE
Resource extraction from ARM assemblies

### DIFF
--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -2333,7 +2333,7 @@ namespace Microsoft.Build.Tasks
 #if FEATURE_ASSEMBLY_LOADFROM
                 // Install assembly resolution event handler.
                 _eventHandler = new ResolveEventHandler(ResolveAssembly);
-                AppDomain.CurrentDomain.AssemblyResolve += _eventHandler;
+                AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += _eventHandler;
 #endif
 
                 for (int i = 0; i < _inFiles.Count; ++i)
@@ -2354,7 +2354,7 @@ namespace Microsoft.Build.Tasks
             {
 #if FEATURE_ASSEMBLY_LOADFROM
                 // Remove the event handler.
-                AppDomain.CurrentDomain.AssemblyResolve -= _eventHandler;
+                AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve -= _eventHandler;
                 _eventHandler = null;
 #endif
             }
@@ -2415,7 +2415,7 @@ namespace Microsoft.Build.Tasks
                     {
                         if (candidateAssemblyName.CompareTo(requestedAssemblyName) == 0)
                         {
-                            return Assembly.UnsafeLoadFrom(_assemblyFiles[i].ItemSpec);
+                            return Assembly.ReflectionOnlyLoadFrom(_assemblyFiles[i].ItemSpec);
                         }
                     }
                 }
@@ -2432,7 +2432,7 @@ namespace Microsoft.Build.Tasks
                     {
                         if (String.Compare(requestedAssemblyName.Name, candidateAssemblyName.Name, StringComparison.CurrentCultureIgnoreCase) == 0)
                         {
-                            return Assembly.UnsafeLoadFrom(_assemblyFiles[i].ItemSpec);
+                            return Assembly.ReflectionOnlyLoadFrom(itemSpec);
                         }
                     }
                 }
@@ -2955,23 +2955,29 @@ namespace Microsoft.Build.Tasks
 
             try
             {
-                a = Assembly.UnsafeLoadFrom(name);
+                a = Assembly.ReflectionOnlyLoadFrom(name);
                 assemblyName = a.GetName();
 
                 if (_extractResWFiles)
                 {
-                    var targetFrameworkAttribute = a.GetCustomAttribute<TargetFrameworkAttribute>();
-                    if (
-                            targetFrameworkAttribute != null &&
-                            (
-                                targetFrameworkAttribute.FrameworkName.StartsWith("Silverlight,", StringComparison.OrdinalIgnoreCase) ||
-                                targetFrameworkAttribute.FrameworkName.StartsWith("WindowsPhone,", StringComparison.OrdinalIgnoreCase)
-                            )
-                        )
+                    var attributes = a.GetCustomAttributesData();
+
+                    var attrib = attributes
+                        .FirstOrDefault(attr => attr?.AttributeType == typeof(TargetFrameworkAttribute))?.NamedArguments
+                        .Where(arg => arg.MemberName == nameof(TargetFrameworkAttribute.FrameworkName)).ToArray();
+
+                    if (attrib.Any())
                     {
-                        // Skip Silverlight assemblies.
-                        _logger.LogMessageFromResources("GenerateResource.SkippingExtractingFromNonSupportedFramework", name, targetFrameworkAttribute.FrameworkName);
-                        return;
+                        Debug.Assert(attrib.First().TypedValue.ArgumentType == typeof(string));
+                        var frameworkName = (string)attrib.First().TypedValue.Value;
+
+                        if (frameworkName.StartsWith("Silverlight,", StringComparison.OrdinalIgnoreCase) ||
+                            frameworkName.StartsWith("WindowsPhone,", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Skip Silverlight assemblies.
+                            _logger.LogMessageFromResources("GenerateResource.SkippingExtractingFromNonSupportedFramework", name, frameworkName);
+                            return;
+                        }
                     }
 
                     _logger.LogMessageFromResources("GenerateResource.ExtractingResWFiles", name, outFileOrDir);
@@ -3111,10 +3117,17 @@ namespace Microsoft.Build.Tasks
             NeutralResourcesLanguageAttribute neutralResourcesLanguageAttribute = null;
             if (mainAssembly)
             {
-                Object[] attrs = a.GetCustomAttributes(typeof(NeutralResourcesLanguageAttribute), false);
-                if (attrs.Length != 0)
+                var neutralResourcesLanguageAttributeData =
+                    a.GetCustomAttributesData()
+                    .FirstOrDefault(attr =>
+                        attr.AttributeType.FullName == typeof(NeutralResourcesLanguageAttribute).FullName);
+                if (neutralResourcesLanguageAttributeData != null)
                 {
-                    neutralResourcesLanguageAttribute = (NeutralResourcesLanguageAttribute)attrs[0];
+                    neutralResourcesLanguageAttribute =
+                        (NeutralResourcesLanguageAttribute) typeof(NeutralResourcesLanguageAttribute)
+                            .GetConstructor(neutralResourcesLanguageAttributeData.ConstructorArguments.Select(ctorarg => ctorarg.ArgumentType)
+                                .ToArray()).Invoke(neutralResourcesLanguageAttributeData.ConstructorArguments.Select(ctorag => ctorag.Value)
+                                .ToArray());
                     bool fallbackToSatellite = neutralResourcesLanguageAttribute.Location == UltimateResourceFallbackLocation.Satellite;
                     if (!fallbackToSatellite && neutralResourcesLanguageAttribute.Location != UltimateResourceFallbackLocation.MainAssembly)
                         _logger.LogWarningWithCodeFromResources(null, name, 0, 0, 0, 0, "GenerateResource.UnrecognizedUltimateResourceFallbackLocation", neutralResourcesLanguageAttribute.Location, name);

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -2432,6 +2432,12 @@ namespace Microsoft.Build.Tasks
                     {
                         if (String.Compare(requestedAssemblyName.Name, candidateAssemblyName.Name, StringComparison.CurrentCultureIgnoreCase) == 0)
                         {
+                            string itemSpec = _assemblyFiles[i].ItemSpec;
+
+                            if (requestedAssemblyName.Name.Contains("System.Runtime"))
+                            {
+                                itemSpec = Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location), "System.Runtime.dll");
+                            }
                             return Assembly.ReflectionOnlyLoadFrom(itemSpec);
                         }
                     }


### PR DESCRIPTION
Fixes #2253 by avoiding "real" loading the assembly, instead loading it in the reflection-only context, which is allowed for assemblies that don't work in the current runtime.