### PR TITLE
Remove unneeded substring

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -632,7 +632,7 @@ namespace Microsoft.Build.Evaluation
                                     ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "InvalidFunctionPropertyExpression", expressionFunction, AssemblyResources.GetString("InvalidFunctionPropertyExpressionDetailMismatchedParenthesis"));
                                 }
 
-                                argumentBuilder.Append(argumentsString.Substring(nestedPropertyStart, (n - nestedPropertyStart) + 1));
+                                argumentBuilder.Append(argumentsString, nestedPropertyStart, (n - nestedPropertyStart) + 1);
                             }
                             else if (argumentsContent[n] == '`' || argumentsContent[n] == '"' || argumentsContent[n] == '\'')
                             {
@@ -646,7 +646,7 @@ namespace Microsoft.Build.Evaluation
                                     ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "InvalidFunctionPropertyExpression", expressionFunction, AssemblyResources.GetString("InvalidFunctionPropertyExpressionDetailMismatchedQuote"));
                                 }
 
-                                argumentBuilder.Append(argumentsString.Substring(quoteStart, (n - quoteStart) + 1));
+                                argumentBuilder.Append(argumentsString, quoteStart, (n - quoteStart) + 1);
                             }
                             else if (argumentsContent[n] == ',')
                             {


### PR DESCRIPTION
This was showing up as ~2% of all allocations in this trace: https://github.com/dotnet/sdk/pull/1432#issuecomment-316852561.

![image](https://user-images.githubusercontent.com/1103906/28446983-872aef1e-6e11-11e7-85da-9e9c3cda701d.png)

To make sure this wasn't causing additional overhead (as there's additional argument checking in the StringBuilder.Append(string, int, int) overload, I did a MicroBench mark:

``` C#
[MemoryDiagnoser]
public class SubString
{
    public string Field = "This is a real long long argument";

    [Benchmark]
    public void StringBuilder_Append()
    {
        for (int i = 0; i < 10000; i++)
        {
            StringBuilder builder = new StringBuilder();

            for (int j = 0; j < 5; j++)
            {
                builder.Append(Field, 20, 11);
            }
        }
    }

    [Benchmark]
    public void StringBuilder_AppendViaSubString()
    {
        for (int i = 0; i < 10000; i++)
        {
            StringBuilder builder = new StringBuilder();

            for (int j = 0; j < 5; j++)
            {
                builder.Append(Field.Substring(20, 11));
            }
        }
    }
}
```
Method |     Mean |     Error |    StdDev |     Gen 0 | Allocated |
--------------------------------- |---------:|----------:|----------:|----------:|----------:|
StringBuilder_Append | 1.325 ms | 0.0060 ms | 0.0053 ms |  589.8438 |   2.37 MB |
StringBuilder_AppendViaSubString | 1.896 ms | 0.0115 ms | 0.0108 ms | 1019.5313 |   4.08 MB |

