### PR TITLE
Reduce allocation in _GenerateCompileDependencyCache

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3291,8 +3291,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="_GenerateCompileDependencyCache" DependsOnTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
-      <CoreCompileCache Include="@(Compile->'%(FullPath)')" />
-      <CoreCompileCache Include="@(ReferencePath->'%(FullPath)')" />
+      <CoreCompileCache Include="@(Compile)" />
+      <CoreCompileCache Include="@(ReferencePath)" />
     </ItemGroup>
 
     <Hash ItemsToHash="@(CoreCompileCache)">


### PR DESCRIPTION
Avoid calling FullPath and the associated performance penalty. We should
not need the FullPath in this case as we are only hashing the list of
files (relative path is fine since the cache is per project).

Fixes #2276

On the project in the bug time spent in _GenerateCompileDependencyCache target went from ~30ms to ~10ms (debug bits).