### PR TITLE
Remove enumerator allocation

### DIFF
--- a/src/Build/Collections/HashTableUtility.cs
+++ b/src/Build/Collections/HashTableUtility.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Collections
         ///  0, if hashtables have identical keys and equivalent (case-insensitive) values
         /// +1, if first hashtable is "greater than" the second one
         /// </returns>
-        internal static int Compare(IDictionary<string, string> h1, IDictionary<string, string> h2)
+        internal static int Compare(Dictionary<string, string> h1, Dictionary<string, string> h2)
         {
             if (h1 == h2) // eg null
             {


### PR DESCRIPTION
This method is only called once, and only passed Dictionary - avoid the boxing of the enumerator, which saves 0.6% of allocations in a design-time build.

![image](https://user-images.githubusercontent.com/1103906/28869049-d340c9da-77be-11e7-85f6-5684f2aed2ca.png)
