### PR TITLE
Ensure all VSTS builds have four-part versions

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,10 +1,6 @@
 {
   "version": "15.5-preview",
   "assemblyVersion": "15.1",
-  "publicReleaseRefSpec": [
-    "^refs/heads/master$",
-    "^refs/heads/vs.*$"
-  ],
   "cloudBuild": {
     "buildNumber": {
       "enabled": true,


### PR DESCRIPTION
Builds from the master branch were being categorized as "release"
builds, and GitVersioning was emitting the official version number as a
three-part version like `15.5.42-preview`, which broke automated
releases, which need the four-part version number for the ExternalAPIs
package.

@AndyGerlicher this should unbreak the automated ingestions.