### PR TITLE
Display an error if an ITaskFactory does not set the TaskType property.

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -1229,7 +1229,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             List<ProjectUsingTaskElement> elementList = new List<ProjectUsingTaskElement>();
             ProjectRootElement project = ProjectRootElement.Create();
             
-            ProjectUsingTaskElement element = project.AddUsingTask("Task1", FileUtilities.ExecutingAssemblyPath, null);
+            ProjectUsingTaskElement element = project.AddUsingTask("Task1", AssemblyUtilities.GetAssemblyLocation(typeof(TaskRegistry_Tests.NullTaskTypeTaskFactory).GetTypeInfo().Assembly), null);
 
             element.TaskFactory = typeof(NullTaskTypeTaskFactory).FullName;
             elementList.Add(element);

--- a/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -23,6 +23,7 @@ using Microsoft.Build.Shared;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using Microsoft.Build.Utilities;
 using Microsoft.CodeAnalysis.BuildTasks;
+using Shouldly;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests.BackEnd
@@ -1221,6 +1222,24 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(0, registeredTaskRecords[0].ParameterGroupAndTaskBody.UsingTaskParameters.Count);
             Assert.Null(registeredTaskRecords[0].ParameterGroupAndTaskBody.InlineTaskXmlBody);
         }
+
+        [Fact]
+        public void TaskFactoryWithNullTaskTypeLogsError()
+        {
+            List<ProjectUsingTaskElement> elementList = new List<ProjectUsingTaskElement>();
+            ProjectRootElement project = ProjectRootElement.Create();
+            
+            ProjectUsingTaskElement element = project.AddUsingTask("Task1", FileUtilities.ExecutingAssemblyPath, null);
+
+            element.TaskFactory = typeof(NullTaskTypeTaskFactory).FullName;
+            elementList.Add(element);
+
+            TaskRegistry registry = CreateTaskRegistryAndRegisterTasks(elementList);
+
+            InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => registry.GetRegisteredTask("Task1", "none", null, false, new TargetLoggingContext(_loggingService, new BuildEventContext(1, 1, BuildEventContext.InvalidProjectContextId, 1)), ElementLocation.Create("none", 1, 2)));
+            
+            exception.ErrorCode.ShouldBe("MSB4239");
+        }
         #endregion
 
         #region ParameterGroupTests
@@ -2310,5 +2329,23 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         #endregion
+
+        /// <summary>
+        /// A task factory that returns null for the TaskType property.
+        /// </summary>
+        public class NullTaskTypeTaskFactory : ITaskFactory
+        {
+            public string FactoryName => nameof(NullTaskTypeTaskFactory);
+
+            public Type TaskType => null;
+
+            public bool Initialize(string taskName, IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost) => true;
+
+            public TaskPropertyInfo[] GetTaskParameters() => null;
+
+            public ITask CreateTask(IBuildEngine taskFactoryLoggingHost) => null;
+
+            public void CleanupTask(ITask task) { }
+        }
     }
 }

--- a/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -1238,7 +1238,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             InvalidProjectFileException exception = Should.Throw<InvalidProjectFileException>(() => registry.GetRegisteredTask("Task1", "none", null, false, new TargetLoggingContext(_loggingService, new BuildEventContext(1, 1, BuildEventContext.InvalidProjectContextId, 1)), ElementLocation.Create("none", 1, 2)));
             
-            exception.ErrorCode.ShouldBe("MSB4239");
+            exception.ErrorCode.ShouldBe("MSB4175");
+
+            exception.Message.ShouldContain("The task factory must return a value for the \"TaskType\" property.");
         }
         #endregion
 

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1411,6 +1411,12 @@ namespace Microsoft.Build.Execution
                                                 RegisteredName);
                                         }
                                     }
+
+                                    // Throw an error if the ITaskFactory did not set the TaskType property.  If the property is null, it can cause NullReferenceExceptions in our code
+                                    if (factory.TaskType == null)
+                                    {
+                                        ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "TaskFactoryTaskTypeIsNotSet", factory.FactoryName);
+                                    }
                                 }
                                 finally
                                 {
@@ -1424,6 +1430,10 @@ namespace Microsoft.Build.Execution
                                     _taskFactoryWrapperInstance = null;
                                     return false;
                                 }
+                            }
+                            catch(InvalidProjectFileException)
+                            {
+                                throw;
                             }
                             catch (InvalidCastException e)
                             {

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1415,7 +1415,7 @@ namespace Microsoft.Build.Execution
                                     // Throw an error if the ITaskFactory did not set the TaskType property.  If the property is null, it can cause NullReferenceExceptions in our code
                                     if (factory.TaskType == null)
                                     {
-                                        ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "TaskFactoryTaskTypeIsNotSet", factory.FactoryName);
+                                        throw new InvalidOperationException(AssemblyResources.GetString("TaskFactoryTaskTypeIsNotSet"));
                                     }
                                 }
                                 finally
@@ -1430,10 +1430,6 @@ namespace Microsoft.Build.Execution
                                     _taskFactoryWrapperInstance = null;
                                     return false;
                                 }
-                            }
-                            catch(InvalidProjectFileException)
-                            {
-                                throw;
                             }
                             catch (InvalidCastException e)
                             {
@@ -1466,7 +1462,6 @@ namespace Microsoft.Build.Execution
 #if DEBUG
                                 message += UnhandledFactoryError;
 #endif
-                                // message += e.ToString();
                                 message += e.Message;
 
                                 ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "TaskFactoryLoadFailure", TaskFactoryAttributeName, taskFactoryLoadInfo.AssemblyLocation, message);

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1085,6 +1085,12 @@
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
   </data>
+  <data name="TaskFactoryTaskTypeIsNotSet" UESanitized="false" Visibility="Public">
+    <value>MSB4239: The task factory "{0}" must return a value for the "TaskType" property.</value>
+    <comment>{StrBegin="MSB4239: "}
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
   <data name="TaskLoadFailure" UESanitized="false" Visibility="Public">
     <value>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</value>
     <comment>{StrBegin="MSB4062: "}UE: This message is shown when a task cannot be loaded from its assembly for various reasons e.g. corrupt assembly,
@@ -1628,7 +1634,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4239.
+        Next message code should be MSB4240.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1086,10 +1086,7 @@
     </comment>
   </data>
   <data name="TaskFactoryTaskTypeIsNotSet" UESanitized="false" Visibility="Public">
-    <value>MSB4239: The task factory "{0}" must return a value for the "TaskType" property.</value>
-    <comment>{StrBegin="MSB4239: "}
-      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
-    </comment>
+    <value>The task factory must return a value for the "TaskType" property.</value>
   </data>
   <data name="TaskLoadFailure" UESanitized="false" Visibility="Public">
     <value>MSB4062: The "{0}" task could not be loaded from the assembly {1}. {2} Confirm that the &lt;UsingTask&gt; declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.</value>
@@ -1634,7 +1631,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4240.
+        Next message code should be MSB4239.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Framework/ITaskFactory.cs
+++ b/src/Framework/ITaskFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.Framework
         string FactoryName { get; }
 
         /// <summary>
-        /// Gets the type of the task this factory will instantiate.
+        /// Gets the type of the task this factory will instantiate.  Implementations must return a value for this property.
         /// </summary>
         Type TaskType { get; }
 


### PR DESCRIPTION
If TaskType is null it can cause a NullReferenceException in our code.  This change ensures that ITaskFactory implementations return a value for this property.

Fixes #1508