### PR TITLE
Avoid boxing dictionary enumerator

### DIFF
--- a/src/Build/Collections/HashTableUtility.cs
+++ b/src/Build/Collections/HashTableUtility.cs
@@ -22,8 +22,11 @@ namespace Microsoft.Build.Collections
         ///  0, if hashtables have identical keys and equivalent (case-insensitive) values
         /// +1, if first hashtable is "greater than" the second one
         /// </returns>
-        internal static int Compare(IDictionary<string, string> h1, IDictionary<string, string> h2)
+        internal static int Compare(Dictionary<string, string> h1, Dictionary<string, string> h2)
         {
+            // NOTE: These are deliberately typed as Dictionary<TKey, TValue> and not
+            // IDictionary<TKey, TValue> to avoid boxing the enumerator
+
             if (h1 == h2) // eg null
             {
                 return 0;


### PR DESCRIPTION
This was allocating 0.2% of data in the MSBuild process during solution open.

![image](https://user-images.githubusercontent.com/1103906/28148952-531bbe0a-67cd-11e7-9365-a87e2fda10a2.png)