### PR TITLE
Port internal changes

### DIFF
--- a/src/Build.UnitTests/Collections/MSBuildNameIgnoreCaseComparer_Tests.cs
+++ b/src/Build.UnitTests/Collections/MSBuildNameIgnoreCaseComparer_Tests.cs
@@ -44,25 +44,26 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void MatchProperty()
         {
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
 
             ProjectPropertyInstance p = ProjectPropertyInstance.Create("foo", "bar");
 
             dictionary.Set(p);
 
             string s = "$(foo)";
-            ProjectPropertyInstance value = MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, s, 2, 4);
+            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, s, 2, 4);
 
             Assert.True(Object.ReferenceEquals(p, value)); // "Should have returned the same object as was inserted"
 
             try
             {
-                MSBuildNameIgnoreCaseComparer.Mutable.SetConstraintsForUnitTestingOnly(s, 2, 4);
-                Assert.Equal(MSBuildNameIgnoreCaseComparer.Default.GetHashCode("foo"), MSBuildNameIgnoreCaseComparer.Mutable.GetHashCode(s));
+                comparer.SetConstraintsForUnitTestingOnly(s, 2, 4);
+                Assert.Equal(MSBuildNameIgnoreCaseComparer.Default.GetHashCode("foo"), comparer.GetHashCode(s));
             }
             finally
             {
-                MSBuildNameIgnoreCaseComparer.Mutable.RemoveConstraintsForUnitTestingOnly();
+                comparer.RemoveConstraintsForUnitTestingOnly();
             }
         }
 
@@ -165,12 +166,13 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsEndPastEnd1()
         {
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
 
             ProjectPropertyInstance p = ProjectPropertyInstance.Create("bbb", "value");
             dictionary.Set(p);
 
-            ProjectPropertyInstance value = MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "abbbaaa", 1, 3);
+            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "abbbaaa", 1, 3);
 
             Assert.True(Object.ReferenceEquals(p, value)); // "Should have returned the same object as was inserted"
         }
@@ -181,7 +183,8 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsSameStartEnd1()
         {
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
 
             ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("A", "value1");
             ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("B", "value2");
@@ -189,7 +192,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             dictionary.Set(p1);
             dictionary.Set(p2);
 
-            ProjectPropertyInstance value = MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "babbbb", 1, 1);
+            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "babbbb", 1, 1);
 
             Assert.True(Object.ReferenceEquals(p1, value)); // "Should have returned the 'A' value"
         }
@@ -200,7 +203,8 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsSameStartEnd2()
         {
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
 
             ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("a", "value1");
             ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("b", "value2");
@@ -208,7 +212,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             dictionary.Set(p1);
             dictionary.Set(p2);
 
-            ProjectPropertyInstance value = MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "aabaa", 2, 2);
+            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "aabaa", 2, 2);
 
             Assert.True(Object.ReferenceEquals(p2, value)); // "Should have returned the 'b' value"
         }
@@ -219,7 +223,8 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsSameStartEnd3()
         {
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
 
             ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("a", "value1");
             ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("b", "value2");
@@ -227,7 +232,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             dictionary.Set(p1);
             dictionary.Set(p2);
 
-            ProjectPropertyInstance value = MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "ab", 0, 0);
+            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "ab", 0, 0);
 
             Assert.True(Object.ReferenceEquals(p1, value)); // "Should have returned the 'a' value"
         }
@@ -238,7 +243,8 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsStartZero()
         {
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
 
             ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("aab", "value1");
             ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("aba", "value2");
@@ -246,7 +252,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             dictionary.Set(p1);
             dictionary.Set(p2);
 
-            ProjectPropertyInstance value = MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "aabaa", 0, 2);
+            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "aabaa", 0, 2);
 
             Assert.True(Object.ReferenceEquals(p1, value)); // "Should have returned the 'aab' value"
         }
@@ -257,7 +263,8 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsEndEnd()
         {
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
 
             ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("aabaaaa", "value1");
             ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("baaaa", "value2");
@@ -270,30 +277,30 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             dictionary.Set(p3);
 
             // Should match o3
-            ProjectPropertyInstance value1 = MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, constraint, 1, 5);
+            ProjectPropertyInstance value1 = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, constraint, 1, 5);
 
             Assert.True(Object.ReferenceEquals(p3, value1)); // "Should have returned the 'abaaa' value"
 
             dictionary.Remove("abaaa"); // get rid of o3
 
-            ProjectPropertyInstance value2 = MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, constraint, 1, 5);
+            ProjectPropertyInstance value2 = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, constraint, 1, 5);
 
             Assert.Null(value2); // "Should not have been a match in the dictionary"
 
             // Even if the string is exactly the same, if only a substring is being compared, then although it 
             // will be judged equal, the hash codes will NOT be the same, and for that reason, a lookup in the 
             // dictionary will fail.  
-            int originalHashCode = MSBuildNameIgnoreCaseComparer.Mutable.GetHashCode("aabaaa");
+            int originalHashCode = comparer.GetHashCode("aabaaa");
             try
             {
-                MSBuildNameIgnoreCaseComparer.Mutable.SetConstraintsForUnitTestingOnly(constraint, 1, 5);
+                comparer.SetConstraintsForUnitTestingOnly(constraint, 1, 5);
 
-                Assert.True(MSBuildNameIgnoreCaseComparer.Mutable.Equals("aabaaa", constraint)); // same on both sides
-                Assert.NotEqual(originalHashCode, MSBuildNameIgnoreCaseComparer.Mutable.GetHashCode(constraint));
+                Assert.True(comparer.Equals("aabaaa", constraint)); // same on both sides
+                Assert.NotEqual(originalHashCode, comparer.GetHashCode(constraint));
             }
             finally
             {
-                MSBuildNameIgnoreCaseComparer.Mutable.RemoveConstraintsForUnitTestingOnly();
+                comparer.RemoveConstraintsForUnitTestingOnly();
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
@@ -8,10 +8,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Microsoft.Build.Evaluation;
 using Xunit;
 using System.Text;
+using Microsoft.Build.Engine.UnitTests;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.UnitTests.Evaluation
 {
@@ -518,6 +522,73 @@ namespace Microsoft.Build.UnitTests.Evaluation
             IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content);
 
             Assert.Equal("0;6;7;8;9", String.Join(";", items.Select(i => i.EvaluatedInclude)));
+        }
+
+        [Fact]
+        public void LazyWildcardExpansionDoesNotEvaluateWildCardsIfNotReferenced()
+        {
+            var content = @"
+<Project>
+   <Import Project=`foo/*.props`/>
+   <ItemGroup>
+      <i Include=`**/foo/**/*.cs`/>
+      <i2 Include=`**/bar/**/*.cs`/>
+   </ItemGroup>
+
+   <ItemGroup>
+      <ItemReference Include=`@(i)`/>
+      <FullPath Include=`@(i->'%(FullPath)')`/>
+      <Identity Include=`@(i->'%(Identity)')`/>
+      <RecursiveDir Include=`@(i->'%(RecursiveDir)')`/>
+   </ItemGroup>
+</Project>
+".Cleanup();
+
+            var import = @"
+<Project>
+   <PropertyGroup>
+      <FromImport>true</FromImport>
+   </PropertyGroup>
+</Project>
+".Cleanup();
+            using (var env = TestEnvironment.Create())
+            {
+                var projectFiles = env.CreateTestProjectWithFiles(content, new[] {"foo/extra.props", "foo/a.cs", "foo/b.cs", "bar/c.cs", "bar/d.cs"});
+
+                File.WriteAllText(projectFiles.CreatedFiles[0], import);
+
+                env.SetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes", ".*foo.*");
+
+                EngineFileUtilities.CaptureLazyWildcardRegexes();
+
+                var project = new Project(projectFiles.ProjectFile);
+
+                Assert.Equal("true", project.GetPropertyValue("FromImport"));
+                Assert.Equal("**/foo/**/*.cs", project.GetConcatenatedItemsOfType("i"));
+
+                var expectedItems = "bar\\c.cs;bar\\d.cs";
+
+                if (!NativeMethodsShared.IsWindows)
+                {
+                    expectedItems = expectedItems.ToSlash();
+                }
+
+                Assert.Equal(expectedItems, project.GetConcatenatedItemsOfType("i2"));
+                
+                var fullPathItems = project.GetConcatenatedItemsOfType("FullPath");
+                Assert.Contains("a.cs", fullPathItems);
+                Assert.Contains("b.cs", fullPathItems);
+
+                var identityItems = project.GetConcatenatedItemsOfType("Identity");
+                Assert.Contains("a.cs", identityItems);
+                Assert.Contains("b.cs", identityItems);
+
+                // direct item references do not expand the lazy wildcard
+                Assert.Equal("**/foo/**/*.cs", project.GetConcatenatedItemsOfType("ItemReference"));
+
+                // recursive dir does not work with lazy wildcards
+                Assert.Equal(string.Empty, project.GetConcatenatedItemsOfType("RecursiveDir"));
+            }
         }
     }
 }

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -51,13 +51,14 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// Comparer whose start and end indexes we can manipulate as necessary.
         /// </summary>
-        private MSBuildNameIgnoreCaseComparer _comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+        private MSBuildNameIgnoreCaseComparer _comparer;
 
         /// <summary>
         /// Creates empty dictionary
         /// </summary>
         public PropertyDictionary()
         {
+            _comparer = MSBuildNameIgnoreCaseComparer.Mutable;
             _properties = new RetrievableEntryHashSet<T>(_comparer);
         }
 
@@ -66,6 +67,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal PropertyDictionary(int capacity)
         {
+            _comparer = MSBuildNameIgnoreCaseComparer.Mutable;
             _properties = new RetrievableEntryHashSet<T>(capacity, _comparer);
         }
 
@@ -79,6 +81,15 @@ namespace Microsoft.Build.Collections
             {
                 Set(element);
             }
+        }
+
+        /// <summary>
+        /// Creates empty dictionary, specifying a comparer
+        /// </summary>
+        internal PropertyDictionary(MSBuildNameIgnoreCaseComparer comparer)
+        {
+            _comparer = comparer;
+            _properties = new RetrievableEntryHashSet<T>(_comparer);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2455,7 +2455,7 @@ namespace Microsoft.Build.Evaluation
                     }
 
                     // Expand the wildcards and provide an alphabetical order list of import statements.
-                    importFilesEscaped = EngineFileUtilities.GetFileListEscaped(directoryOfImportingFile, importExpressionEscapedItem);
+                    importFilesEscaped = EngineFileUtilities.GetFileListEscaped(directoryOfImportingFile, importExpressionEscapedItem, forceEvaluate: true);
                 }
                 catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
                 {

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -10,12 +10,32 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Shared;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Internal
 {
     internal class EngineFileUtilities
     {
-        /// <summary>
+        // Regexes for wildcard filespecs that should not get expanded
+        // By default all wildcards are expanded.
+        private static List<Regex> s_lazyWildCardExpansionRegexes;
+
+        static EngineFileUtilities()
+        {
+            if (Traits.Instance.UseLazyWildCardEvaluation)
+            {
+                CaptureLazyWildcardRegexes();
+            }
+        }
+
+        // used by test to reset regexes
+        internal static void CaptureLazyWildcardRegexes()
+        {
+            s_lazyWildCardExpansionRegexes = PopulateRegexFromEnvironment();
+        }
+
+
+    /// <summary>
         /// Used for the purposes of evaluating an item specification. Given a filespec that may include wildcard characters * and
         /// ?, we translate it into an actual list of files. If the input filespec doesn't contain any wildcard characters, and it
         /// doesn't appear to point to an actual file on disk, then we just give back the input string as an array of length one,
@@ -27,15 +47,17 @@ namespace Microsoft.Build.Internal
         /// </summary>
         /// <param name="directoryEscaped">The directory to evaluate, escaped.</param>
         /// <param name="filespecEscaped">The filespec to evaluate, escaped.</param>
+        /// <param name="forceEvaluate">Whether to force file glob expansion when eager expansion is turned off</param>
         /// <returns>Array of file paths, unescaped.</returns>
         internal static string[] GetFileListUnescaped
             (
             string directoryEscaped,
-            string filespecEscaped
+            string filespecEscaped,
+            bool forceEvaluate = false
             )
 
         {
-            return GetFileList(directoryEscaped, filespecEscaped, false /* returnEscaped */);
+            return GetFileList(directoryEscaped, filespecEscaped, false /* returnEscaped */, forceEvaluate);
         }
 
         /// <summary>
@@ -51,15 +73,17 @@ namespace Microsoft.Build.Internal
         /// <param name="directoryEscaped">The directory to evaluate, escaped.</param>
         /// <param name="filespecEscaped">The filespec to evaluate, escaped.</param>
         /// <param name="excludeSpecsEscaped">Filespecs to exclude, escaped.</param>
+        /// <param name="forceEvaluate">Whether to force file glob expansion when eager expansion is turned off</param>
         /// <returns>Array of file paths, escaped.</returns>
         internal static string[] GetFileListEscaped
             (
             string directoryEscaped,
             string filespecEscaped,
-            IEnumerable<string> excludeSpecsEscaped = null
+            IEnumerable<string> excludeSpecsEscaped = null,
+            bool forceEvaluate = false
             )
         {
-            return GetFileList(directoryEscaped, filespecEscaped, true /* returnEscaped */, excludeSpecsEscaped);
+            return GetFileList(directoryEscaped, filespecEscaped, true /* returnEscaped */, forceEvaluate, excludeSpecsEscaped);
         }
 
         private static bool FilespecHasWildcards(string filespecEscaped)
@@ -99,6 +123,7 @@ namespace Microsoft.Build.Internal
         /// <param name="directoryEscaped">The directory to evaluate, escaped.</param>
         /// <param name="filespecEscaped">The filespec to evaluate, escaped.</param>
         /// <param name="returnEscaped"><code>true</code> to return escaped specs.</param>
+        /// <param name="forceEvaluateWildCards">Whether to force file glob expansion when eager expansion is turned off</param>
         /// <param name="excludeSpecsEscaped">The exclude specification, escaped.</param>
         /// <returns>Array of file paths.</returns>
         private static string[] GetFileList
@@ -106,6 +131,7 @@ namespace Microsoft.Build.Internal
             string directoryEscaped,
             string filespecEscaped,
             bool returnEscaped,
+            bool forceEvaluateWildCards,
             IEnumerable<string> excludeSpecsEscaped = null
             )
         {
@@ -118,8 +144,19 @@ namespace Microsoft.Build.Internal
 
             string[] fileList;
 
-            if (FilespecHasWildcards(filespecEscaped))
+            if (!FilespecHasWildcards(filespecEscaped) ||
+                FilespecMatchesLazyWildcard(filespecEscaped, forceEvaluateWildCards))
             {
+                // Just return the original string.
+                fileList = new string[] { returnEscaped ? filespecEscaped : EscapingUtilities.UnescapeAll(filespecEscaped) };
+            }
+            else
+            {
+                if (Traits.Instance.LogExpandedWildcards)
+                {
+                    ErrorUtilities.DebugTraceMessage("Expanding wildcard for file spec {0}", filespecEscaped);
+                }
+
                 // Unescape before handing it to the filesystem.
                 var directoryUnescaped = EscapingUtilities.UnescapeAll(directoryEscaped);
                 var filespecUnescaped = EscapingUtilities.UnescapeAll(filespecEscaped);
@@ -152,13 +189,13 @@ namespace Microsoft.Build.Internal
                     }
                 }
             }
-            else
-            {
-                // Just return the original string.
-                fileList = new string[] { returnEscaped ? filespecEscaped : EscapingUtilities.UnescapeAll(filespecEscaped) };
-            }
 
             return fileList;
+        }
+
+        private static bool FilespecMatchesLazyWildcard(string filespecEscaped, bool forceEvaluateWildCards)
+        {
+            return Traits.Instance.UseLazyWildCardEvaluation && !forceEvaluateWildCards && MatchesLazyWildcard(filespecEscaped);
         }
 
         private static bool IsValidExclude(string exclude)
@@ -171,6 +208,36 @@ namespace Microsoft.Build.Internal
             // unescape the path fragments to unfold potentially escaped wildcard chars)
             var hasBothWildcardsAndEscapedWildcards = FileMatcher.HasWildcards(exclude) && EscapingUtilities.ContainsEscapedWildcards(exclude);
             return !hasBothWildcardsAndEscapedWildcards;
+        }
+
+        private static List<Regex> PopulateRegexFromEnvironment()
+        {
+            string wildCards = Environment.GetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes");
+            if (string.IsNullOrEmpty(wildCards))
+            {
+                return new List<Regex>(0);
+            }
+            else
+            {
+                List<Regex> regexes = new List<Regex>();
+                foreach (string regex in wildCards.Split(';'))
+                {
+                    Regex item = new Regex(regex, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+                    // trigger a match first?
+                    item.IsMatch("foo");
+                    regexes.Add(item);
+                }
+
+                return regexes;
+            }
+        }
+
+        // TODO: assumption on file system case sensitivity: https://github.com/Microsoft/msbuild/issues/781
+        private static readonly Lazy<ConcurrentDictionary<string, bool>> _regexMatchCache = new Lazy<ConcurrentDictionary<string, bool>>(() => new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase));
+
+        private static bool MatchesLazyWildcard(string fileSpec)
+        {
+            return _regexMatchCache.Value.GetOrAdd(fileSpec, file => s_lazyWildCardExpansionRegexes.Any(regex => regex.IsMatch(fileSpec)));
         }
 
         /// Returns a Func that will return true IFF its argument matches any of the specified filespecs

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
 using System.Diagnostics;
@@ -14,6 +15,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Globalization;
 using System.Collections.Generic;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Shared
 {
@@ -38,6 +40,9 @@ namespace Microsoft.Build.Shared
 
         internal static readonly GetFileSystemEntries s_defaultGetFileSystemEntries = new GetFileSystemEntries(GetAccessibleFileSystemEntries);
         private static readonly DirectoryExists s_defaultDirectoryExists = new DirectoryExists(Directory.Exists);
+
+        private static readonly Lazy<ConcurrentDictionary<string, string[]>> s_cachedFileEnumerations = new Lazy<ConcurrentDictionary<string, string[]>>(() => new ConcurrentDictionary<string, string[]>(StringComparer.OrdinalIgnoreCase));
+        private static readonly Lazy<ConcurrentDictionary<string, object>> s_cachedFileEnumerationsLock = new Lazy<ConcurrentDictionary<string, object>>(() => new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase));
 
         /// <summary>
         /// Cache of the list of invalid path characters, because this method returns a clone (for security reasons)
@@ -68,6 +73,12 @@ namespace Microsoft.Build.Shared
         /// <param name="stripProjectDirectory"></param>
         /// <returns>The array of filesystem entries.</returns>
         internal delegate string[] GetFileSystemEntries(FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory);
+
+        internal static void TestClearCaches()
+        {
+            s_cachedFileEnumerations.Value.Clear();
+            s_cachedFileEnumerationsLock.Value.Clear();
+        }
 
         /// <summary>
         /// Determines whether the given path has any wild card characters.
@@ -1391,8 +1402,66 @@ namespace Microsoft.Build.Shared
             IEnumerable<string> excludeSpecsUnescaped = null
         )
         {
-            string[] files = GetFiles(projectDirectoryUnescaped, filespecUnescaped, excludeSpecsUnescaped, s_defaultGetFileSystemEntries, s_defaultDirectoryExists);
-            return files;
+            // Possible future improvement: make sure file existence caching happens only at evaluation time, and maybe only within a build session. https://github.com/Microsoft/msbuild/issues/2306
+            if (Traits.Instance.MSBuildCacheFileEnumerations)
+            {
+                string filesKey = ComputeFileEnumerationCacheKey(projectDirectoryUnescaped, filespecUnescaped, excludeSpecsUnescaped);
+                string[] files;
+                if (!s_cachedFileEnumerations.Value.TryGetValue(filesKey, out files))
+                {
+                    // avoid parallel evaluations of the same wildcard by using a unique lock for each wildcard
+                    object locks = s_cachedFileEnumerationsLock.Value.GetOrAdd(filesKey, _ => new object());
+                    lock (locks)
+                    {
+                        if (!s_cachedFileEnumerations.Value.TryGetValue(filesKey, out files))
+                        {
+                            files =
+                                s_cachedFileEnumerations.Value.GetOrAdd(
+                                    filesKey,
+                                    (_) =>
+                                        GetFiles(
+                                            projectDirectoryUnescaped,
+                                            filespecUnescaped,
+                                            excludeSpecsUnescaped,
+                                            s_defaultGetFileSystemEntries,
+                                            s_defaultDirectoryExists));
+                        }
+                    }
+                }
+
+                // Copy the file enumerations to prevent outside modifications of the cache (e.g. sorting, escaping) and to maintain the original contract that a new array is created on each call.
+                var filesToReturn = new string[files.Length];
+                Array.Copy(files, filesToReturn, files.Length);
+                return filesToReturn;
+            }
+            else
+            {
+                string[] files = GetFiles(
+                    projectDirectoryUnescaped,
+                    filespecUnescaped,
+                    excludeSpecsUnescaped,
+                    s_defaultGetFileSystemEntries,
+                    s_defaultDirectoryExists);
+                return files;
+            }
+        }
+
+        private static string ComputeFileEnumerationCacheKey(string projectDirectoryUnescaped, string filespecUnescaped, IEnumerable<string> excludes)
+        {
+            var sb = new StringBuilder();
+
+            sb.Append(projectDirectoryUnescaped);
+            sb.Append(filespecUnescaped);
+
+            if (excludes != null)
+            {
+                foreach (var exclude in excludes)
+                {
+                    sb.Append(exclude);
+                }
+            }
+
+            return sb.ToString();
         }
 
         enum SearchAction

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+#if !CLR2COMPATIBILITY
+using System.Collections.Concurrent;
+#endif
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -13,6 +16,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Text;
 using System.Threading;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Shared
 {
@@ -83,6 +87,10 @@ namespace Microsoft.Build.Shared
         };
 
         private static readonly char[] Slashes = { '/', '\\' };
+
+#if !CLR2COMPATIBILITY
+        private static ConcurrentDictionary<string, bool> FileExistenceCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+#endif
 
         /// <summary>
         /// Retrieves the MSBuild runtime cache directory
@@ -849,12 +857,19 @@ namespace Microsoft.Build.Shared
             fullPath = AttemptToShortenPath(fullPath);
             if (NativeMethodsShared.IsWindows)
             {
-                NativeMethodsShared.WIN32_FILE_ATTRIBUTE_DATA data = new NativeMethodsShared.WIN32_FILE_ATTRIBUTE_DATA();
-                bool success = false;
-
-                success = NativeMethodsShared.GetFileAttributesEx(fullPath, 0, ref data);
-
-                return success;
+#if !CLR2COMPATIBILITY
+                if (Traits.Instance.CacheFileExistence)
+                {
+                    // Possible future improvement: make sure file existence caching happens only at evaluation time, and maybe only within a build session. https://github.com/Microsoft/msbuild/issues/2306
+                    return FileExistenceCache.GetOrAdd(fullPath, NativeMethodsShared.FileExists);
+                }
+                else
+                {
+#endif
+                    return NativeMethodsShared.FileExists(fullPath);
+#if !CLR2COMPATIBILITY
+                }
+#endif
             }
             else
             {

--- a/src/Shared/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Shared/MSBuildNameIgnoreCaseComparer.cs
@@ -32,11 +32,6 @@ namespace Microsoft.Build.Collections
         private static MSBuildNameIgnoreCaseComparer s_immutableComparer = new MSBuildNameIgnoreCaseComparer(true /* immutable */);
 
         /// <summary>
-        /// The default mutable comparer instance that will ideally be shared by all users who need a mutable comparer. 
-        /// </summary>
-        private static MSBuildNameIgnoreCaseComparer s_mutableComparer = new MSBuildNameIgnoreCaseComparer(false /* mutable */);
-
-        /// <summary>
         /// The processor architecture on which we are running, but default it will be x86
         /// </summary>
         private static NativeMethodsShared.ProcessorArchitectures s_runningProcessorArchitecture = NativeMethodsShared.ProcessorArchitectures.X86;
@@ -99,10 +94,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// The default mutable comparer instance.
         /// </summary>
-        internal static MSBuildNameIgnoreCaseComparer Mutable
-        {
-            get { return s_mutableComparer; }
-        }
+        internal static MSBuildNameIgnoreCaseComparer Mutable => new MSBuildNameIgnoreCaseComparer(immutable: false);
 
         /// <summary>
         /// Performs the "Equals" operation on two MSBuild property, item or metadata names

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -1405,5 +1405,15 @@ namespace Microsoft.Build.Shared
         }
 
 #endregion
+
+#region helper methods
+
+        internal static bool FileExists(string path)
+        {
+            WIN32_FILE_ATTRIBUTE_DATA data = new WIN32_FILE_ATTRIBUTE_DATA();
+            return GetFileAttributesEx(path, 0, ref data);
+        }
+
+#endregion
     }
 }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool UseLazyWildCardEvaluation = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes"));
         public readonly bool LogExpandedWildcards = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGEXPANDEDWILDCARDS"));
+        public readonly bool CacheFileExistence = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileExistence"));
 
         /// <summary>
         /// Cache wildcard expansions

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -17,6 +17,12 @@ namespace Microsoft.Build.Utilities
 
         public EscapeHatches EscapeHatches { get; }
 
+        /// <summary>
+        /// Do not expand wildcards that match a certain pattern
+        /// </summary>
+        public readonly bool UseLazyWildCardEvaluation = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes"));
+        public readonly bool LogExpandedWildcards = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGEXPANDEDWILDCARDS"));
+
         public Traits()
         {
             EscapeHatches = new EscapeHatches();

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Build.Utilities
         public readonly bool CacheFileExistence = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileExistence"));
 
         /// <summary>
+        /// Eliminate locking in OpportunisticIntern at the expense of memory
+        /// </summary>
+        public readonly bool UseSimpleInternConcurrency = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildUseSimpleInternConcurrency"));
+
+        /// <summary>
         /// Cache wildcard expansions
         /// </summary>
         public readonly bool MSBuildCacheFileEnumerations = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileEnumerations"));

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Build.Utilities
         public readonly bool UseLazyWildCardEvaluation = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes"));
         public readonly bool LogExpandedWildcards = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGEXPANDEDWILDCARDS"));
 
+        /// <summary>
+        /// Cache wildcard expansions
+        /// </summary>
+        public readonly bool MSBuildCacheFileEnumerations = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileEnumerations"));
+
         public Traits()
         {
             EscapeHatches = new EscapeHatches();

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1008,6 +1008,11 @@ namespace Microsoft.Build.UnitTests
             return items;
         }
 
+        internal static string GetConcatenatedItemsOfType(this Project project, string itemType, string itemSeparator = ";")
+        {
+            return string.Join(itemSeparator, project.Items.Where(i => i.ItemType.Equals(itemType)).Select(i => i.EvaluatedInclude));
+        }
+
         /// <summary>
         /// Get the items of type "i" in the project provided
         /// </summary>


### PR DESCRIPTION
This PR ports the changes from an internal fork of MSBuild with the goal of removing the fork. There are two types of changes
- feature flagged features that are needed by internal tooling
  - not expanding wildcards
  - caching wildcard expansions
  - caching file system existence checks
- changes that reduce lock contention

I tested this locally and RPS. RPS shows no degradation, and the local tests show about 5ms improvement for a 28 project solution.

Each commit contains one logical change, for ease of review.

