### PR TITLE
[tests] CopyMSBuild: copy .dll.config too

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1916,7 +1916,7 @@ namespace Microsoft.Build.UnitTests
                 // Copy MSBuild.exe & dependent files (they will not be in the GAC so they must exist next to msbuild.exe)
                 var filesToCopy = Directory
                     .EnumerateFiles(source)
-                    .Where(f=> f.EndsWith(".dll") || f.EndsWith(".tasks") || f.EndsWith(".exe") || f.EndsWith(".exe.config") || f.EndsWith(".runtimeconfig.json"));
+                    .Where(f=> f.EndsWith(".dll") || f.EndsWith(".tasks") || f.EndsWith(".exe") || f.EndsWith(".exe.config") || f.EndsWith(".dll.config") || f.EndsWith(".runtimeconfig.json"));
 
                 var directoriesToCopy = Directory
                     .EnumerateDirectories(source)


### PR DESCRIPTION
Fixes tests on mono/osx.
      Microsoft.Build.UnitTests.XMakeAppTests.ResponseFileInProjectDirectoryWinsOverMainMSBuildRsp
      Microsoft.Build.UnitTests.XMakeAppTests.ProjectDirectoryIsMSBuildExeDirectory