### PR TITLE
Self referencing Update operations skip matching

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Build.Evaluation
                 return listBuilder.Select(itemData => itemData.Item).ToList();
             }
 
+            // todo Refactoring: MutateItems should clone each item before mutation (see Update). Make a template method that clones the items to be mutated so that all operations get the behaviour
             protected virtual void MutateItems(ICollection<I> items) { }
 
             protected virtual void SaveItems(ICollection<I> items, ImmutableList<ItemData>.Builder listBuilder) { }

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Evaluation
                 return listBuilder.Select(itemData => itemData.Item).ToList();
             }
 
-            // todo Refactoring: MutateItems should clone each item before mutation (see Update). Make a template method that clones the items to be mutated so that all operations get the behaviour
+            // todo Refactoring: MutateItems should clone each item before mutation. See https://github.com/Microsoft/msbuild/issues/2328
             protected virtual void MutateItems(ICollection<I> items) { }
 
             protected virtual void SaveItems(ICollection<I> items, ImmutableList<ItemData>.Builder listBuilder) { }

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Build.Evaluation
             {
             }
 
-            //todo port the self referencing matching optimization (e.g. <I Remove="@(I)">) from Update to Remove as well. Ideally make one mechanism for both
+            // todo port the self referencing matching optimization (e.g. <I Remove="@(I)">) from Update to Remove as well. Ideally make one mechanism for both. https://github.com/Microsoft/msbuild/issues/2314
+            // todo Perf: do not match against the globs: https://github.com/Microsoft/msbuild/issues/2329
             protected override ICollection<I> SelectItems(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
                 return SelectItemsMatchingItemSpec(listBuilder, _itemElement.RemoveLocation).ToImmutableHashSet();

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Build.Evaluation
             {
             }
 
+            //todo port the self referencing matching optimization (e.g. <I Remove="@(I)">) from Update to Remove as well. Ideally make one mechanism for both
             protected override ICollection<I> SelectItems(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
                 return SelectItemsMatchingItemSpec(listBuilder, _itemElement.RemoveLocation).ToImmutableHashSet();

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Build.Construction;
 using System.Collections.Immutable;
@@ -20,6 +21,8 @@ namespace Microsoft.Build.Evaluation
                 _metadata = builder.Metadata.ToImmutable();
             }
 
+            delegate bool ItemSpecMatchesItem(ItemSpec<P, I> itemSpec, I item);
+
             public override void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
                 if (!_conditionResult)
@@ -27,16 +30,30 @@ namespace Microsoft.Build.Evaluation
                     return;
                 }
 
-                var matchedItems = ImmutableList.CreateBuilder<I>();
+                ItemSpecMatchesItem matchItemspec;
+
+                if (ItemSpecOnlyReferencesOneItemType(_itemSpec, _itemElement.ItemType))
+                {
+                    // Perf optimization: If the Update operation references itself (e.g. <I Update="@(I)"/>)
+                    // then all items are updated and matching is not necessary
+                    matchItemspec = (itemSpec, item) => true;
+                }
+                else
+                {
+                    matchItemspec = (itemSpec, item) => itemSpec.MatchesItem(item);
+                }
+
+                ICollection<I> matchedItems = ImmutableList.CreateBuilder<I>();
 
                 for (int i = 0; i < listBuilder.Count; i++)
                 {
                     var itemData = listBuilder[i];
 
-                    if (_itemSpec.MatchesItem(itemData.Item))
+                    if (matchItemspec(_itemSpec, itemData.Item))
                     {
-                        // item lists should be deep immutable, so clone and replace items before mutating them
-                        // otherwise, with GetItems caching enabled, future operations would mutate the state of past operations
+                        // items should be deep immutable, so clone and replace items before mutating them
+                        // otherwise, with GetItems caching enabled, the mutations would leak into the cache causing
+                        // future operations to mutate the state of past operations
                         var clonedItemData = listBuilder[i].Clone(_itemFactory, _itemElement);
                         listBuilder[i] = clonedItemData;
 
@@ -45,6 +62,28 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 DecorateItemsWithMetadata(matchedItems, _metadata);
+            }
+
+            private static bool ItemSpecOnlyReferencesOneItemType(ItemSpec<P, I> itemSpec, string itemType)
+            {
+                if (itemSpec.Fragments.Count() != 1)
+                {
+                    return false;
+                }
+
+                var itemExpressionFragment = itemSpec.Fragments.First() as ItemExpressionFragment<P, I>;
+
+                if (itemExpressionFragment == null)
+                {
+                    return false;
+                }
+
+                if (!itemExpressionFragment.Capture.ItemType.Equals(itemType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                return true;
             }
         }
     }

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Evaluation
                     return false;
                 }
 
-                var itemExpressionFragment = itemSpec.Fragments.First() as ItemExpressionFragment<P, I>;
+                var itemExpressionFragment = itemSpec.Fragments.Single() as ItemExpressionFragment<P, I>;
 
                 if (itemExpressionFragment == null)
                 {


### PR DESCRIPTION
Perf optimization: If the Update operation references itself (e.g. `<I Update="@(I)"/>`) then all items are updated and matching is not necessary.

Implements the simpler, more constrained optimization from #2314