### PR TITLE
Update License to reflect .Net Foundation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
+MSBuild
+
 The MIT License (MIT)
 
-Copyright (c) 2015 Microsoft
+Copyright (c) .NET Foundation and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Legal team pointed out that our license should reflect that MSBuild is a .NET Foundation project.