### PR TITLE
Fix #2367: incorrect evaluation of VisualStudioInstallRootDirectory

### DIFF
--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -386,6 +386,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentVSFromMSBuildAssembly()
         {
             using (var env = new EmptyVSEnviroment())
@@ -403,6 +405,8 @@ namespace Microsoft.Build.Engine.UnitTests
         }
 
         [Fact]
+        [Trait("Category", "nonlinuxtests")]
+        [Trait("Category", "nonosxtests")]
         public void BuildEnvironmentVSFromMSBuildAssemblyAmd64()
         {
             using (var env = new EmptyVSEnviroment())

--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -385,6 +385,40 @@ namespace Microsoft.Build.Engine.UnitTests
             }
         }
 
+        [Fact]
+        public void BuildEnvironmentVSFromMSBuildAssembly()
+        {
+            using (var env = new EmptyVSEnviroment())
+            {
+                var msBuildAssembly = Path.Combine(env.BuildDirectory, "Microsoft.Build.dll");
+
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => msBuildAssembly, ReturnNull,
+                    env.VsInstanceMock, env.EnvironmentMock);
+
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
+            }
+        }
+
+        [Fact]
+        public void BuildEnvironmentVSFromMSBuildAssemblyAmd64()
+        {
+            using (var env = new EmptyVSEnviroment())
+            {
+                var msBuildAssembly = Path.Combine(env.BuildDirectory64, "Microsoft.Build.dll");
+
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => msBuildAssembly, ReturnNull,
+                    env.VsInstanceMock, env.EnvironmentMock);
+
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
+                BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
+                BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
+                BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
+            }
+        }
+
         private static string ReturnNull()
         {
             return null;

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Build.Shared
                         msBuildExe,
                         runningTests: CheckIfRunningTests(),
                         runningInVisualStudio: false,
-                        visualStudioPath: GetVsRootFromMSBuildAssembly(buildAssembly));
+                        visualStudioPath: GetVsRootFromMSBuildAssembly(msBuildExe));
                 }
             }
 


### PR DESCRIPTION
When using TryFromMSBuildAssembly with Microsoft.Build.dll inside the amd64 directory, the VisualStudioInstallRootDirectory
is incorrectly evaluated as if in 32 bits mode.

Fix for #2367 