### PR TITLE
Should not opt in the SHA-2 workaround for 3rd party crypto providers

### DIFF
--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -1175,6 +1175,13 @@ namespace System.Deployment.Internal.CodeSigning
                 return oldCsp;
             }
 
+            // 3rd party crypto providers in general don't need to be forcefully upgraded.
+            // This not an ideal way to check for that but is the best we have available.
+            if (!oldCsp.CspKeyContainerInfo.ProviderName.StartsWith("Microsoft", StringComparison.Ordinal))
+            {
+                return oldCsp;
+            }
+
             const int PROV_RSA_AES = 24;    // CryptoApi provider type for an RSA provider supporting sha-256 digital signatures
             CspParameters csp = new CspParameters();
             csp.ProviderType = PROV_RSA_AES;


### PR DESCRIPTION
The code modified in this PR is used by clickonce to sign the manifest file. In order to support signing with SHA-2 cert, a workaround was added. However, this workaround should be opted out for 3rd party crypto providers. Otherwise, it causes verification failure(unknown publisher) when the manifest file is signed by a SHA-2 EV cert.