### PR TITLE
[mono][tests] Use GetCommandLineArgs, also, to check for test runners

### DIFF
--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Engine.UnitTests
                 var msBuildConfig = Path.Combine(path, $"{MSBuildExeName}.config");
 
                 env.WithEnvironment("MSBUILD_EXE_PATH", env.MSBuildExePath);
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory.ShouldBe(path);
                 BuildEnvironmentHelper.Instance.CurrentMSBuildExePath.ShouldBe(msBuildPath);
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyVSEnviroment())
             {
                 // All we know about is path to msbuild.exe as the command-line arg[0]
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyStandaloneEnviroment(MSBuildExeName))
             {
                 // All we know about is path to msbuild.exe as the command-line arg[0]
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory);
@@ -100,7 +100,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyVSEnviroment())
             {
                 // All we know about is path to msbuild.exe as the current process
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
@@ -117,7 +117,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyStandaloneEnviroment(MSBuildExeName))
             {
                 // All we know about is path to msbuild.exe as the current process
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory);
@@ -134,7 +134,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyStandaloneEnviroment("MSBuild.dll"))
             {
                 // All we know about is path to msbuild.exe as the current process
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory);
@@ -150,7 +150,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyStandaloneEnviroment(MSBuildExeName))
             {
                 // Only the app base directory will be available
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, () => env.BuildDirectory, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, () => env.BuildDirectory, env.VsInstanceMock, env.EnvironmentMock);
 
                 // Make sure we get the right MSBuild entry point. On .NET Core this will be MSBuild.dll, otherwise MSBuild.exe
                 Path.GetFileName(BuildEnvironmentHelper.Instance.CurrentMSBuildExePath).ShouldBe(MSBuildExeName);
@@ -171,7 +171,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyVSEnviroment())
             {
                 // All we know about is path to DevEnv.exe
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
@@ -191,7 +191,7 @@ namespace Microsoft.Build.Engine.UnitTests
             {
                 env.WithEnvironment("VSINSTALLDIR", env.TempFolderRoot);
                 env.WithEnvironment("VisualStudioVersion", "15.0");
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
                 BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
@@ -206,7 +206,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyVSEnviroment())
             {
                 // We only know we're in msbuild.exe, we should still be able to attempt to find Visual Studio
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
                 BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyVSEnviroment())
             {
                 // We only know we're in amd64\msbuild.exe, we should still be able to attempt to find Visual Studio
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
                 BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
@@ -239,7 +239,7 @@ namespace Microsoft.Build.Engine.UnitTests
                 env.WithVsInstance(new VisualStudioInstance("VS", env.TempFolderRoot, new Version("15.0")));
 
                 // This test has no context to find MSBuild other than Visual Studio root.
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
                 BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.VisualStudio);
@@ -255,7 +255,7 @@ namespace Microsoft.Build.Engine.UnitTests
                 env.WithVsInstance(new VisualStudioInstance("VS", env.TempFolderRoot, new Version("14.0")));
 
                 // This test has no context to find MSBuild other than Visual Studio root.
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBeNull();
                 BuildEnvironmentHelper.Instance.Mode.ShouldBe(BuildEnvironmentMode.None);
@@ -280,7 +280,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (var env = new EmptyVSEnviroment())
             {
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeTrue();
                 BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
@@ -295,7 +295,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (var env = new EmptyVSEnviroment())
             {
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.BlendPath, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.BlendPath, ReturnNull, () => env.MSBuildExePath, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.RunningInVisualStudio.ShouldBeTrue();
                 BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
@@ -310,7 +310,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (var env = new EmptyVSEnviroment())
             {
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull,
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.DevEnvPath, ReturnNull, ReturnNull,
                     ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
@@ -327,7 +327,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyStandaloneEnviroment(MSBuildExeName, writeFakeFiles:true, includeAmd64Folder:true))
             {
                 var msBuild64Exe = Path.Combine(env.BuildDirectory, "amd64", MSBuildExeName);
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => msBuild64Exe, ReturnNull, ReturnNull,
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => msBuild64Exe, ReturnNull, ReturnNull, ReturnNull,
                     env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
@@ -344,7 +344,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (var env = new EmptyStandaloneEnviroment(MSBuildExeName, writeFakeFiles: true, includeAmd64Folder: true))
             {
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull,
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath, ReturnNull, ReturnNull,
                     ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
@@ -360,7 +360,7 @@ namespace Microsoft.Build.Engine.UnitTests
         {
             using (var env = new EmptyVSEnviroment())
             {
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => env.MSBuildExePath64, ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32.ShouldBe(env.BuildDirectory);
                 BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64.ShouldBe(env.BuildDirectory64);
@@ -375,7 +375,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyStandaloneEnviroment(MSBuildExeName))
             {
                 var entryProcess = Path.Combine(Path.GetTempPath(), "foo.exe");
-                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => entryProcess, ReturnNull, ReturnNull,
+                BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(() => entryProcess, ReturnNull, ReturnNull, ReturnNull,
                     env.VsInstanceMock, env.EnvironmentMock);
 
                 BuildEnvironmentHelper.Instance.CurrentMSBuildExePath.ShouldBe(entryProcess);

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -294,12 +294,22 @@ namespace Microsoft.Build.Shared
             return FileUtilities.CombinePaths(visualStudioRoot, "MSBuild", CurrentToolsVersion, "Bin", "MSBuild.exe");
         }
 
+        private static string GetProcessFromCommandLine()
+        {
+#if FEATURE_GET_COMMANDLINE
+            return Environment.GetCommandLineArgs()[0];
+#else
+            return null;
+#endif
+        }
+
         private static bool CheckIfRunningTests()
         {
             var runningProcess = s_getProcessFromRunningProcess();
+            var processCommandLine = s_getProcessFromCommandLine();
 
             // First check if we're running in a known test runner.
-            if (IsProcessInList(runningProcess, s_testRunners))
+            if (IsProcessInList(runningProcess, s_testRunners) || (processCommandLine != null && IsProcessInList(processCommandLine, s_testRunners)))
             {
 #if FEATURE_APPDOMAIN
                 // If we are, then ensure we're running MSBuild's tests by seeing if any of our assemblies are loaded.
@@ -361,11 +371,13 @@ namespace Microsoft.Build.Shared
         /// Resets the current singleton instance (for testing).
         /// </summary>
         internal static void ResetInstance_ForUnitTestsOnly(Func<string> getProcessFromRunningProcess = null,
+            Func<string> getProcessFromCommandLine = null,
             Func<string> getExecutingAssemblyPath = null, Func<string> getAppContextBaseDirectory = null,
             Func<IEnumerable<VisualStudioInstance>> getVisualStudioInstances = null,
             Func<string, string> getEnvironmentVariable = null)
         {
             s_getProcessFromRunningProcess = getProcessFromRunningProcess ?? GetProcessFromRunningProcess;
+            s_getProcessFromCommandLine = getProcessFromCommandLine ?? GetProcessFromCommandLine;
             s_getExecutingAssemblyPath = getExecutingAssemblyPath ?? GetExecutingAssemblyPath;
             s_getAppContextBaseDirectory = getAppContextBaseDirectory ?? GetAppContextBaseDirectory;
             s_getVisualStudioInstances = getVisualStudioInstances ?? VisualStudioLocationHelper.GetInstances;
@@ -375,6 +387,7 @@ namespace Microsoft.Build.Shared
         }
 
         private static Func<string> s_getProcessFromRunningProcess = GetProcessFromRunningProcess;
+        private static Func<string> s_getProcessFromCommandLine = GetProcessFromCommandLine;
         private static Func<string> s_getExecutingAssemblyPath = GetExecutingAssemblyPath;
         private static Func<string> s_getAppContextBaseDirectory = GetAppContextBaseDirectory;
         private static Func<IEnumerable<VisualStudioInstance>> s_getVisualStudioInstances = VisualStudioLocationHelper.GetInstances;


### PR DESCRIPTION
When running a test runner under mono, the process name is not helpful
to determine if we are running tests. Getting command line arguments,
OTOH, do help with this.

So, we bring back the old `GetProcessFromCommandLine()` method. And
also, add this as a parameter to the `ResetInstance_ForUnitTestsOnly(..)`
method.

This fixes
Microsoft.Build.Engine.UnitTests.BuildEnvironmentHelper_Tests.BuildEnvironmentDetectsRunningTests