### PR TITLE
Use ComSpec when GetPathToSystemFile(cmd) is bogus

### DIFF
--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -520,6 +520,11 @@ namespace Microsoft.Build.Tasks
         /// <returns>path to cmd.exe</returns>
         protected override string GenerateFullPathToTool()
         {
+            return CommandProcessorPath.Value;
+        }
+
+        private static readonly Lazy<string> CommandProcessorPath = new Lazy<string>(() =>
+        {
             // Get the fully qualified path to cmd.exe
             if (NativeMethodsShared.IsWindows)
             {
@@ -541,7 +546,7 @@ namespace Microsoft.Build.Tasks
             {
                 return "sh";
             }
-        }
+        });
 
         /// <summary>
         /// Gets the working directory to use for the process. Should return null if ToolTask should use the

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -523,7 +523,19 @@ namespace Microsoft.Build.Tasks
             // Get the fully qualified path to cmd.exe
             if (NativeMethodsShared.IsWindows)
             {
-                return ToolLocationHelper.GetPathToSystemFile("cmd.exe");
+                var systemCmd = ToolLocationHelper.GetPathToSystemFile("cmd.exe");
+
+#if !FEATURE_SPECIAL_FOLDERS
+                // Work around https://github.com/Microsoft/msbuild/issues/2273 and
+                // https://github.com/dotnet/corefx/issues/19110, which result in
+                // a bad path being returned above on Nano Server SKUs of Windows.
+                if (!File.Exists(systemCmd))
+                {
+                    return Environment.GetEnvironmentVariable("ComSpec");
+                }
+#endif
+
+                return systemCmd;
             }
             else
             {


### PR DESCRIPTION
Fixes #2273 by falling back to `%ComSpec%` when `ToolLocationHelper.GetPathToSystemFile("cmd.exe")` returns a nonexistent value, as it does when `SHGetFolderPath` returns the user's home directory instead of the system directory, as it sometimes does on Nano Server.

Tested against the trivial `<Exec>` repro project and against a `dotnet new mvc` project; both succeed.