### PR TITLE
Reduce Allocs

### DIFF
--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -701,7 +701,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal static string[] GetTaskFiles(DirectoryGetFiles getFiles, ILoggingService loggingServices, BuildEventContext buildEventContext, string taskPattern, string searchPath, string taskFileWarning)
         {
-            string[] defaultTasksFiles = { };
+            string[] defaultTasksFiles = null;
 
             try
             {
@@ -744,8 +744,12 @@ namespace Microsoft.Build.Evaluation
             }
 
             // Sort the file names to give a deterministic order
-            Array.Sort<string>(defaultTasksFiles, StringComparer.OrdinalIgnoreCase);
-            return defaultTasksFiles;
+            if (defaultTasksFiles != null)
+            {
+                Array.Sort<string>(defaultTasksFiles, StringComparer.OrdinalIgnoreCase);
+                return defaultTasksFiles;
+            }
+            return Array.Empty<string>();
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Build.Evaluation
                 return null;
             }
 
-            var list = new List<string>();
+            var list = new List<string>(capacity: expandedCount);
             for (var i = 0; i < expandedCount; i++)
             {
                 var item = expanded[i];

--- a/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Build.Shared;
 
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
@@ -43,9 +42,21 @@ namespace Microsoft.Build.Evaluation
                     // Expand the items and use DefaultIfEmpty in case there is nothing returned
                     // Then check if everything is not null (because the list was empty), not
                     // already loaded into the cache, and exists
-                    return ExpandArgumentAsFileList((GenericExpressionNode) _arguments[0], state)
-                        .DefaultIfEmpty()
-                        .All(i => i != null && (state.LoadedProjectsCache?.TryGet(i) != null || FileUtilities.FileOrDirectoryExistsNoThrow(i)));
+                    var list = ExpandArgumentAsFileList((GenericExpressionNode) _arguments[0], state);
+                    if (list == null)
+                    {
+                        return false;
+                    }
+
+                    foreach (var item in list)
+                    {
+                        if (item == null || !(state.LoadedProjectsCache?.TryGet(item) != null || FileUtilities.FileOrDirectoryExistsNoThrow(item)))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {
@@ -137,7 +148,7 @@ namespace Microsoft.Build.Evaluation
             return expandedValue;
         }
 
-        private IEnumerable<string> ExpandArgumentAsFileList(GenericExpressionNode argumentNode, ConditionEvaluator.IConditionEvaluationState state, bool isFilePath = true)
+        private List<string> ExpandArgumentAsFileList(GenericExpressionNode argumentNode, ConditionEvaluator.IConditionEvaluationState state, bool isFilePath = true)
         {
             string argument = argumentNode.GetUnexpandedValue(state);
 
@@ -147,11 +158,30 @@ namespace Microsoft.Build.Evaluation
                 argument = FileUtilities.FixFilePath(argument);
             }
 
-            return state.ExpandIntoTaskItems(argument)
-                .Select(i =>
-                    state.EvaluationDirectory != null && !Path.IsPathRooted(i.ItemSpec)
-                        ? Path.GetFullPath(Path.Combine(state.EvaluationDirectory, i.ItemSpec))
-                        : i.ItemSpec);
+
+            IList<TaskItem> expanded = state.ExpandIntoTaskItems(argument);
+            var expandedCount = expanded.Count;
+
+            if (expandedCount == 0)
+            {
+                return null;
+            }
+
+            var list = new List<string>();
+            for (var i = 0; i < expandedCount; i++)
+            {
+                var item = expanded[i];
+                if (state.EvaluationDirectory != null && !Path.IsPathRooted(item.ItemSpec))
+                {
+                    list.Add(Path.GetFullPath(Path.Combine(state.EvaluationDirectory, item.ItemSpec)));
+                }
+                else
+                {
+                    list.Add(item.ItemSpec);
+                }
+            }
+
+            return list;
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -791,8 +791,9 @@ namespace Microsoft.Build.Evaluation
             // Pass1: evaluate properties, load imports, and gather everything else
             PerformDepthFirstPass(_projectRootElement);
 
-            List<string> initialTargets = new List<string>(_initialTargetsList.Count);
-            for (int i = 0; i < _initialTargetsList.Count; i++)
+            var initialTargetsListCount = _initialTargetsList.Count;
+            List<string> initialTargets = new List<string>(initialTargetsListCount);
+            for (var i = 0; i < initialTargetsListCount; i++)
             {
                 initialTargets.Add(EscapingUtilities.UnescapeAll(_initialTargetsList[i].Trim()));
             }
@@ -806,9 +807,10 @@ namespace Microsoft.Build.Evaluation
             DataCollection.CommentMarkProfile(8817, endPass1);
 #endif
             // Pass2: evaluate item definitions
-            foreach (ProjectItemDefinitionGroupElement itemDefinitionGroupElement in _itemDefinitionGroupElements)
+            var itemsDefinitionGroupElementsCount = _itemDefinitionGroupElements.Count;
+            for (var i = 0; i < itemsDefinitionGroupElementsCount; i++)
             {
-                EvaluateItemDefinitionGroupElement(itemDefinitionGroupElement);
+                EvaluateItemDefinitionGroupElement(_itemDefinitionGroupElements[i]);
             }
 #if (!STANDALONEBUILD)
             CodeMarkers.Instance.CodeMarker(CodeMarkerEvent.perfMSBuildProjectEvaluatePass2End);
@@ -823,18 +825,20 @@ namespace Microsoft.Build.Evaluation
             lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _evaluationLoggingContext);
 
             // Pass3: evaluate project items
-            foreach (ProjectItemGroupElement itemGroupElement in _itemGroupElements)
+            var itemsGroupCount = _itemGroupElements.Count;
+            for (var i = 0; i < itemsGroupCount; i++)
             {
-                EvaluateItemGroupElement(itemGroupElement, lazyEvaluator);
+                EvaluateItemGroupElement(_itemGroupElements[i], lazyEvaluator);
             }
 
             if (lazyEvaluator != null)
             {
-
                 // Tell the lazy evaluator to compute the items and add them to _data
                 IList<LazyItemEvaluator<P, I, M, D>.ItemData> items = lazyEvaluator.GetAllItems();
-                foreach (var itemData in items)
+                var itemsCount = items.Count;
+                for (var i = 0; i < itemsCount; i++)
                 {
+                    var itemData = items[i];
                     if (itemData.ConditionResult)
                     {
                         _data.AddItem(itemData.Item);
@@ -863,16 +867,20 @@ namespace Microsoft.Build.Evaluation
             DataCollection.CommentMarkProfile(8819, endPass3);
 #endif
             // Pass4: evaluate using-tasks
-            foreach (Pair<string, ProjectUsingTaskElement> entry in _usingTaskElements)
+            var entryCount = _usingTaskElements.Count;
+            for (var i = 0; i < entryCount; i++)
             {
+                var entry = _usingTaskElements[i];
                 EvaluateUsingTaskElement(entry.Key, entry.Value);
             }
 
             // If there was no DefaultTargets attribute found in the depth first pass, 
             // use the name of the first target. If there isn't any target, don't error until build time.
+
+            var targetElementsCount = _targetElements.Count;
             if (_data.DefaultTargets == null || _data.DefaultTargets.Count == 0)
             {
-                List<string> defaultTargets = new List<string>(_targetElements.Count);
+                List<string> defaultTargets = new List<string>(targetElementsCount);
                 if (_targetElements.Count > 0)
                 {
                     defaultTargets.Add(_targetElements[0].Name);
@@ -894,9 +902,9 @@ namespace Microsoft.Build.Evaluation
 #endif
 
             // Pass5: read targets (but don't evaluate them: that happens during build)
-            foreach (ProjectTargetElement targetElement in _targetElements)
+            for (var i = 0; i < targetElementsCount; i++)
             {
-                ReadTargetElement(targetElement, activeTargetsByEvaluationOrder, activeTargets);
+                ReadTargetElement(_targetElements[i], activeTargetsByEvaluationOrder, activeTargets);
             }
 
             foreach (ProjectTargetElement target in activeTargetsByEvaluationOrder)
@@ -962,9 +970,10 @@ namespace Microsoft.Build.Evaluation
             if (!Traits.Instance.EscapeHatches.IgnoreTreatAsLocalProperty)
             {
                 IList<string> globalPropertiesToTreatAsLocals = _expander.ExpandIntoStringListLeaveEscaped(currentProjectOrImport.TreatAsLocalProperty, ExpanderOptions.ExpandProperties, currentProjectOrImport.TreatAsLocalPropertyLocation);
-
-                foreach (string propertyName in globalPropertiesToTreatAsLocals)
+                var globalPropertiesToTreatAsLocalsCount = globalPropertiesToTreatAsLocals.Count;
+                for (var i = 0; i < globalPropertiesToTreatAsLocalsCount; i++)
                 {
+                    var propertyName = globalPropertiesToTreatAsLocals[i];
                     XmlUtilities.VerifyThrowProjectValidElementName(propertyName, currentProjectOrImport.Location);
                     _data.GlobalPropertiesToTreatAsLocal.Add(propertyName);
                 }
@@ -1006,9 +1015,14 @@ namespace Microsoft.Build.Evaluation
             var implicitImports = currentProjectOrImport.GetImplicitImportNodes(currentProjectOrImport);
 
             // Evaluate the "top" implicit imports as if they were the first entry in the file.
-            foreach (var import in implicitImports.Where(i => i.ImplicitImportLocation == ImplicitImportLocation.Top))
+            var implicitImportsCount = implicitImports.Count;
+            for (var i = 0; i < implicitImportsCount; i++)
             {
-                EvaluateImportElement(currentProjectOrImport.DirectoryPath, import);
+                var import = implicitImports[i];
+                if (import.ImplicitImportLocation == ImplicitImportLocation.Top)
+                {
+                    EvaluateImportElement(currentProjectOrImport.DirectoryPath, import);
+                }
             }
 
             foreach (ProjectElement element in currentProjectOrImport.Children)
@@ -1172,9 +1186,14 @@ namespace Microsoft.Build.Evaluation
             }
 
             // Evaluate the "bottom" implicit imports as if they were the last entry in the file.
-            foreach (var import in implicitImports.Where(i => i.ImplicitImportLocation == ImplicitImportLocation.Bottom))
+            implicitImportsCount = implicitImports.Count;
+            for (var i = 0; i < implicitImportsCount; i++)
             {
-                EvaluateImportElement(currentProjectOrImport.DirectoryPath, import);
+                var import = implicitImports[i];
+                if (import.ImplicitImportLocation == ImplicitImportLocation.Bottom)
+                {
+                    EvaluateImportElement(currentProjectOrImport.DirectoryPath, import);
+                }
             }
 
 #if FEATURE_MSBUILD_DEBUGGER

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -791,6 +791,7 @@ namespace Microsoft.Build.Evaluation
             // Pass1: evaluate properties, load imports, and gather everything else
             PerformDepthFirstPass(_projectRootElement);
 
+            // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
             var initialTargetsListCount = _initialTargetsList.Count;
             List<string> initialTargets = new List<string>(initialTargetsListCount);
             for (var i = 0; i < initialTargetsListCount; i++)
@@ -807,6 +808,7 @@ namespace Microsoft.Build.Evaluation
             DataCollection.CommentMarkProfile(8817, endPass1);
 #endif
             // Pass2: evaluate item definitions
+            // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
             var itemsDefinitionGroupElementsCount = _itemDefinitionGroupElements.Count;
             for (var i = 0; i < itemsDefinitionGroupElementsCount; i++)
             {
@@ -825,6 +827,7 @@ namespace Microsoft.Build.Evaluation
             lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _evaluationLoggingContext);
 
             // Pass3: evaluate project items
+            // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
             var itemsGroupCount = _itemGroupElements.Count;
             for (var i = 0; i < itemsGroupCount; i++)
             {
@@ -835,6 +838,7 @@ namespace Microsoft.Build.Evaluation
             {
                 // Tell the lazy evaluator to compute the items and add them to _data
                 IList<LazyItemEvaluator<P, I, M, D>.ItemData> items = lazyEvaluator.GetAllItems();
+                // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
                 var itemsCount = items.Count;
                 for (var i = 0; i < itemsCount; i++)
                 {
@@ -867,6 +871,7 @@ namespace Microsoft.Build.Evaluation
             DataCollection.CommentMarkProfile(8819, endPass3);
 #endif
             // Pass4: evaluate using-tasks
+            // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
             var entryCount = _usingTaskElements.Count;
             for (var i = 0; i < entryCount; i++)
             {
@@ -877,16 +882,15 @@ namespace Microsoft.Build.Evaluation
             // If there was no DefaultTargets attribute found in the depth first pass, 
             // use the name of the first target. If there isn't any target, don't error until build time.
 
-            var targetElementsCount = _targetElements.Count;
-            if (_data.DefaultTargets == null || _data.DefaultTargets.Count == 0)
+            if (_data.DefaultTargets == null)
             {
-                List<string> defaultTargets = new List<string>(targetElementsCount);
-                if (_targetElements.Count > 0)
-                {
-                    defaultTargets.Add(_targetElements[0].Name);
-                }
+                _data.DefaultTargets = new List<string>(1);
+            }
 
-                _data.DefaultTargets = defaultTargets;
+            var targetElementsCount = _targetElements.Count;
+            if (_data.DefaultTargets.Count == 0 && targetElementsCount > 0)
+            {
+                _data.DefaultTargets.Add(_targetElements[0].Name);
             }
 
             Dictionary<string, List<TargetSpecification>> targetsWhichRunBeforeByTarget = new Dictionary<string, List<TargetSpecification>>(StringComparer.OrdinalIgnoreCase);
@@ -970,6 +974,7 @@ namespace Microsoft.Build.Evaluation
             if (!Traits.Instance.EscapeHatches.IgnoreTreatAsLocalProperty)
             {
                 IList<string> globalPropertiesToTreatAsLocals = _expander.ExpandIntoStringListLeaveEscaped(currentProjectOrImport.TreatAsLocalProperty, ExpanderOptions.ExpandProperties, currentProjectOrImport.TreatAsLocalPropertyLocation);
+                // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
                 var globalPropertiesToTreatAsLocalsCount = globalPropertiesToTreatAsLocals.Count;
                 for (var i = 0; i < globalPropertiesToTreatAsLocalsCount; i++)
                 {
@@ -1015,6 +1020,7 @@ namespace Microsoft.Build.Evaluation
             var implicitImports = currentProjectOrImport.GetImplicitImportNodes(currentProjectOrImport);
 
             // Evaluate the "top" implicit imports as if they were the first entry in the file.
+            // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
             var implicitImportsCount = implicitImports.Count;
             for (var i = 0; i < implicitImportsCount; i++)
             {
@@ -1186,6 +1192,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             // Evaluate the "bottom" implicit imports as if they were the last entry in the file.
+            // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
             implicitImportsCount = implicitImports.Count;
             for (var i = 0; i < implicitImportsCount; i++)
             {

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -343,8 +343,10 @@ namespace Microsoft.Build.Evaluation
 
             IList<string> splits = ExpressionShredder.SplitSemiColonSeparatedList(expression);
 
-            foreach (string split in splits)
+            var splitsCount = splits.Count;
+            for (var i = 0; i < splitsCount; i++)
             {
+                var split = splits[i];
                 bool isTransformExpression;
                 IList<T> itemsToAdd = ItemExpander.ExpandSingleItemVectorExpressionIntoItems<I, T>(this, split, _items, itemFactory, options, false /* do not include null items */, out isTransformExpression, elementLocation);
 

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -343,6 +343,7 @@ namespace Microsoft.Build.Evaluation
 
             IList<string> splits = ExpressionShredder.SplitSemiColonSeparatedList(expression);
 
+            // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
             var splitsCount = splits.Count;
             for (var i = 0; i < splitsCount; i++)
             {

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Text;
 using System.Threading;
@@ -1054,23 +1055,89 @@ namespace Microsoft.Build.Shared
 
         internal static string NormalizeForPathComparison(this string s) => s.ToSlash().TrimTrailingSlashes();
 
+        // TODO: assumption on file system case sensitivity: https://github.com/Microsoft/msbuild/issues/781
         internal static bool PathsEqual(string path1, string path2)
         {
-            var trim1 = path1.TrimTrailingSlashes();
-            var trim2 = path2.TrimTrailingSlashes();
-
-            if (string.Equals(trim1, trim2, PathComparison))
+            if (path1 == null && path2 == null)
             {
                 return true;
             }
+            if (path1 == null || path2 == null)
+            {
+                return false;
+            }
 
-            var slash1 = trim1.ToSlash();
-            var slash2 = trim2.ToSlash();
+            var endA = path1.Length - 1;
+            var endB = path2.Length - 1;
 
-            return string.Equals(slash1, slash2, PathComparison);
+            // Trim trailing slashes
+            for (var i = endA; i >= 0; i--)
+            {
+                var c = path1[i];
+                if (c == '/' || c == '\\')
+                {
+                    endA--;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            for (var i = endB; i >= 0; i--)
+            {
+                var c = path2[i];
+                if (c == '/' || c == '\\')
+                {
+                    endB--;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (endA != endB)
+            {
+                // Lengths not the same
+                return false;
+            }
+
+            for (var i = 0; i <= endA; i++)
+            {
+                var charA = (uint)path1[i];
+                var charB = (uint)path2[i];
+
+                if ((charA | charB) > 0x7F)
+                {
+                    // Non-ascii chars move to non fast path
+                    return PathsEqualNonAscii(path1, path2, i, endA - i + 1);
+                }
+
+                // uppercase both chars - notice that we need just one compare per char
+                if ((uint)(charA - 'a') <= (uint)('z' - 'a')) charA -= 0x20;
+                if ((uint)(charB - 'a') <= (uint)('z' - 'a')) charB -= 0x20;
+
+                // Set path delimiters the same
+                if (charA == '\\')
+                {
+                    charA = '/';
+                }
+                if (charB == '\\')
+                {
+                    charB = '/';
+                }
+
+                if (charA != charB)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
-		internal static StreamWriter OpenWrite(string path, bool append, Encoding encoding = null)
+        internal static StreamWriter OpenWrite(string path, bool append, Encoding encoding = null)
         {
             const int DefaultFileStreamBufferSize = 4096;
             FileMode mode = append ? FileMode.Append : FileMode.Create;
@@ -1097,6 +1164,25 @@ namespace Microsoft.Build.Shared
             {
                 return new StreamReader(fileStream, encoding, detectEncodingFromByteOrderMarks);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool PathsEqualNonAscii(string strA, string strB, int i, int length)
+        {
+            if (string.Compare(strA, i, strB, i, length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return true;
+            }
+
+            var slash1 = strA.ToSlash();
+            var slash2 = strB.ToSlash();
+
+            if (string.Compare(slash1, i, slash2, i, length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1166,6 +1166,9 @@ namespace Microsoft.Build.Shared
             }
         }
 
+        // Method is simple set of function calls and may inline;
+        // we don't want it inlining into the tight loop that calls it as an exit case,
+        // so mark as non-inlining
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool PathsEqualNonAscii(string strA, string strB, int i, int length)
         {

--- a/src/Shared/ProjectErrorUtilities.cs
+++ b/src/Shared/ProjectErrorUtilities.cs
@@ -55,11 +55,11 @@ namespace Microsoft.Build.Shared
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
-        internal static void ThrowInvalidProject
+        internal static void ThrowInvalidProject<T1>
         (
             IElementLocation elementLocation,
             string resourceName,
-            object arg0
+            T1 arg0
         )
         {
             VerifyThrowInvalidProject(false, null, elementLocation, resourceName, arg0);
@@ -72,12 +72,12 @@ namespace Microsoft.Build.Shared
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
-        internal static void VerifyThrowInvalidProject
+        internal static void VerifyThrowInvalidProject<T1>
         (
             bool condition,
             IElementLocation elementLocation,
             string resourceName,
-            object arg0
+            T1 arg0
         )
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName, arg0);
@@ -90,12 +90,12 @@ namespace Microsoft.Build.Shared
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
-        internal static void ThrowInvalidProject
+        internal static void ThrowInvalidProject<T1, T2>
         (
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1
+            T1 arg0,
+            T2 arg1
         )
         {
             VerifyThrowInvalidProject(false, null, elementLocation, resourceName, arg0, arg1);
@@ -109,13 +109,13 @@ namespace Microsoft.Build.Shared
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
-        internal static void ThrowInvalidProject
+        internal static void ThrowInvalidProject<T1, T2, T3>
         (
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1,
-            object arg2
+            T1 arg0,
+            T2 arg1,
+            T3 arg2
         )
         {
             VerifyThrowInvalidProject(false, null, elementLocation, resourceName, arg0, arg1, arg2);
@@ -130,14 +130,14 @@ namespace Microsoft.Build.Shared
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
         /// <param name="arg3"></param>
-        internal static void ThrowInvalidProject
+        internal static void ThrowInvalidProject<T1, T2, T3, T4>
         (
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3
+            T1 arg0,
+            T2 arg1,
+            T3 arg2,
+            T4 arg3
         )
         {
             VerifyThrowInvalidProject(false, null, elementLocation, resourceName, arg0, arg1, arg2, arg3);
@@ -167,13 +167,13 @@ namespace Microsoft.Build.Shared
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
-        internal static void VerifyThrowInvalidProject
+        internal static void VerifyThrowInvalidProject<T1, T2>
         (
             bool condition,
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1
+            T1 arg0,
+            T2 arg1
         )
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName, arg0, arg1);
@@ -188,14 +188,14 @@ namespace Microsoft.Build.Shared
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
-        internal static void VerifyThrowInvalidProject
+        internal static void VerifyThrowInvalidProject<T1, T2, T3>
         (
             bool condition,
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1,
-            object arg2
+            T1 arg0,
+            T2 arg1,
+            T3 arg2
         )
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName, arg0, arg1, arg2);
@@ -211,15 +211,15 @@ namespace Microsoft.Build.Shared
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
         /// <param name="arg3"></param>
-        internal static void VerifyThrowInvalidProject
+        internal static void VerifyThrowInvalidProject<T1, T2, T3, T4>
         (
             bool condition,
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3
+            T1 arg0,
+            T2 arg1,
+            T3 arg2,
+            T4 arg3
         )
         {
             VerifyThrowInvalidProject(condition, null, elementLocation, resourceName, arg0, arg1, arg2, arg3);
@@ -260,13 +260,13 @@ namespace Microsoft.Build.Shared
         /// <param name="elementLocation">The <see cref="IElementLocation"/> of the element.</param>
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
-        internal static void VerifyThrowInvalidProject
+        internal static void VerifyThrowInvalidProject<T1>
         (
             bool condition,
             string errorSubCategoryResourceName,
             IElementLocation elementLocation,
             string resourceName,
-            object arg0
+            T1 arg0
         )
         {
             // PERF NOTE: check the condition here instead of pushing it into
@@ -288,14 +288,14 @@ namespace Microsoft.Build.Shared
         /// <param name="resourceName">The resource string for the error message.</param>
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
-        internal static void VerifyThrowInvalidProject
+        internal static void VerifyThrowInvalidProject<T1, T2>
         (
             bool condition,
             string errorSubCategoryResourceName,
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1
+            T1 arg0,
+            T2 arg1
         )
         {
             // PERF NOTE: check the condition here instead of pushing it into
@@ -318,15 +318,15 @@ namespace Microsoft.Build.Shared
         /// <param name="arg0"></param>
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
-        internal static void VerifyThrowInvalidProject
+        internal static void VerifyThrowInvalidProject<T1, T2, T3>
         (
             bool condition,
             string errorSubCategoryResourceName,
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1,
-            object arg2
+            T1 arg0,
+            T2 arg1,
+            T3 arg2
         )
         {
             // PERF NOTE: check the condition here instead of pushing it into
@@ -350,16 +350,16 @@ namespace Microsoft.Build.Shared
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
         /// <param name="arg3"></param>
-        internal static void VerifyThrowInvalidProject
+        internal static void VerifyThrowInvalidProject<T1, T2, T3, T4>
         (
             bool condition,
             string errorSubCategoryResourceName,
             IElementLocation elementLocation,
             string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3
+            T1 arg0,
+            T2 arg1,
+            T3 arg2,
+            T4 arg3
         )
         {
             // PERF NOTE: check the condition here instead of pushing it into

--- a/src/Shared/ReuseableStringBuilder.cs
+++ b/src/Shared/ReuseableStringBuilder.cs
@@ -295,9 +295,6 @@ namespace Microsoft.Build.Shared
             /// </summary>
             internal static void Release(StringBuilder returningBuilder)
             {
-                // ErrorUtilities.VerifyThrow(handouts.TryRemove(returningBuilder, out dummy), "returned but not loaned");
-                returningBuilder.Clear(); // This is free: it just sets length to zero internally
-
                 // It's possible for someone to cause the builder to
                 // enlarge to such an extent that this static field
                 // would be a leak. To avoid that, only accept
@@ -309,6 +306,9 @@ namespace Microsoft.Build.Shared
                 // So the shared builder will be "replaced".
                 if (returningBuilder.Capacity < MaxBuilderSize)
                 {
+                    // ErrorUtilities.VerifyThrow(handouts.TryRemove(returningBuilder, out dummy), "returned but not loaned");
+                    returningBuilder.Clear(); // This is free: it just sets length to zero internally
+
                     Interlocked.Exchange(ref s_sharedBuilder, returningBuilder);
 #if DEBUG
                     Interlocked.Increment(ref s_accepts);

--- a/src/Shared/ReuseableStringBuilder.cs
+++ b/src/Shared/ReuseableStringBuilder.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Build.Shared
                 if (returningBuilder.Capacity < MaxBuilderSize)
                 {
                     // ErrorUtilities.VerifyThrow(handouts.TryRemove(returningBuilder, out dummy), "returned but not loaned");
-                    returningBuilder.Clear(); // This is free: it just sets length to zero internally
+                    returningBuilder.Clear(); // Clear before pooling
 
                     Interlocked.Exchange(ref s_sharedBuilder, returningBuilder);
 #if DEBUG


### PR DESCRIPTION
Remove opportunistic array allocation from `GetTaskFiles`

Remove IEnumerator and closure capture allocations from `FunctionCallExpressionNode`
Remove IEnumerator allocations from `Evaluator.ReadNewTargetElement`
Remove IEnumerator allocations from `Evaluator.PerformDepthFirstPass`

Remove IEnumerator allocations from `Expander.ExpandIntoItemsLeaveEscaped`

Reduce `string`  allocations from `FileUtilities.PathsEqual`

Reduce boxing allocations from `ProjectErrorUtilities`

Remove `StringBuilder.Clear` allocation on discarded `StringBuilder`s

Saves 20% of allocations (496MB) in a Rosyln restore (2389MB to 1893MB)

/cc @davkean @KirillOsenkov