### PR TITLE
Avoid creating char[] allocations

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -108,6 +108,10 @@ namespace Microsoft.Build.Evaluation
         where P : class, IProperty
         where I : class, IItem
     {
+        private static readonly char[] s_singleQuoteChar = { '\'' };
+        private static readonly char[] s_backtickChar = { '`' };
+        private static readonly char[] s_doubleQuoteChar = { '"' };
+
         /// <summary>
         /// Those characters which indicate that an expression may contain expandable
         /// expressions
@@ -573,15 +577,15 @@ namespace Microsoft.Build.Evaluation
                 {
                     if (argValue[0] == '\'' && argValue[argValue.Length - 1] == '\'')
                     {
-                        arguments.Add(argValue.Trim('\''));
+                        arguments.Add(argValue.Trim(s_singleQuoteChar));
                     }
                     else if (argValue[0] == '`' && argValue[argValue.Length - 1] == '`')
                     {
-                        arguments.Add(argValue.Trim('`'));
+                        arguments.Add(argValue.Trim(s_backtickChar));
                     }
                     else if (argValue[0] == '"' && argValue[argValue.Length - 1] == '"')
                     {
-                        arguments.Add(argValue.Trim('"'));
+                        arguments.Add(argValue.Trim(s_doubleQuoteChar));
                     }
                     else
                     {


### PR DESCRIPTION
This was allocation 0.3% of all allocations in some traces.

![image](https://user-images.githubusercontent.com/1103906/28447510-88ce0d8a-6e14-11e7-8595-8161d27558ec.png)
