### PR TITLE
Add target framework metadata to TargetPathWithTargetPlatformMoniker

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1834,6 +1834,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <TargetPathWithTargetPlatformMoniker Include="$(TargetPath)">
         <TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
         <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+        <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
+        <TargetFrameworkVersion>$(TargetFrameworkVersion)</TargetFrameworkVersion>
+        <TargetFrameworkVersion Condition="$(TargetFrameworkVersion.StartsWith('v'))">$(TargetFrameworkVersion.Substring(1))</TargetFrameworkVersion>
         <ReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == 'true'">$(TargetRefPath)</ReferenceAssembly>
         <CopyUpToDateMarker>@(CopyUpToDateMarker)</CopyUpToDateMarker>
       </TargetPathWithTargetPlatformMoniker>

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -92,7 +92,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <PropertyGroup>
       <!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
-      <_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
+      <_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true'">true</_HasReferenceToSystemRuntime>
+      <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
+      <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard' and '%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' &lt; '2.0'">true</_HasReferenceToSystemRuntime>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">


### PR DESCRIPTION
...and check it in ImplicitlyExpandDesignTimeFacades

Fixes dotnet/sdk#1393.  What is happening with that bug is that the System.Runtime facades are not being added in the design-time build when you have a reference from a .NET Framework project to a .NET Standard 1.x project that doesn't have any output on disk yet.  This results in failed intellisense, which persists even after you build the solution and/or restart VS, because the design-time build is cached.

An alternative fix to this would be to set the `TargetPlatformIdentifier` of .NET Standard projects to `Portable`.  Then the existing logic that handles references to PCLs would kick in.  I would like to change the `TargetPlatformIdentifier` of .NET Standard projects to `Portable` in the future, as I think it's more correct than the current value of `Windows`.  However, the change in this PR should be less risky so I think it's the right way to fix the bug for now.