### PR TITLE
Detect MSBuild amd64 environment running outside VS

### DIFF
--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -321,6 +321,40 @@ namespace Microsoft.Build.Engine.UnitTests
         [Fact]
         [Trait("Category", "nonlinuxtests")]
         [Trait("Category", "nonosxtests")]
+        public void BuildEnvironmentFindsAmd64RunningInAmd64NoVS()
+        {
+            using (var env = new EmptyStandaloneEnviroment(MSBuildExeName, writeFakeFiles:true, includeAmd64Folder:true))
+            {
+                var msBuild64Exe = Path.Combine(env.BuildDirectory, "amd64", MSBuildExeName);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => msBuild64Exe, ReturnNull, ReturnNull,
+                    env.VsInstanceMock, env.EnvironmentMock);
+
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(Path.Combine(env.BuildDirectory, "amd64"));
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBeNull();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.Standalone);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
+        public void BuildEnvironmentFindsAmd64NoVS()
+        {
+            using (var env = new EmptyStandaloneEnviroment(MSBuildExeName, writeFakeFiles: true, includeAmd64Folder: true))
+            {
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull,
+                    ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(Path.Combine(env.BuildDirectory, "amd64"));
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.Standalone);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentFindsAmd64RunningInAmd64()
         {
             using (var env = new EmptyVSEnviroment())
@@ -412,7 +446,7 @@ namespace Microsoft.Build.Engine.UnitTests
 
             private readonly List<VisualStudioInstance> _mockInstances = new List<VisualStudioInstance>();
 
-            public EmptyStandaloneEnviroment(string msBuildExeName, bool writeFakeFiles = true)
+            public EmptyStandaloneEnviroment(string msBuildExeName, bool writeFakeFiles = true, bool includeAmd64Folder = false)
             {
                 try
                 {
@@ -425,6 +459,13 @@ namespace Microsoft.Build.Engine.UnitTests
                     {
                         File.WriteAllText(MSBuildExePath, string.Empty);
                         File.WriteAllText($"{MSBuildExePath}.config", string.Empty);
+
+                        if (includeAmd64Folder)
+                        {
+                            Directory.CreateDirectory(Path.Combine(BuildDirectory, "amd64"));
+                            File.WriteAllText(Path.Combine(BuildDirectory, "amd64", msBuildExeName), string.Empty);
+                            File.WriteAllText(Path.Combine(BuildDirectory, "amd64", $"{MSBuildExePath}.config"), string.Empty);
+                        }
                     }
                 }
                 catch (Exception)

--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Shared;
+using Shouldly;
 using Xunit;
 
 namespace Microsoft.Build.Engine.UnitTests
@@ -28,10 +29,10 @@ namespace Microsoft.Build.Engine.UnitTests
             string toolsDirectoryPath = BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.ToLowerInvariant();
             string actualMSBuildPath = BuildEnvironmentHelper.Instance.CurrentMSBuildExePath.ToLowerInvariant();
 
-            Assert.Equal(configFilePath, actualMSBuildPath + ".config");
-            Assert.Equal(expectedMSBuildPath, actualMSBuildPath);
-            Assert.Equal(toolsDirectoryPath, Path.GetDirectoryName(expectedMSBuildPath));
-            Assert.Equal(BuildEnvironmentMode.Standalone, BuildEnvironmentHelper.Instance.Mode);
+            configFilePath.ShouldBe($"{actualMSBuildPath}.config");
+            actualMSBuildPath.ShouldBe(expectedMSBuildPath);
+            Path.GetDirectoryName(expectedMSBuildPath).ShouldBe(toolsDirectoryPath);
+            BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.Standalone);
         }
 
         [Fact]
@@ -46,13 +47,13 @@ namespace Microsoft.Build.Engine.UnitTests
                 env.WithEnvironment("MSBUILD_EXE_PATH", env.MSBuildExePath);
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(path, BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
-                Assert.Equal(msBuildPath, BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
-                Assert.Equal(msBuildConfig, BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.Null(BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
-                Assert.Equal(BuildEnvironmentMode.Standalone, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.ShouldBe(path);
+                BuildEnvironmentHelper.Instance.CurrentMSBuildExePath.ShouldBe(msBuildPath);
+                BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile.ShouldBe(msBuildConfig);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBeNull();
+                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.Standalone);
             }
         }
 
@@ -66,11 +67,11 @@ namespace Microsoft.Build.Engine.UnitTests
                 // All we know about is path to msbuild.exe as the command-line arg[0]
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -83,11 +84,11 @@ namespace Microsoft.Build.Engine.UnitTests
                 // All we know about is path to msbuild.exe as the command-line arg[0]
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
-                Assert.Equal(BuildEnvironmentMode.Standalone, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.Standalone);
             }
         }
 
@@ -101,11 +102,11 @@ namespace Microsoft.Build.Engine.UnitTests
                 // All we know about is path to msbuild.exe as the current process
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -118,11 +119,11 @@ namespace Microsoft.Build.Engine.UnitTests
                 // All we know about is path to msbuild.exe as the current process
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
-                Assert.Equal(BuildEnvironmentMode.Standalone, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.Standalone);
             }
         }
 
@@ -135,11 +136,11 @@ namespace Microsoft.Build.Engine.UnitTests
                 // All we know about is path to msbuild.exe as the current process
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
-                Assert.Equal(BuildEnvironmentMode.Standalone, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.Standalone);
             }
         }
 
@@ -152,13 +153,13 @@ namespace Microsoft.Build.Engine.UnitTests
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, () => env.BuildDirectory, env.VsInstanceMock, env.EnvironmentMock);
 
                 // Make sure we get the right MSBuild entry point. On .NET Core this will be MSBuild.dll, otherwise MSBuild.exe
-                Assert.Equal(MSBuildExeName, Path.GetFileName(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath));
+                Path.GetFileName(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath).ShouldBe(MSBuildExeName);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
-                Assert.Equal(BuildEnvironmentMode.Standalone, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.Standalone);
             }
         }
 
@@ -172,12 +173,12 @@ namespace Microsoft.Build.Engine.UnitTests
                 // All we know about is path to DevEnv.exe
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.True(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.False(BuildEnvironmentHelper.Instance.RunningTests);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeTrue();
+                BuildEnvironmentHelper.Instance.RunningTests.ShouldBeFalse();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -192,8 +193,8 @@ namespace Microsoft.Build.Engine.UnitTests
                 env.WithEnvironment("VisualStudioVersion", "15.0");
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -207,8 +208,8 @@ namespace Microsoft.Build.Engine.UnitTests
                 // We only know we're in msbuild.exe, we should still be able to attempt to find Visual Studio
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -222,8 +223,8 @@ namespace Microsoft.Build.Engine.UnitTests
                 // We only know we're in amd64\msbuild.exe, we should still be able to attempt to find Visual Studio
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -240,8 +241,8 @@ namespace Microsoft.Build.Engine.UnitTests
                 // This test has no context to find MSBuild other than Visual Studio root.
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -256,8 +257,8 @@ namespace Microsoft.Build.Engine.UnitTests
                 // This test has no context to find MSBuild other than Visual Studio root.
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Null(BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.None, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBeNull();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.None);
             }
         }
 
@@ -268,8 +269,8 @@ namespace Microsoft.Build.Engine.UnitTests
 #endif
         public void BuildEnvironmentDetectsRunningTests()
         {
-            Assert.True(BuildEnvironmentHelper.Instance.RunningTests);
-            Assert.False(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
+            BuildEnvironmentHelper.Instance.RunningTests.ShouldBeTrue();
+            BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeFalse();
         }
 
         [Fact]
@@ -281,9 +282,9 @@ namespace Microsoft.Build.Engine.UnitTests
             {
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.True(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeTrue();
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -296,9 +297,9 @@ namespace Microsoft.Build.Engine.UnitTests
             {
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.BlendPath, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.True(BuildEnvironmentHelper.Instance.RunningInVisualStudio);
-                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeTrue();
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -312,9 +313,9 @@ namespace Microsoft.Build.Engine.UnitTests
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull,
                     ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -359,12 +360,12 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (var env = new EmptyVSEnviroment())
             {
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(()=>env.MSBuildExePath64, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(env.BuildDirectory, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32);
-                Assert.Equal(env.BuildDirectory64, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64);
-                Assert.Equal(env.TempFolderRoot, BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.VisualStudio, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
             }
         }
 
@@ -377,10 +378,10 @@ namespace Microsoft.Build.Engine.UnitTests
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => entryProcess, ReturnNull, ReturnNull,
                     env.VsInstanceMock, env.EnvironmentMock);
 
-                Assert.Equal(entryProcess, BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
-                Assert.Equal(Path.GetDirectoryName(entryProcess), BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
-                Assert.Null(BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory);
-                Assert.Equal(BuildEnvironmentMode.None, BuildEnvironmentHelper.Instance.Mode);
+                BuildEnvironmentHelper.Instance.CurrentMSBuildExePath.ShouldBe(entryProcess);
+                BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.ShouldBe(Path.GetDirectoryName(entryProcess));
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBeNull();
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.None);
             }
         }
 

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -424,41 +424,63 @@ namespace Microsoft.Build.Shared
     {
         public BuildEnvironment(BuildEnvironmentMode mode, string currentMSBuildExePath, bool runningTests, bool runningInVisualStudio, string visualStudioPath)
         {
+            FileInfo currentMSBuildExeFile = null;
+            DirectoryInfo currentToolsDirectory = null;
+
             Mode = mode;
             RunningTests = runningTests;
             RunningInVisualStudio = runningInVisualStudio;
-
             CurrentMSBuildExePath = currentMSBuildExePath;
-            CurrentMSBuildToolsDirectory = Path.GetDirectoryName(currentMSBuildExePath);
-            CurrentMSBuildConfigurationFile = string.Concat(currentMSBuildExePath, ".config");
-
             VisualStudioInstallRootDirectory = visualStudioPath;
 
-            if (mode == BuildEnvironmentMode.VisualStudio)
+            if (!string.IsNullOrEmpty(currentMSBuildExePath))
             {
-                var isAmd64 = FileUtilities.EnsureNoTrailingSlash(CurrentMSBuildToolsDirectory)
-                    .EndsWith("amd64", StringComparison.OrdinalIgnoreCase);
+                currentMSBuildExeFile = new FileInfo(currentMSBuildExePath);
+                currentToolsDirectory = currentMSBuildExeFile.Directory;
 
-                if (isAmd64)
+                CurrentMSBuildToolsDirectory = currentMSBuildExeFile.DirectoryName;
+                CurrentMSBuildConfigurationFile = string.Concat(currentMSBuildExePath, ".config");
+                MSBuildToolsDirectory32 = CurrentMSBuildToolsDirectory;
+                MSBuildToolsDirectory64 = CurrentMSBuildToolsDirectory;
+            }
+
+            // We can't detect an environment, don't try to set other paths.
+            if (mode == BuildEnvironmentMode.None || currentMSBuildExeFile == null || currentToolsDirectory == null)
+                return;
+
+            // Check to see if our current folder is 'amd64'
+            bool runningInAmd64 = string.Equals(currentToolsDirectory.Name, "amd64", StringComparison.OrdinalIgnoreCase);
+
+            var msBuildExeName = currentMSBuildExeFile.Name;
+            var folderAbove = currentToolsDirectory.Parent?.FullName;
+
+            if (folderAbove != null)
+            {
+                // Calculate potential paths to other architecture MSBuild.exe
+                var potentialAmd64FromX86 = FileUtilities.CombinePaths(CurrentMSBuildToolsDirectory, "amd64", msBuildExeName);
+                var potentialX86FromAmd64 = Path.Combine(folderAbove, msBuildExeName);
+
+                // Check for existence of an MSBuild file. Note this is not necessary in a VS installation where we always want to
+                // assume the correct layout.
+                var existsCheck = mode == BuildEnvironmentMode.VisualStudio ? new Func<string, bool>(_ => true) : File.Exists;
+
+                // Running in amd64 folder and the X86 path is valid
+                if (runningInAmd64 && existsCheck(potentialX86FromAmd64))
                 {
-                    MSBuildToolsDirectory32 = FileUtilities.GetFolderAbove(CurrentMSBuildToolsDirectory);
+                    MSBuildToolsDirectory32 = folderAbove;
                     MSBuildToolsDirectory64 = CurrentMSBuildToolsDirectory;
                 }
-                else
+                // Not running in amd64 folder and the amd64 path is valid
+                else if (!runningInAmd64 && existsCheck(potentialAmd64FromX86))
                 {
                     MSBuildToolsDirectory32 = CurrentMSBuildToolsDirectory;
                     MSBuildToolsDirectory64 = Path.Combine(CurrentMSBuildToolsDirectory, "amd64");
                 }
             }
-            else
-            {
-                MSBuildToolsDirectory32 = CurrentMSBuildToolsDirectory;
-                MSBuildToolsDirectory64 = CurrentMSBuildToolsDirectory;
-            }
 
             MSBuildExtensionsPath = mode == BuildEnvironmentMode.VisualStudio
                 ? Path.Combine(VisualStudioInstallRootDirectory, "MSBuild")
-                : CurrentMSBuildToolsDirectory;
+                : MSBuildToolsDirectory32;
         }
 
         internal BuildEnvironmentMode Mode { get; }


### PR DESCRIPTION
When MSBuild is detected outside of a Visual Studio environment, allow
the ToolsDirectory32 and 64 properties to be set correctly when
MSBuild.exe exists in the correct folder structure (amd64\MSBuild.exe).