### PR TITLE
Reuse RequestBuilder threads

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Build.BackEnd
     internal class RequestBuilder : IRequestBuilder, IRequestBuilderCallback, IBuildComponent
     {
         /// <summary>
+        /// The dedicated scheduler object.
+        /// </summary>
+        private static readonly TaskScheduler s_dedicatedScheduler = new DedicatedThreadsTaskScheduler();
+
+        /// <summary>
         /// The event used to signal that this request should immediately terminate.
         /// </summary>
         private ManualResetEvent _terminateEvent;
@@ -109,16 +114,6 @@ namespace Microsoft.Build.BackEnd
         /// Flag indicating whether this request builder has been zombied by a cancellation request.
         /// </summary>
         private bool _isZombie = false;
-
-        /// <summary>
-        /// The dedicated scheduler object.
-        /// </summary>
-        private static TaskScheduler _dedicatedScheduler;
-
-        /// <summary>
-        /// Gets the dedicated scheduler.
-        /// </summary>
-        private TaskScheduler DedicatedScheduler => _dedicatedScheduler ?? (_dedicatedScheduler = new DedicatedThreadsTaskScheduler());
 
         /// <summary>
         /// Creates a new request builder.
@@ -637,7 +632,7 @@ namespace Microsoft.Build.BackEnd
                         },
                         _cancellationTokenSource.Token,
                         TaskCreationOptions.None,
-                        DedicatedScheduler).Unwrap();
+                        s_dedicatedScheduler).Unwrap();
                 }
             }
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -625,8 +625,8 @@ namespace Microsoft.Build.BackEnd
                             return this.RequestThreadProc(setThreadParameters: true);
                         },
                         _cancellationTokenSource.Token,
-                        TaskCreationOptions.LongRunning,
-                        TaskScheduler.Default).Unwrap();
+                        TaskCreationOptions.None,
+                        AwaitExtensions.DedicatedThreadsTaskSchedulerInstance).Unwrap();
                 }
             }
         }
@@ -658,8 +658,10 @@ namespace Microsoft.Build.BackEnd
                 threadName = "RequestBuilder STA thread";
             }
 #endif
-
-            Thread.CurrentThread.Name = threadName;
+            if (string.IsNullOrEmpty(Thread.CurrentThread.Name))
+            {
+                Thread.CurrentThread.Name = threadName;
+            }
         }
 
         /// <summary>

--- a/src/Shared/AwaitExtensions.cs
+++ b/src/Shared/AwaitExtensions.cs
@@ -238,11 +238,8 @@ namespace Microsoft.Build.Shared
 
         private sealed class DedicatedThreadsTaskScheduler : TaskScheduler
         {
-            private static readonly int _maxThreads = Environment.ProcessorCount;
-
             private readonly BlockingCollection<Task> _tasks = new BlockingCollection<Task>();
             private int _availableThreads = 0;
-            private int _createdThreads = 0;
 
             protected override void QueueTask(Task task)
             {
@@ -272,25 +269,7 @@ namespace Microsoft.Build.Shared
                 if (count == 0)
                 {
                     // No threads were available for request
-                    TryInjectThread();
-                }
-            }
-
-            private void TryInjectThread()
-            {
-                // Increment created thread, but don't go over maxThreads,
-                // Add thread if we incremented
-                var count = Volatile.Read(ref _createdThreads);
-                while (count < _maxThreads)
-                {
-                    var prev = Interlocked.CompareExchange(ref _createdThreads, count + 1, count);
-                    if (prev == count)
-                    {
-                        // Add thread
-                        InjectThread();
-                        break;
-                    }
-                    count = prev;
+                    InjectThread();
                 }
             }
 

--- a/src/Shared/AwaitExtensions.cs
+++ b/src/Shared/AwaitExtensions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -23,11 +24,21 @@ namespace Microsoft.Build.Shared
         /// Synchronizes access to the staScheduler field.
         /// </summary>
         private static Object s_staSchedulerSync = new Object();
+        /// <summary>
+        /// Synchronizes access to the dedicatedSchedulerSync field.
+        /// </summary>
+        private static Object s_dedicatedSchedulerSync = new Object();
 
         /// <summary>
         /// The singleton STA scheduler object.
         /// </summary>
         private static TaskScheduler s_staScheduler;
+
+        /// <summary>
+        /// The singleton dedicated scheduler object.
+        /// </summary>
+        private static TaskScheduler s_dedicatedScheduler;
+
 
         /// <summary>
         /// Gets the STA scheduler.
@@ -48,6 +59,28 @@ namespace Microsoft.Build.Shared
                 }
 
                 return s_staScheduler;
+            }
+        }
+
+        /// <summary>
+        /// Gets the dedicated scheduler.
+        /// </summary>
+        internal static TaskScheduler DedicatedThreadsTaskSchedulerInstance
+        {
+            get
+            {
+                if (s_dedicatedScheduler == null)
+                {
+                    lock (s_dedicatedSchedulerSync)
+                    {
+                        if (s_dedicatedScheduler == null)
+                        {
+                            s_dedicatedScheduler = new DedicatedThreadsTaskScheduler();
+                        }
+                    }
+                }
+
+                return s_dedicatedScheduler;
             }
         }
 
@@ -200,6 +233,79 @@ namespace Microsoft.Build.Shared
             {
                 // We don't get STA threads back here, so just deny the inline execution.
                 return false;
+            }
+        }
+
+        private sealed class DedicatedThreadsTaskScheduler : TaskScheduler
+        {
+            private static readonly int _maxThreads = Environment.ProcessorCount;
+
+            private readonly BlockingCollection<Task> _tasks = new BlockingCollection<Task>();
+            private int _availableThreads = 0;
+            private int _createdThreads = 0;
+
+            protected override void QueueTask(Task task)
+            {
+                RequestThread();
+                _tasks.Add(task);
+            }
+
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+            protected override IEnumerable<Task> GetScheduledTasks() => _tasks;
+
+            private void RequestThread()
+            {
+                // Decrement available thread count; don't drop below zero
+                // Prior value is stored in count
+                var count = Volatile.Read(ref _availableThreads);
+                while (count > 0)
+                {
+                    var prev = Interlocked.CompareExchange(ref _availableThreads, count - 1, count);
+                    if (prev == count)
+                    {
+                        break;
+                    }
+                    count = prev;
+                }
+
+                if (count == 0)
+                {
+                    // No threads were available for request
+                    TryInjectThread();
+                }
+            }
+
+            private void TryInjectThread()
+            {
+                // Increment created thread, but don't go over maxThreads,
+                // Add thread if we incremented
+                var count = Volatile.Read(ref _createdThreads);
+                while (count < _maxThreads)
+                {
+                    var prev = Interlocked.CompareExchange(ref _createdThreads, count + 1, count);
+                    if (prev == count)
+                    {
+                        // Add thread
+                        InjectThread();
+                        break;
+                    }
+                    count = prev;
+                }
+            }
+
+            private void InjectThread()
+            {
+                var thread = new Thread(() =>
+                {
+                    foreach (Task t in _tasks.GetConsumingEnumerable())
+                    {
+                        TryExecuteTask(t);
+                        Interlocked.Increment(ref _availableThreads);
+                    }
+                });
+                thread.IsBackground = true;
+                thread.Start();
             }
         }
     }


### PR DESCRIPTION
RequestBuilder queues tasks with `TaskCreationOptions.LongRunning` which means their threads don't interfere with the threadpool. However it also means a new thread is created for every task and it is unbounded.

This means a Nuget restore of Rosyln creates 3274 short-lived Request Builder threads

![](https://aoa.blob.core.windows.net/aspnet/requestbuildthreads-unbounded.jpg)

This change introduces a TaskScheduler which caps the number of created threads (at processor count); and reuses them when they have stopped doing work rather than creating a new thread.

This means the same Nuget restore creates only 3 threads (on an 8 core machine, so upper bound 8)

![](https://aoa.blob.core.windows.net/aspnet/requestbuilder-threads.png)

I *believe* this change is safe as there is also a STA TaskScheduler which only allows one thread; so on the assumption that works; this should also work.

/cc @stephentoub