### PR TITLE
Copy application base directory when creating app domain for task

### DIFF
--- a/src/Shared/TaskLoader.cs
+++ b/src/Shared/TaskLoader.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Build.Shared
 
                         // Apply the appdomain settings to the new appdomain before creating it
                         appDomainInfo.SetConfigurationBytes(currentAppdomainBytes);
+                        appDomainInfo.ApplicationBase = appDomainSetup.ApplicationBase;
 
                         if (BuildEnvironmentHelper.Instance.RunningTests)
                         {


### PR DESCRIPTION
This fixes #1900 in scenario described there. I've tested the it locally, but I was not able to write unit test for the fix. Because ApplicationBase is being overwritten by test environment variables just few lines bellow. 