### PR TITLE
Include the name of the conflicting assembly as a part of warning MSB3277

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3770,6 +3770,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             bool result = Execute(t);
 
             Assert.Equal(1, e.Warnings); // @"Expected one warning."
+            e.AssertLogContainsMessageFromResource(AssemblyResources.GetString, "ResolveAssemblyReference.FoundConflicts", "D");
 
             Assert.Equal(0, t.SuggestedRedirects.Length);
             Assert.Equal(3, t.ResolvedFiles.Length);
@@ -3808,6 +3809,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             bool result = Execute(t);
 
             Assert.Equal(1, e.Warnings); // @"Expected one warning."
+            e.AssertLogContainsMessageFromResource(AssemblyResources.GetString, "ResolveAssemblyReference.FoundConflicts", "D");
 
             Assert.Equal(0, t.SuggestedRedirects.Length);
             Assert.Equal(3, t.ResolvedFiles.Length);

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3539,8 +3539,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(3, t.ResolvedDependencyFiles.Length);
-            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V2_DDllPath)); // "Expected to find assembly, but didn't."
-            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath)); // "Expected to find assembly, but didn't."
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V2_DDllPath));
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath));
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V2_GDllPath));
+            
             Assert.Equal(1, t.SuggestedRedirects.Length);
             Assert.True(ContainsItem(t.SuggestedRedirects, @"D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa")); // "Expected to find suggested redirect, but didn't"
             Assert.Equal(1, e.Warnings); // "Should only be one warning for suggested redirects."
@@ -3939,8 +3941,11 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.True(result); // @"Expected a success because this conflict is solvable."
             Assert.Equal(3, t.ResolvedFiles.Length);
-            Assert.True(ContainsItem(t.ResolvedFiles, s_myLibraries_V2_DDllPath)); // "Expected to find assembly, but didn't."
+            Assert.True(ContainsItem(t.ResolvedFiles, s_myLibraries_V2_DDllPath));
+
             Assert.Equal(2, t.ResolvedDependencyFiles.Length);
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath));
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V2_GDllPath));
         }
 
 
@@ -4569,9 +4574,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(2, t.ResolvedFiles.Length);
+
             Assert.Equal(4, t.ResolvedDependencyFiles.Length);
-            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath)); // "Expected to find assembly, but didn't."
-            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath)); // "Expected to find assembly, but didn't."
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath));
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V2_DDllPath));
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V2_GDllPath));
+            Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_E_EDllPath));
 
             foreach (ITaskItem item in t.ResolvedDependencyFiles)
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -3538,7 +3538,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Execute(t);
 
-            Assert.Equal(2, t.ResolvedDependencyFiles.Length);
+            Assert.Equal(3, t.ResolvedDependencyFiles.Length);
             Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V2_DDllPath)); // "Expected to find assembly, but didn't."
             Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath)); // "Expected to find assembly, but didn't."
             Assert.Equal(1, t.SuggestedRedirects.Length);
@@ -3940,7 +3940,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.True(result); // @"Expected a success because this conflict is solvable."
             Assert.Equal(3, t.ResolvedFiles.Length);
             Assert.True(ContainsItem(t.ResolvedFiles, s_myLibraries_V2_DDllPath)); // "Expected to find assembly, but didn't."
-            Assert.Equal(1, t.ResolvedDependencyFiles.Length);
+            Assert.Equal(2, t.ResolvedDependencyFiles.Length);
         }
 
 
@@ -4569,7 +4569,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(2, t.ResolvedFiles.Length);
-            Assert.Equal(3, t.ResolvedDependencyFiles.Length);
+            Assert.Equal(4, t.ResolvedDependencyFiles.Length);
             Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath)); // "Expected to find assembly, but didn't."
             Assert.True(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath)); // "Expected to find assembly, but didn't."
 

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -214,6 +214,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         protected static readonly string s_myLibraries_V1_DDllPath = Path.Combine(s_myLibraries_V1Path, "D.dll");
         protected static readonly string s_myLibraries_V1_E_EDllPath = Path.Combine(s_myLibraries_V1_EPath, "E.dll");
         protected static readonly string s_myLibraries_V2_DDllPath = Path.Combine(s_myLibraries_V2Path, "D.dll");
+        protected static readonly string s_myLibraries_V1_GDllPath = Path.Combine(s_myLibraries_V1Path, "G.dll");
+        protected static readonly string s_myLibraries_V2_GDllPath = Path.Combine(s_myLibraries_V2Path, "G.dll");
 
         protected static readonly string s_regress454863_ADllPath = Path.Combine(s_rootPathPrefix, "Regress454863", "A.dll");
         protected static readonly string s_regress454863_BDllPath = Path.Combine(s_rootPathPrefix, "Regress454863", "B.dll");
@@ -397,6 +399,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             s_myLibraries_V1_E_EDllPath,
             @"c:\RogueLibraries\v1\D.dll",
             s_myLibraries_V2_DDllPath,
+            s_myLibraries_V1_GDllPath,
+            s_myLibraries_V2_GDllPath,
             @"c:\MyStronglyNamed\A.dll",
             @"c:\MyWeaklyNamed\A.dll",
             @"c:\MyInaccessible\A.dll",
@@ -1296,6 +1300,14 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             if (path.EndsWith(s_myLibraries_V2_DDllPath))
             {
                 return new AssemblyNameExtension("D, VErsion=2.0.0.0, CulturE=neutral, PublicKEyToken=aaaaaaaaaaaaaaaa");
+            if (path.EndsWith(s_myLibraries_V1_GDllPath))
+            {
+                return new AssemblyNameExtension("G, Version=1.0.0.0, Culture=neutral, PublicKEyToken=aaaaaaaaaaaaaaaa");
+            }
+
+            if (path.EndsWith(s_myLibraries_V2_GDllPath))
+            {
+                return new AssemblyNameExtension("G, Version=2.0.0.0, Culture=neutral, PublicKEyToken=aaaaaaaaaaaaaaaa");
             }
 
             if (String.Compare(path, @"C:\Regress317975\a.dll", StringComparison.OrdinalIgnoreCase) == 0)
@@ -2117,7 +2129,16 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 return new AssemblyNameExtension[]
                 {
-                    new AssemblyNameExtension("D, Version=2.0.0.0, Culture=neutral, PuBlIcKeYToken=aaaaaaaaaaaaaaaa")
+                    new AssemblyNameExtension("D, Version=2.0.0.0, Culture=neutral, PuBlIcKeYToken=aaaaaaaaaaaaaaaa"),
+                    new AssemblyNameExtension("G, Version=2.0.0.0, Culture=neutral, PuBlIcKeYToken=aaaaaaaaaaaaaaaa")
+                };
+            }
+
+            if (String.Compare(path, s_myLibraries_GDllPath, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return new AssemblyNameExtension[]
+                {
+                    new AssemblyNameExtension("D, Version=3.0.0.0, Culture=neutral, PuBlIcKeYToken=aaaaaaaaaaaaaaaa")
                 };
             }
 

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -1300,6 +1300,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             if (path.EndsWith(s_myLibraries_V2_DDllPath))
             {
                 return new AssemblyNameExtension("D, VErsion=2.0.0.0, CulturE=neutral, PublicKEyToken=aaaaaaaaaaaaaaaa");
+            }
+
             if (path.EndsWith(s_myLibraries_V1_GDllPath))
             {
                 return new AssemblyNameExtension("G, Version=1.0.0.0, Culture=neutral, PublicKEyToken=aaaaaaaaaaaaaaaa");
@@ -2131,14 +2133,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 {
                     new AssemblyNameExtension("D, Version=2.0.0.0, Culture=neutral, PuBlIcKeYToken=aaaaaaaaaaaaaaaa"),
                     new AssemblyNameExtension("G, Version=2.0.0.0, Culture=neutral, PuBlIcKeYToken=aaaaaaaaaaaaaaaa")
-                };
-            }
-
-            if (String.Compare(path, s_myLibraries_GDllPath, StringComparison.OrdinalIgnoreCase) == 0)
-            {
-                return new AssemblyNameExtension[]
-                {
-                    new AssemblyNameExtension("D, Version=3.0.0.0, Culture=neutral, PuBlIcKeYToken=aaaaaaaaaaaaaaaa")
                 };
             }
 

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1866,7 +1866,7 @@ namespace Microsoft.Build.Tasks
                     if (entry != null)
                     {
                         // We have found an entry in the redist list that this assembly is a framework assembly of some version
-                        // also one if its parent refernces has specific version set to true, therefore we need to make sure
+                        // also one if its parent references has specific version set to true, therefore we need to make sure
                         // that we do not consider it for conflict resolution.
                         continue;
                     }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -960,7 +960,6 @@ namespace Microsoft.Build.Tasks
                     if (idealAssemblyRemappings != null)
                     {
                         bool foundAtLeastOneValidBindingRedirect = false;
-                        bool foundAtLeastOneUnresolvableConflict = false;
 
                         var buffer = new StringBuilder();
                         var ns = XNamespace.Get("urn:schemas-microsoft-com:asm.v1");
@@ -1037,7 +1036,9 @@ namespace Microsoft.Build.Tasks
 
                                 if (conflictVictims.Length == 0)
                                 {
-                                    foundAtLeastOneUnresolvableConflict = true;
+                                    // This warning is logged regardless of AutoUnify since it means a conflict existed where the reference
+                                    // chosen was not the conflict victor in a version comparison, in other words it was older.
+                                    Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.FoundConflicts", idealRemappingPartialAssemblyName.Name);
                                 }
                             }
                         }
@@ -1059,13 +1060,6 @@ namespace Microsoft.Build.Tasks
                             }
                             // else AutoUnify is on and bindingRedirect generation is not supported
                             // we don't warn in this case since the binder will automatically unify these remappings
-                        }
-
-                        if (foundAtLeastOneUnresolvableConflict)
-                        {
-                            // This warning is logged regardless of AutoUnify since it means a conflict existed where the reference
-                            // chosen was not the conflict victor in a version comparison, in other words it was older.
-                            Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.FoundConflicts");
                         }
                     }
 

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -971,9 +971,10 @@ namespace Microsoft.Build.Tasks
                             AssemblyName idealRemappingPartialAssemblyName = idealRemapping.PartialAssemblyName;
                             Reference reference = idealAssemblyRemappingsIdentities[i].reference;
 
+                            AssemblyNameExtension[] conflictVictims = reference.GetConflictVictims();
+
                             for (int j = 0; j < idealRemapping.BindingRedirects.Length; j++)
                             {
-                                AssemblyNameExtension[] conflictVictims = reference.GetConflictVictims();
                                 foreach (AssemblyNameExtension conflictVictim in conflictVictims)
                                 {
                                     // Make note we only output a conflict suggestion if the reference has at 
@@ -1033,13 +1034,13 @@ namespace Microsoft.Build.Tasks
                                         buffer.Append(node.ToString(SaveOptions.DisableFormatting));
                                     }
                                 }
+                            }
 
-                                if (conflictVictims.Length == 0)
-                                {
-                                    // This warning is logged regardless of AutoUnify since it means a conflict existed where the reference
-                                    // chosen was not the conflict victor in a version comparison, in other words it was older.
-                                    Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.FoundConflicts", idealRemappingPartialAssemblyName.Name);
-                                }
+                            if (conflictVictims.Length == 0)
+                            {
+                                // This warning is logged regardless of AutoUnify since it means a conflict existed where the reference
+                                // chosen was not the conflict victor in a version comparison, in other words it was older.
+                                Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.FoundConflicts", idealRemappingPartialAssemblyName.Name);
                             }
                         }
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1532,7 +1532,7 @@
     <comment>{StrBegin="MSB3276: "}</comment>
   </data>
   <data name="ResolveAssemblyReference.FoundConflicts">
-    <value>MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</value>
+    <value>MSB3277: Found conflicts between different versions of "{0}" that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed.</value>
     <comment>{StrBegin="MSB3277: "}</comment>
   </data>
   <data name="ResolveAssemblyReference.LogAttributeFormat">


### PR DESCRIPTION
Modify the message MSB3277 to include the name of the conflicting assembly - a partial resolution of #608 . The message will be repeated once for each distinct assembly that is experiencing conflicts.

Old message:
```
MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  
These reference conflicts are listed in the build log when log verbosity is set to detailed.
```

New message (sample):
```
MSB3277: Found conflicts between different versions of "Newtonsoft.Json" that could not be resolved.  
These reference conflicts are listed in the build log when log verbosity is set to detailed.
```

I found two unit tests that trigger this warning - `ConflictWithBackVersionPrimary()` and `ConflictWithBackVersionPrimaryWithAutoUnify()`, both found in `src\Tasks.UnitTests\AssemblyDependency\Miscellaneous.cs`; both tests have been modified to assert the correct message exists in the log.
