### PR TITLE
Avoid params char[] allocation

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1021,7 +1021,7 @@ namespace Microsoft.Build.Shared
 
         internal static string TrimTrailingSlashes(this string s)
         {
-            return s.TrimEnd('/', '\\');
+            return s.TrimEnd(Slashes);
         }
 
         /// <summary>


### PR DESCRIPTION
This method got inlined a few methods, so it's hard to see, but I think this was this array creation, or probably also including an inlined: https://github.com/Microsoft/msbuild/pull/2284.

![image](https://user-images.githubusercontent.com/1103906/28124065-fb97cce4-6765-11e7-9dd8-1fead853df11.png)
