### PR TITLE
Remove namespace check of every XML element

### DIFF
--- a/src/Build/Construction/ProjectElement.cs
+++ b/src/Build/Construction/ProjectElement.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Build.Construction
         internal ProjectElement(XmlElement xmlElement, ProjectElementContainer parent, ProjectRootElement containingProject)
         {
             ErrorUtilities.VerifyThrowArgumentNull(xmlElement, "xmlElement");
-            ProjectXmlUtilities.VerifyThrowProjectValidNamespace((XmlElementWithLocation)xmlElement);
             ErrorUtilities.VerifyThrowArgumentNull(containingProject, "containingProject");
 
             this.XmlElement = (XmlElementWithLocation)xmlElement;

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -228,10 +228,6 @@
     <value>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</value>
     <comment>{StrBegin="MSB4142: "}</comment>
   </data>
-  <data name="CustomNamespaceNotAllowedOnThisChildElement" UESanitized="false" Visibility="Public">
-    <value>MSB4097: The element &lt;{0}&gt; beneath element &lt;{1}&gt; may not have a custom XML namespace.</value>
-    <comment>{StrBegin="MSB4097: "}</comment>
-  </data>
   <data name="DefaultTasksFileFailure" UESanitized="false" Visibility="Public">
     <value>MSB4009: The default tasks file could not be successfully loaded. {0}</value>
     <comment>{StrBegin="MSB4009: "}UE: This message is shown when one of the default tasks file (*.tasks) located alongside the MSBuild binaries cannot
@@ -1649,6 +1645,7 @@ MSB4031
 MSB4167
 MSB4178
 MSB4076
+MSB4097
 MSB4098
 MSB4168
 MSB4151

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Build.Internal
 
                     case XmlNodeType.Element:
                         XmlElementWithLocation childElement = (XmlElementWithLocation)child;
-                        VerifyThrowProjectValidNamespace(childElement);
                         children.Add(childElement);
                         break;
 
@@ -94,19 +93,6 @@ namespace Microsoft.Build.Internal
         internal static void ThrowProjectInvalidChildElement(string name, string parentName, ElementLocation location)
         {
             ProjectErrorUtilities.ThrowInvalidProject(location, "UnrecognizedChildElement", name, parentName);
-        }
-
-        /// <summary>
-        /// Verifies that an element is in the MSBuild namespace, otherwise throws an InvalidProjectFileException.
-        /// </summary>
-        internal static void VerifyThrowProjectValidNamespace(XmlElementWithLocation element)
-        {
-            // If a namespace was specified it must be the default MSBuild namespace.
-            if (!VerifyValidProjectNamespace(element))
-            {
-                ProjectErrorUtilities.ThrowInvalidProject(element.Location,
-                    "CustomNamespaceNotAllowedOnThisChildElement", element.Name, element.ParentNode?.Name);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2373 by only checking the top-level namespace of a project, not
the namespace of every element.

This is arguably incorrect since XML namespace _could_ be per-element,
but a) that never worked before and b) you'd have to manually edit a
project in a fairly odd way to get that, so the performance gain here
seems to outweigh the risk.