### PR TITLE
Replace empty array creation with Array.Empty<T>

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -861,7 +861,7 @@ namespace Microsoft.Build.Execution
                 }
 
                 // Submit the build request.
-                BuildRequestBlocker blocker = new BuildRequestBlocker(-1, new string[0], new BuildRequest[] { submission.BuildRequest });
+                BuildRequestBlocker blocker = new BuildRequestBlocker(-1, Array.Empty<string>(), new BuildRequest[] { submission.BuildRequest });
                 _workQueue.Post(() =>
                 {
                     try
@@ -948,7 +948,7 @@ namespace Microsoft.Build.Execution
 
             if (existingConfiguration == null)
             {
-                existingConfiguration = new BuildRequestConfiguration(GetNewConfigurationId(), new BuildRequestData(newInstance, new string[] { }), null /* use the instance's tools version */, null /* shouldn't need to get toolsets because ProjectInstance's ToolsVersion overrides */);
+                existingConfiguration = new BuildRequestConfiguration(GetNewConfigurationId(), new BuildRequestData(newInstance, Array.Empty<string>()), null /* use the instance's tools version */, null /* shouldn't need to get toolsets because ProjectInstance's ToolsVersion overrides */);
             }
             else
             {

--- a/src/Build/BackEnd/Components/Communications/NodePacketTranslatorExtensions.cs
+++ b/src/Build/BackEnd/Components/Communications/NodePacketTranslatorExtensions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Build.BackEnd
                     return constructor;
                 });
 
-            var targetInstanceChild = (INodePacketTranslatable) parameterlessConstructor.Invoke(new object[0]);
+            var targetInstanceChild = (INodePacketTranslatable) parameterlessConstructor.Invoke(Array.Empty<object>());
 
             targetInstanceChild.Translate(translator);
 

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -930,7 +930,7 @@ namespace Microsoft.Build.BackEnd
             }
             else
             {
-                results = new BuildResult[] { };
+                results = Array.Empty<BuildResult>();
             }
 
             ErrorUtilities.VerifyThrow(requests.Length == results.Length, "# results != # requests");

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     if (_cancellationToken.IsCancellationRequested || errorResult)
                     {
-                        results[i] = new TargetResult(new TaskItem[] { }, new WorkUnitResult(WorkUnitResultCode.Skipped, WorkUnitActionCode.Continue, null));
+                        results[i] = new TargetResult(Array.Empty<TaskItem>(), new WorkUnitResult(WorkUnitResultCode.Skipped, WorkUnitActionCode.Continue, null));
                     }
                     else
                     {
@@ -298,7 +298,7 @@ namespace Microsoft.Build.BackEnd
                         }
                         else
                         {
-                            results[i] = new TargetResult(new TaskItem[] { }, new WorkUnitResult(WorkUnitResultCode.Skipped, WorkUnitActionCode.Continue, null));
+                            results[i] = new TargetResult(Array.Empty<TaskItem>(), new WorkUnitResult(WorkUnitResultCode.Skipped, WorkUnitActionCode.Continue, null));
                         }
                     }
                 }

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Build.BackEnd
 
             if (!condition)
             {
-                _targetResult = new TargetResult(new TaskItem[0] { }, new WorkUnitResult(WorkUnitResultCode.Skipped, WorkUnitActionCode.Continue, null));
+                _targetResult = new TargetResult(Array.Empty<TaskItem>(), new WorkUnitResult(WorkUnitResultCode.Skipped, WorkUnitActionCode.Continue, null));
                 _state = TargetEntryState.Completed;
 
                 if (!projectLoggingContext.LoggingService.OnlyLogCriticalEvents)
@@ -708,7 +708,7 @@ namespace Microsoft.Build.BackEnd
             // create a result for this target to report when it gets to the Completed state.
             if (null == _targetResult)
             {
-                _targetResult = new TargetResult(new TaskItem[] { }, new WorkUnitResult(WorkUnitResultCode.Failed, WorkUnitActionCode.Stop, null));
+                _targetResult = new TargetResult(Array.Empty<TaskItem>(), new WorkUnitResult(WorkUnitResultCode.Failed, WorkUnitActionCode.Stop, null));
             }
 
             _state = TargetEntryState.Completed;

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -892,8 +892,8 @@ namespace Microsoft.Build.BackEnd
                         (
                         projectFileNames,
                         propertyDictionaries,
-                        toolsVersion ?? new string[] { },
-                        targetNames ?? new string[] { },
+                        toolsVersion ?? Array.Empty<string>(),
+                        targetNames ?? Array.Empty<string>(),
                         true
                         );
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1504,7 +1504,7 @@ namespace Microsoft.Build.BackEnd
         private void HandleRequestBlockedOnResultsTransfer(SchedulableRequest parentRequest, List<ScheduleResponse> responses)
         {
             // Create the new request which will go to the configuration's results node.
-            BuildRequest newRequest = new BuildRequest(parentRequest.BuildRequest.SubmissionId, BuildRequest.ResultsTransferNodeRequestId, parentRequest.BuildRequest.ConfigurationId, new string[0], null, parentRequest.BuildRequest.BuildEventContext, parentRequest.BuildRequest, parentRequest.BuildRequest.BuildRequestDataFlags);
+            BuildRequest newRequest = new BuildRequest(parentRequest.BuildRequest.SubmissionId, BuildRequest.ResultsTransferNodeRequestId, parentRequest.BuildRequest.ConfigurationId, Array.Empty<string>(), null, parentRequest.BuildRequest.BuildEventContext, parentRequest.BuildRequest, parentRequest.BuildRequest.BuildRequestDataFlags);
 
             // Assign a new global request id - always different from any other.
             newRequest.GlobalRequestId = _nextGlobalRequestId;

--- a/src/Build/Definition/ToolsetRegistryReader.cs
+++ b/src/Build/Definition/ToolsetRegistryReader.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Evaluation
         {
             get
             {
-                string[] toolsVersionNames = new string[] { };
+                string[] toolsVersionNames = Array.Empty<string>();
                 try
                 {
                     RegistryKeyWrapper subKey = null;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -2825,7 +2825,7 @@ namespace Microsoft.Build.Evaluation
                 _methodMethodName = methodName;
                 if (arguments == null)
                 {
-                    _arguments = new string[0];
+                    _arguments = Array.Empty<string>();
                 }
                 else
                 {
@@ -3403,7 +3403,7 @@ namespace Microsoft.Build.Evaluation
                 // If there are no arguments, then just create an empty array
                 if (String.IsNullOrEmpty(argumentsContent))
                 {
-                    functionArguments = new string[0];
+                    functionArguments = Array.Empty<string>();
                 }
                 else
                 {
@@ -3488,7 +3488,7 @@ namespace Microsoft.Build.Evaluation
                     if (argumentStartIndex == expressionFunction.Length - 1)
                     {
                         argumentsContent = String.Empty;
-                        functionArguments = new string[0];
+                        functionArguments = Array.Empty<string>();
                     }
                     else
                     {
@@ -3498,7 +3498,7 @@ namespace Microsoft.Build.Evaluation
                         // If there are no arguments, then just create an empty array
                         if (String.IsNullOrEmpty(argumentsContent))
                         {
-                            functionArguments = new string[0];
+                            functionArguments = Array.Empty<string>();
                         }
                         else
                         {
@@ -3521,7 +3521,7 @@ namespace Microsoft.Build.Evaluation
                         nextMethodIndex = indexerIndex;
                     }
 
-                    functionArguments = new string[0];
+                    functionArguments = Array.Empty<string>();
 
                     if (nextMethodIndex > 0)
                     {

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1547,7 +1547,7 @@ namespace Microsoft.Build.Execution
         /// </remarks>
         public bool Build(string target, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers)
         {
-            string[] targets = (target == null) ? new string[] { } : new string[] { target };
+            string[] targets = (target == null) ? Array.Empty<string>() : new string[] { target };
 
             return Build(targets, loggers, remoteLoggers);
         }
@@ -1989,7 +1989,7 @@ namespace Microsoft.Build.Execution
 
             if (null == targets)
             {
-                targets = new string[] { };
+                targets = Array.Empty<string>();
             }
 
             BuildResult results;

--- a/src/Build/Logging/ParallelLogger/ParallelLoggerHelpers.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelLoggerHelpers.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.BackEnd.Logging
             // or the event is raised before the project started event
             if (startedEvent == null)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
 
             List<ProjectStartedEventMinimumFields> projectStackTrace = GetProjectCallStack(e);

--- a/src/Build/Utilities/RegistryKeyWrapper.cs
+++ b/src/Build/Utilities/RegistryKeyWrapper.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Build.Internal
         {
             try
             {
-                return Exists() ? WrappedKey.GetValueNames() : new string[] { };
+                return Exists() ? WrappedKey.GetValueNames() : Array.Empty<string>();
             }
             catch (Exception ex)
             {
@@ -154,7 +154,7 @@ namespace Microsoft.Build.Internal
         {
             try
             {
-                return Exists() ? WrappedKey.GetSubKeyNames() : new string[] { };
+                return Exists() ? WrappedKey.GetSubKeyNames() : Array.Empty<string>();
             }
             catch (Exception ex)
             {

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -683,7 +683,7 @@ namespace Microsoft.Build.CommandLine
             }
             else if (IsParameterlessSwitchSet(parameterlessSwitch))
             {
-                result = new string[] { };
+                result = Array.Empty<string>();
             }
 
             return result;

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -780,11 +780,11 @@ namespace Microsoft.Build.Shared
             // Some assemblies (real case was interop assembly) may have null PKTs.
             if (aPKT == null)
             {
-                aPKT = new byte[0];
+                aPKT = Array.Empty<byte>();
             }
             if (bPKT == null)
             {
-                bPKT = new byte[0];
+                bPKT = Array.Empty<byte>();
             }
 
             if (aPKT.Length != bPKT.Length)

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -780,11 +780,11 @@ namespace Microsoft.Build.Shared
             // Some assemblies (real case was interop assembly) may have null PKTs.
             if (aPKT == null)
             {
-                aPKT = Array.Empty<byte>();
+                aPKT = new byte[0];
             }
             if (bPKT == null)
             {
-                bPKT = Array.Empty<byte>();
+                bPKT = new byte[0];
             }
 
             if (aPKT.Length != bPKT.Length)

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Build.Shared
 
             if (entries == null)
             {
-                entries = new string[0];
+                entries = Array.Empty<string>();
             }
 
             return entries;
@@ -205,12 +205,12 @@ namespace Microsoft.Build.Shared
             catch (System.Security.SecurityException)
             {
                 // For code access security.
-                return new string[0];
+                return Array.Empty<string>();
             }
             catch (System.UnauthorizedAccessException)
             {
                 // For OS security.
-                return new string[0];
+                return Array.Empty<string>();
             }
         }
 
@@ -257,12 +257,12 @@ namespace Microsoft.Build.Shared
             catch (System.Security.SecurityException)
             {
                 // For code access security.
-                return new string[0];
+                return Array.Empty<string>();
             }
             catch (System.UnauthorizedAccessException)
             {
                 // For OS security.
-                return new string[0];
+                return Array.Empty<string>();
             }
         }
 
@@ -1524,14 +1524,14 @@ namespace Microsoft.Build.Shared
                     // - maintain legacy behaviour where an illegal filespec is treated as a normal string
                     if (FileUtilities.PathsEqual(filespecUnescaped, excludeSpec))
                     {
-                        return new string[0];
+                        return Array.Empty<string>();
                     }
 
                     var match = FileMatch(excludeSpec, filespecUnescaped);
 
                     if (match.isLegalFileSpec && match.isMatch)
                     {
-                        return new string[0];
+                        return Array.Empty<string>();
                     }
                 }
             }
@@ -1580,7 +1580,7 @@ namespace Microsoft.Build.Shared
 
             if (action == SearchAction.ReturnEmptyList)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
             else if (action == SearchAction.ReturnFileSpec)
             {

--- a/src/Shared/NodePacketTranslator.cs
+++ b/src/Shared/NodePacketTranslator.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Build.BackEnd
                 }
                 else
                 {
-                    byteArray = new byte[0];
+                    byteArray = Array.Empty<byte>();
                 }
             }
 

--- a/src/Shared/NodePacketTranslator.cs
+++ b/src/Shared/NodePacketTranslator.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Build.BackEnd
                 }
                 else
                 {
-                    byteArray = Array.Empty<byte>();
+                    byteArray = new byte[0];
                 }
             }
 
@@ -1611,5 +1611,5 @@ namespace Microsoft.Build.BackEnd
             }
         }
 #endif
-                }
+    }
 }

--- a/src/Tasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyInformation.cs
@@ -656,7 +656,7 @@ namespace Microsoft.Build.Tasks
         {
             if (!NativeMethodsShared.IsWindows)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
 
 #if FEATURE_ASSEMBLY_LOADFROM

--- a/src/Tasks/AssemblyDependency/InstalledAssemblies.cs
+++ b/src/Tasks/AssemblyDependency/InstalledAssemblies.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Build.Tasks
         {
             if (_redistList == null)
             {
-                return new AssemblyEntry[0];
+                return Array.Empty<AssemblyEntry>();
             }
 
             return _redistList.FindAssemblyNameFromSimpleName(simpleName);

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Scatter files associated with this reference.
         /// </summary>
-        private string[] _scatterFiles = new string[0];
+        private string[] _scatterFiles = Array.Empty<string>();
 
         /// <summary>
         /// ArrayList of Exception.
@@ -378,7 +378,7 @@ namespace Microsoft.Build.Tasks
         {
             if (scatterFilesToAttach == null || scatterFilesToAttach.Length == 0)
             {
-                _scatterFiles = new string[0];
+                _scatterFiles = Array.Empty<string>();
             }
             else
             {
@@ -645,7 +645,7 @@ namespace Microsoft.Build.Tasks
 
                     if (_fullPath == null || _fullPath.Length == 0)
                     {
-                        _scatterFiles = new string[0];
+                        _scatterFiles = Array.Empty<string>();
                         _satelliteFiles = new ArrayList();
                         _serializationAssemblyFiles = new ArrayList();
                         _assembliesConsideredAndRejected = new ArrayList();

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Tasks
         private Dictionary<AssemblyNameExtension, Reference> _references = new Dictionary<AssemblyNameExtension, Reference>(AssemblyNameComparer.GenericComparer);
 
         /// <summary>The table of remapped assemblies. Used for Unification.</summary>
-        private DependentAssembly[] _remappedAssemblies = new DependentAssembly[0];
+        private DependentAssembly[] _remappedAssemblies = Array.Empty<DependentAssembly>();
         /// <summary>If true, then search for dependencies.</summary>
         private bool _findDependencies = true;
         /// <summary>
@@ -2434,13 +2434,13 @@ namespace Microsoft.Build.Tasks
             out ITaskItem[] copyLocalFiles
         )
         {
-            primaryFiles = new ITaskItem[0];
-            dependencyFiles = new ITaskItem[0];
-            relatedFiles = new ITaskItem[0];
-            satelliteFiles = new ITaskItem[0];
-            serializationAssemblyFiles = new ITaskItem[0];
-            scatterFiles = new ITaskItem[0];
-            copyLocalFiles = new ITaskItem[0];
+            primaryFiles = Array.Empty<ITaskItem>();
+            dependencyFiles = Array.Empty<ITaskItem>();
+            relatedFiles = Array.Empty<ITaskItem>();
+            satelliteFiles = Array.Empty<ITaskItem>();
+            serializationAssemblyFiles = Array.Empty<ITaskItem>();
+            scatterFiles = Array.Empty<ITaskItem>();
+            copyLocalFiles = Array.Empty<ITaskItem>();
 
             ArrayList primaryItems = new ArrayList();
             ArrayList dependencyItems = new ArrayList();

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -58,17 +58,17 @@ namespace Microsoft.Build.Tasks
 
         #region Properties
 
-        private ITaskItem[] _assemblyFiles = new TaskItem[0];
-        private ITaskItem[] _assemblyNames = new TaskItem[0];
-        private ITaskItem[] _installedAssemblyTables = new TaskItem[0];
-        private ITaskItem[] _installedAssemblySubsetTables = new TaskItem[0];
-        private ITaskItem[] _fullFrameworkAssemblyTables = new TaskItem[0];
-        private ITaskItem[] _resolvedSDKReferences = new TaskItem[0];
+        private ITaskItem[] _assemblyFiles = Array.Empty<TaskItem>();
+        private ITaskItem[] _assemblyNames = Array.Empty<TaskItem>();
+        private ITaskItem[] _installedAssemblyTables = Array.Empty<TaskItem>();
+        private ITaskItem[] _installedAssemblySubsetTables = Array.Empty<TaskItem>();
+        private ITaskItem[] _fullFrameworkAssemblyTables = Array.Empty<TaskItem>();
+        private ITaskItem[] _resolvedSDKReferences = Array.Empty<TaskItem>();
         private bool _ignoreDefaultInstalledAssemblyTables = false;
         private bool _ignoreDefaultInstalledAssemblySubsetTables = false;
-        private string[] _candidateAssemblyFiles = new string[0];
-        private string[] _targetFrameworkDirectories = new string[0];
-        private string[] _searchPaths = new string[0];
+        private string[] _candidateAssemblyFiles = Array.Empty<string>();
+        private string[] _targetFrameworkDirectories = Array.Empty<string>();
+        private string[] _searchPaths = Array.Empty<string>();
         private string[] _allowedAssemblyExtensions = new string[] { ".winmd", ".dll", ".exe" };
         private string[] _relatedFileExtensions = new string[] { ".pdb", ".xml", ".pri" };
         private string _appConfigFile = null;
@@ -76,16 +76,16 @@ namespace Microsoft.Build.Tasks
         private bool _autoUnify = false;
         private bool _ignoreVersionForFrameworkReferences = false;
         private bool _ignoreTargetFrameworkAttributeVersionMismatch = false;
-        private ITaskItem[] _resolvedFiles = new TaskItem[0];
-        private ITaskItem[] _resolvedDependencyFiles = new TaskItem[0];
-        private ITaskItem[] _relatedFiles = new TaskItem[0];
-        private ITaskItem[] _satelliteFiles = new TaskItem[0];
-        private ITaskItem[] _serializationAssemblyFiles = new TaskItem[0];
-        private ITaskItem[] _scatterFiles = new TaskItem[0];
-        private ITaskItem[] _copyLocalFiles = new TaskItem[0];
-        private ITaskItem[] _suggestedRedirects = new TaskItem[0];
-        private string[] _targetFrameworkSubsets = new string[0];
-        private string[] _fullTargetFrameworkSubsetNames = new string[0];
+        private ITaskItem[] _resolvedFiles = Array.Empty<TaskItem>();
+        private ITaskItem[] _resolvedDependencyFiles = Array.Empty<TaskItem>();
+        private ITaskItem[] _relatedFiles = Array.Empty<TaskItem>();
+        private ITaskItem[] _satelliteFiles = Array.Empty<TaskItem>();
+        private ITaskItem[] _serializationAssemblyFiles = Array.Empty<TaskItem>();
+        private ITaskItem[] _scatterFiles = Array.Empty<TaskItem>();
+        private ITaskItem[] _copyLocalFiles = Array.Empty<TaskItem>();
+        private ITaskItem[] _suggestedRedirects = Array.Empty<TaskItem>();
+        private string[] _targetFrameworkSubsets = Array.Empty<string>();
+        private string[] _fullTargetFrameworkSubsetNames = Array.Empty<string>();
         private string _targetedFrameworkMoniker = String.Empty;
 
         private bool _findDependencies = true;
@@ -101,8 +101,8 @@ namespace Microsoft.Build.Tasks
         private string _targetProcessorArchitecture = null;
 
         private string _profileName = String.Empty;
-        private string[] _fullFrameworkFolders = new string[0];
-        private string[] _latestTargetFrameworkDirectories = new string[0];
+        private string[] _fullFrameworkFolders = Array.Empty<string>();
+        private string[] _latestTargetFrameworkDirectories = Array.Empty<string>();
         private bool _copyLocalDependenciesWhenParentReferenceInGac = true;
         private Dictionary<string, MessageImportance> _showAssemblyFoldersExLocations = new Dictionary<string, MessageImportance>(StringComparer.OrdinalIgnoreCase);
         private bool _logVerboseSearchResults = false;

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Tasks
 
         #region Properties
 
-        private ITaskItem[] _files = new TaskItem[0];
+        private ITaskItem[] _files = Array.Empty<TaskItem>();
         private ITaskItem[] _assignedFiles = null;
         private ITaskItem[] _assignedFilesWithCulture = null;
         private ITaskItem[] _assignedFilesWithNoCulture = null;

--- a/src/Tasks/AssignTargetPath.cs
+++ b/src/Tasks/AssignTargetPath.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Tasks
         #region Properties
 
         private string _rootFolder = null;
-        private ITaskItem[] _files = new ITaskItem[0];
+        private ITaskItem[] _files = Array.Empty<ITaskItem>();
         private ITaskItem[] _assignedFiles = null;
 
         /// <summary>

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -399,8 +399,8 @@ namespace Microsoft.Build.Tasks
             // If there are no source files then just return success.
             if (_sourceFiles == null || _sourceFiles.Length == 0)
             {
-                _destinationFiles = new TaskItem[0];
-                _copiedFiles = new TaskItem[0];
+                _destinationFiles = Array.Empty<TaskItem>();
+                _copiedFiles = Array.Empty<TaskItem>();
                 return true;
             }
 
@@ -539,7 +539,7 @@ namespace Microsoft.Build.Tasks
                     {
                         Log.LogErrorWithCodeFromResources("Copy.Error", _sourceFiles[i].ItemSpec, _destinationFolder.ItemSpec, e.Message);
                         // Clear the outputs.
-                        _destinationFiles = new ITaskItem[0];
+                        _destinationFiles = Array.Empty<ITaskItem>();
                         return false;
                     }
 

--- a/src/Tasks/CreateItem.cs
+++ b/src/Tasks/CreateItem.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Tasks
         {
             if (Include == null)
             {
-                _include = new TaskItem[0];
+                _include = Array.Empty<TaskItem>();
                 return true;
             }
 

--- a/src/Tasks/CreateProperty.cs
+++ b/src/Tasks/CreateProperty.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Build.Tasks
         {
             if (_prop == null)
             {
-                _prop = new string[0];
+                _prop = Array.Empty<string>();
             }
 
             return true;

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Build.Tasks
         [Output]
         public ITaskItem[] Outputs
         {
-            get { return _outputs ?? new ITaskItem[0]; }
+            get { return _outputs ?? Array.Empty<ITaskItem>(); }
             set { _outputs = value; }
         }
 
@@ -204,7 +204,7 @@ namespace Microsoft.Build.Tasks
         [Output]
         public ITaskItem[] ConsoleOutput
         {
-            get { return !ConsoleToMSBuild ? new ITaskItem[0] : _nonEmptyOutput.ToArray(); }
+            get { return !ConsoleToMSBuild ? Array.Empty<ITaskItem>(): _nonEmptyOutput.ToArray(); }
         }
 
         #endregion

--- a/src/Tasks/FileIO/ReadLinesFromFile.cs
+++ b/src/Tasks/FileIO/ReadLinesFromFile.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Tasks
     public class ReadLinesFromFile : TaskExtension
     {
         private ITaskItem _file = null;
-        private ITaskItem[] _lines = new TaskItem[0];
+        private ITaskItem[] _lines = Array.Empty<TaskItem>();
 
         /// <summary>
         /// File to read lines from.

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -418,7 +418,7 @@ namespace Microsoft.Build.Tasks
         {
             get
             {
-                return new ITaskItem[0];
+                return Array.Empty<ITaskItem>();
             }
         }
 
@@ -430,7 +430,7 @@ namespace Microsoft.Build.Tasks
         {
             get
             {
-                return new ITaskItem[0];
+                return Array.Empty<ITaskItem>();
             }
         }
 

--- a/src/Tasks/GetInstalledSDKLocations.cs
+++ b/src/Tasks/GetInstalledSDKLocations.cs
@@ -194,8 +194,8 @@ namespace Microsoft.Build.Tasks
                     item.SetMetadata("PlatformVersion", sdk.Value.Item2);
 
                     // Need to stash these so we can unroll the platform via GetMatchingPlatformSDK when we get the reference files for the sdks
-                    item.SetMetadata(DirectoryRootsMetadataName, String.Join(";", SDKDirectoryRoots ?? new string[0]));
-                    item.SetMetadata(ExtensionDirectoryRootsMetadataName, String.Join(";", SDKExtensionDirectoryRoots ?? new string[0]));
+                    item.SetMetadata(DirectoryRootsMetadataName, String.Join(";", SDKDirectoryRoots ?? Array.Empty<string>()));
+                    item.SetMetadata(ExtensionDirectoryRootsMetadataName, String.Join(";", SDKExtensionDirectoryRoots ?? Array.Empty<string>()));
                     item.SetMetadata(RegistryRootMetadataName, SDKRegistryRoot);
 
                     outputItems.Add(item);

--- a/src/Tasks/GetReferenceAssemblyPaths.cs
+++ b/src/Tasks/GetReferenceAssemblyPaths.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-                    return new string[0];
+                    return Array.Empty<string>();
                 }
             }
         }
@@ -106,7 +106,7 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-                    return new string[0];
+                    return Array.Empty<string>();
                 }
             }
         }

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -30,22 +30,22 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Set of resolvedSDK references which we will use to find the reference assemblies.
         /// </summary>
-        private ITaskItem[] _resolvedSDKReferences = new TaskItem[0];
+        private ITaskItem[] _resolvedSDKReferences = Array.Empty<TaskItem>();
 
         /// <summary>
         /// Set of the redist files for the resolved sdks
         /// </summary>
-        private ITaskItem[] _sdkRedistFiles = new TaskItem[0];
+        private ITaskItem[] _sdkRedistFiles = Array.Empty<TaskItem>();
 
         /// <summary>
         /// Resolved reference assemblies from the SDK
         /// </summary>
-        private ITaskItem[] _references = new TaskItem[0];
+        private ITaskItem[] _references = Array.Empty<TaskItem>();
 
         /// <summary>
         /// Redist files from the SDKs
         /// </summary>
-        private ITaskItem[] _redistFiles = new TaskItem[0];
+        private ITaskItem[] _redistFiles = Array.Empty<TaskItem>();
 
         /// <summary>
         /// Set of resolved reference assemblies. This removes any duplicate ones between sdks.
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Files to be copied locally
         /// </summary>
-        private ITaskItem[] _copyLocalFiles = new TaskItem[0];
+        private ITaskItem[] _copyLocalFiles = Array.Empty<TaskItem>();
 
         /// <summary>
         /// Set of reference assembly extensions to look for.
@@ -1302,7 +1302,7 @@ namespace Microsoft.Build.Tasks
                     return Directory.GetDirectories(redistPath, "*", SearchOption.AllDirectories).ToList<string>();
                 }
 
-                return new string[0];
+                return Array.Empty<string>();
             }
 
             /// <summary>
@@ -1316,7 +1316,7 @@ namespace Microsoft.Build.Tasks
                     return Directory.GetDirectories(referencesPath, "*", SearchOption.AllDirectories).ToList<string>();
                 }
 
-                return new string[0];
+                return Array.Empty<string>();
             }
         }
 

--- a/src/Tasks/ListOperators/FindUnderPath.cs
+++ b/src/Tasks/ListOperators/FindUnderPath.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Tasks
     {
         private bool _updateToAbsolutePaths = false;
         private ITaskItem _path = null;
-        private ITaskItem[] _files = new TaskItem[0];
+        private ITaskItem[] _files = Array.Empty<TaskItem>();
         private ITaskItem[] _inPath = null;
         private ITaskItem[] _outOfPath = null;
 

--- a/src/Tasks/ListOperators/RemoveDuplicates.cs
+++ b/src/Tasks/ListOperators/RemoveDuplicates.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class RemoveDuplicates : TaskExtension
     {
-        private ITaskItem[] _inputs = new TaskItem[0];
+        private ITaskItem[] _inputs = Array.Empty<TaskItem>();
         private ITaskItem[] _filtered = null;
 
         /// <summary>

--- a/src/Tasks/ManifestUtil/ComImporter.cs
+++ b/src/Tasks/ManifestUtil/ComImporter.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private readonly ResourceManager _resources = new ResourceManager("Microsoft.Build.Tasks.Core.Strings.ManifestUtilities", System.Reflection.Assembly.GetExecutingAssembly());
         private bool _success = true;
 
-        private readonly static string[] s_emptyArray = Array.Empty<string>();
-
         // These must be defined in sorted order!
         private readonly static string[] s_knownImplementedCategories = new string[]
         {
@@ -118,7 +116,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
         private void CheckForUnknownSubKeys(RegistryKey key)
         {
-            CheckForUnknownSubKeys(key, s_emptyArray);
+            CheckForUnknownSubKeys(key, Array.Empty<string>());
         }
 
         private void CheckForUnknownSubKeys(RegistryKey key, string[] knownNames)
@@ -131,7 +129,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 
         private void CheckForUnknownValues(RegistryKey key)
         {
-            CheckForUnknownValues(key, s_emptyArray);
+            CheckForUnknownValues(key, Array.Empty<string>());
         }
 
         private void CheckForUnknownValues(RegistryKey key, string[] knownNames)

--- a/src/Tasks/ManifestUtil/ComImporter.cs
+++ b/src/Tasks/ManifestUtil/ComImporter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         private readonly ResourceManager _resources = new ResourceManager("Microsoft.Build.Tasks.Core.Strings.ManifestUtilities", System.Reflection.Assembly.GetExecutingAssembly());
         private bool _success = true;
 
-        private readonly static string[] s_emptyArray = new string[] { };
+        private readonly static string[] s_emptyArray = Array.Empty<string>();
 
         // These must be defined in sorted order!
         private readonly static string[] s_knownImplementedCategories = new string[]

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -517,7 +517,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     a[i++] = node.Value;
             }
             else
-                a = new string[0];
+                a = Array.Empty<string>();
             return a;
         }
 

--- a/src/Tasks/Move.cs
+++ b/src/Tasks/Move.cs
@@ -111,8 +111,8 @@ namespace Microsoft.Build.Tasks
             // If there are no source files then just return success.
             if (SourceFiles == null || SourceFiles.Length == 0)
             {
-                DestinationFiles = new TaskItem[0];
-                _movedFiles = new TaskItem[0];
+                DestinationFiles = Array.Empty<TaskItem>();
+                _movedFiles = Array.Empty<TaskItem>();
                 return true;
             }
 
@@ -155,7 +155,7 @@ namespace Microsoft.Build.Tasks
                         Log.LogErrorWithCodeFromResources("Move.Error", SourceFiles[i].ItemSpec, DestinationFolder.ItemSpec, e.Message);
 
                         // Clear the outputs.
-                        DestinationFiles = new ITaskItem[0];
+                        DestinationFiles = Array.Empty<ITaskItem>();
                         return false;
                     }
 

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Build.Tasks
         public static RedistList GetFrameworkList20()
         {
             string frameworkVersion20Path = ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version20);
-            string[] redistListPaths = new string[0];
+            string[] redistListPaths = Array.Empty<string>();
             if (frameworkVersion20Path != null)
             {
                 redistListPaths = RedistList.GetRedistListPathsFromDisk(frameworkVersion20Path);
@@ -274,7 +274,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         public static RedistList GetRedistListFromPath(string path)
         {
-            string[] redistListPaths = (path == null) ? new string[0] : RedistList.GetRedistListPathsFromDisk(path);
+            string[] redistListPaths = (path == null) ? Array.Empty<string>(): RedistList.GetRedistListPathsFromDisk(path);
 
             AssemblyTableInfo[] assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
 
@@ -292,7 +292,7 @@ namespace Microsoft.Build.Tasks
 
             // On dogfood build machines, v3.5 is not formally installed, so this returns null.
             // We don't use redist lists in this case.            
-            string[] redistListPaths = (referenceAssembliesPath == null) ? new string[0] : RedistList.GetRedistListPathsFromDisk(referenceAssembliesPath);
+            string[] redistListPaths = (referenceAssembliesPath == null) ? Array.Empty<string>(): RedistList.GetRedistListPathsFromDisk(referenceAssembliesPath);
 
             AssemblyTableInfo[] assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
 
@@ -340,7 +340,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            return new string[0];
+            return Array.Empty<string>();
         }
 
         /// <summary>
@@ -1135,7 +1135,7 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            return new string[0];
+            return Array.Empty<string>();
         }
         #endregion
     }

--- a/src/Tasks/ResGen.cs
+++ b/src/Tasks/ResGen.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Build.Tasks
                     {
                         if (!File.Exists(outputFile.ItemSpec))
                         {
-                            this.OutputFiles = new ITaskItem[0];
+                            this.OutputFiles = Array.Empty<ITaskItem>();
                         }
                     }
 

--- a/src/Tasks/ResolveComReference.cs
+++ b/src/Tasks/ResolveComReference.cs
@@ -1395,7 +1395,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         internal IEnumerable<string> GetResolvedAssemblyReferenceItemSpecs()
         {
-            return (ResolvedAssemblyReferences == null) ? new string[0] : ResolvedAssemblyReferences.Select(rar => rar.ItemSpec);
+            return (ResolvedAssemblyReferences == null) ? Array.Empty<string>(): ResolvedAssemblyReferences.Select(rar => rar.ItemSpec);
         }
 
         /// <summary>

--- a/src/Tasks/ResolveNativeReference.cs
+++ b/src/Tasks/ResolveNativeReference.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Build.Tasks
         private ITaskItem[] _containedTypeLibraries = null;
         private ITaskItem[] _containedLooseTlbFiles = null;
         private ITaskItem[] _containedLooseEtcFiles = null;
-        private string[] _additionalSearchPaths = new string[0];
+        private string[] _additionalSearchPaths = Array.Empty<string>();
         #endregion
 
         #region Nested classes

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -79,12 +79,12 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         ///  Set of sdk references to resolve to paths on disk.
         /// </summary>
-        private ITaskItem[] _sdkReferences = new ITaskItem[0];
+        private ITaskItem[] _sdkReferences = Array.Empty<ITaskItem>();
 
         /// <summary>
         /// The list of installed SDKs the location of the SDK, the SDKName metadata is the SDKName.
         /// </summary>
-        private ITaskItem[] _installedSDKs = new ITaskItem[0];
+        private ITaskItem[] _installedSDKs = Array.Empty<ITaskItem>();
 
         /// <summary>
         /// Should resolution errors be logged as warnings or errors.
@@ -356,7 +356,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public override bool Execute()
         {
-            ResolvedSDKReferences = new TaskItem[0];
+            ResolvedSDKReferences = Array.Empty<TaskItem>();
 
             if (InstalledSDKs.Length == 0)
             {

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1125,7 +1125,7 @@ namespace Microsoft.Build.Utilities
                 ErrorUtilities.DebugTraceMessage("GetLegacyTargetPlatformReferences", "Encountered exception trying to gather the platform references: {0}", e.Message);
             }
 
-            return new string[0];
+            return Array.Empty<string>();
         }
 
         /// <summary>
@@ -1148,7 +1148,7 @@ namespace Microsoft.Build.Utilities
             ErrorUtilities.VerifyThrowArgumentLength(targetPlatformIdentifier, "targetPlatformIdentifier");
             ErrorUtilities.VerifyThrowArgumentLength(targetPlatformVersion, "targetPlatformVersion");
 
-            string[] contractWinMDs = new string[0];
+            string[] contractWinMDs = Array.Empty<string>();
 
             TargetPlatformSDK matchingSdk = GetMatchingPlatformSDK(targetPlatformIdentifier, targetPlatformVersion, diskRoots, null, registryRoot);
             string platformKey = TargetPlatformSDK.GetSdkKey(targetPlatformIdentifier, targetPlatformVersion);
@@ -1190,7 +1190,7 @@ namespace Microsoft.Build.Utilities
         {
             if (apiContracts == null)
             {
-                return new string[] { };
+                return Array.Empty<string>();
             }
 
             List<string> contractWinMDs = new List<string>();

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedInputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedInputFiles.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Build.Utilities
             if (_sourcesNeedingCompilation.Length == 0)
             {
                 FileTracker.LogMessageFromResources(_log, MessageImportance.Normal, "Tracking_AllOutputsAreUpToDate");
-                _sourcesNeedingCompilation = new ITaskItem[0];
+                _sourcesNeedingCompilation = Array.Empty<ITaskItem>();
             }
             else
             {
@@ -427,7 +427,7 @@ namespace Microsoft.Build.Utilities
                 {
                     // All sources and outputs exist, and the oldest output is newer than the newest input -- we're up to date!
                     FileTracker.LogMessageFromResources(_log, MessageImportance.Normal, "Tracking_AllOutputsAreUpToDate");
-                    return new ITaskItem[0];
+                    return Array.Empty<ITaskItem>();
                 }
             }
 


### PR DESCRIPTION
Replaced all usage across the tree of empty array creation with Array.Empty<T> to remove unneeded allocations. Avoided tests to reduce the diff and because of diminishing returns.