### PR TITLE
Avoid allocation on enumerating ReadOnlyEmptyList

### DIFF
--- a/src/Shared/ReadOnlyEmptyList.cs
+++ b/src/Shared/ReadOnlyEmptyList.cs
@@ -8,6 +8,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 using Microsoft.Build.Shared;
 
@@ -110,7 +111,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public IEnumerator<T> GetEnumerator()
         {
-            yield break;
+            return Enumerable.Empty<T>().GetEnumerator();
         }
 
         /// <summary>


### PR DESCRIPTION
Enumerable.Empty<T>() returns a T[] that has an allocation free enumerator for empty.

This was allocating about 1.1 MB opening ProjectSystem.sln.

![image](https://user-images.githubusercontent.com/1103906/28146431-20063834-67bd-11e7-912e-eb267e51a216.png)
