### PR TITLE
Do not prevent taking the switch /NodeReuse when FEATURE_NODE_REUSE i…

### DIFF
--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -94,9 +94,7 @@ namespace Microsoft.Build.CommandLine
             FileLoggerParameters7,
             FileLoggerParameters8,
             FileLoggerParameters9,
-#if FEATURE_NODE_REUSE
             NodeReuse,
-#endif
             Preprocess,
 #if !FEATURE_NAMED_PIPES_FULL_DUPLEX
             ClientToServerPipeHandle,
@@ -274,9 +272,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "fileloggerparameters7", "flp7" },     ParameterizedSwitch.FileLoggerParameters7,      null,                           false,          "MissingFileLoggerParameterError",     true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "fileloggerparameters8", "flp8" },     ParameterizedSwitch.FileLoggerParameters8,      null,                           false,          "MissingFileLoggerParameterError",     true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "fileloggerparameters9", "flp9" },     ParameterizedSwitch.FileLoggerParameters9,      null,                           false,          "MissingFileLoggerParameterError",     true,   false  ),
-#if FEATURE_NODE_REUSE
             new ParameterizedSwitchInfo(  new string[] { "nodereuse", "nr" },                   ParameterizedSwitch.NodeReuse,                  null,                           false,          "MissingNodeReuseParameterError",      true,   false  ),
-#endif
             new ParameterizedSwitchInfo(  new string[] { "preprocess", "pp" },                  ParameterizedSwitch.Preprocess,                 null,                           false,          null,                                  true,   false  ),
 #if !FEATURE_NAMED_PIPES_FULL_DUPLEX
             new ParameterizedSwitchInfo(  new string[] { "clientToServerPipeHandle", "c2s" },   ParameterizedSwitch.ClientToServerPipeHandle,   null,                           false,          null,                                  true,   false  ),
@@ -510,7 +506,7 @@ namespace Microsoft.Build.CommandLine
                     // check if they were all stored successfully i.e. they were all non-empty (after removing quoting, if requested)
                     parametersStored = (emptyParameters == 0);
                 }
-                
+
             }
             else
             {

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -74,14 +74,14 @@
       LOCALIZATION: The prefix "MSB1050 : error MSBxxxx:" should not be localized.
     </comment>
   </data>
-  
+
   <data name="ConfigurationFailurePrefixNoErrorCode" UESanitized="false" Visibility="Public">
     <value>MSBUILD : Configuration error {0}: {1}</value>
     <comment>{SubString="Configuration"}UE: This prefixes any error from reading the toolset definitions in msbuild.exe.config or the registry.
       There's no error code because one was included in the error message.
       LOCALIZATION: The word "Configuration" should be localized, the words "MSBuild" and "error" should NOT be localized.
     </comment>
-  </data>  
+  </data>
   <data name="CannotAutoDisableAutoResponseFile" UESanitized="false" Visibility="Public">
     <value>MSBUILD : error MSB1027: The /noautoresponse switch cannot be specified in the MSBuild.rsp auto-response file, nor in any response file that is referenced by the auto-response file.</value>
     <comment>{StrBegin="MSBUILD : error MSB1027: "}LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:", "/noautoresponse" and "MSBuild.rsp" should not be localized.</comment>
@@ -186,9 +186,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <value>  @&lt;file&gt;            Insert command-line settings from a text file. To specify
                      multiple response files, specify each response file
                      separately.
-                     
-                     Any response files named "msbuild.rsp" are automatically 
-                     consumed from the following locations: 
+
+                     Any response files named "msbuild.rsp" are automatically
+                     consumed from the following locations:
                      (1) the directory of msbuild.exe
                      (2) the directory of the first project or solution built
 </value>
@@ -299,22 +299,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                         ErrorsOnly--Show only errors.
                         WarningsOnly--Show only warnings.
                         NoItemAndPropertyList--Don't show list of items and
-                            properties at the start of each project build.    
-                        ShowCommandLine--Show TaskCommandLineEvent messages  
+                            properties at the start of each project build.
+                        ShowCommandLine--Show TaskCommandLineEvent messages
                         ShowTimestamp--Display the Timestamp as a prefix to any
-                            message.                                           
-                        ShowEventId--Show eventId for started events, finished 
+                            message.
+                        ShowEventId--Show eventId for started events, finished
                             events, and messages
                         ForceNoAlign--Does not align the text to the size of
                             the console buffer
                         DisableConsoleColor--Use the default console colors
                             for all logging messages.
                         DisableMPLogging-- Disable the multiprocessor
-                            logging style of output when running in 
+                            logging style of output when running in
                             non-multiprocessor mode.
                         EnableMPLogging--Enable the multiprocessor logging
                             style even when running in non-multiprocessor
-                            mode. This logging style is on by default. 
+                            mode. This logging style is on by default.
                         ForceConsoleColor--Use ANSI console colors even if
                             console does not support it
                         Verbosity--overrides the /verbosity setting for this
@@ -364,22 +364,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </comment>
   </data>
   <data name="HelpMessage_17_MaximumCPUSwitch" UESanitized="false" Visibility="Public">
-      <value>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to 
+      <value>  /maxcpucount[:n]   Specifies the maximum number of concurrent processes to
                      build with. If the switch is not used, the default
                      value used is 1. If the switch is used without a value
-                     MSBuild will use up to the number of processors on the 
+                     MSBuild will use up to the number of processors on the
                      computer. (Short form: /m[:n])
       </value>
       <comment>
           LOCALIZATION: "maxcpucount" should not be localized.
           LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
       </comment>
-  </data>    
+  </data>
   <data name="HelpMessage_16_Examples" UESanitized="true" Visibility="Public">
     <value>Examples:
 
         MSBuild MyApp.sln /t:Rebuild /p:Configuration=Release
-        MSBuild MyApp.csproj /t:Clean 
+        MSBuild MyApp.csproj /t:Clean
                              /p:Configuration=Debug;TargetFrameworkVersion=v3.5
     </value>
     <comment>
@@ -399,10 +399,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 
  <data name="HelpMessage_18_DistributedLoggerSwitch" UESanitized="true" Visibility="Public">
-    <value>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;                     
+    <value>  /distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;
                      Use this logger to log events from MSBuild, attaching a
                      different logger instance to each node. To specify
-                     multiple loggers, specify each logger separately. 
+                     multiple loggers, specify each logger separately.
                      (Short form /dl)
                      The &lt;logger&gt; syntax is:
                        [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
@@ -427,8 +427,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </data>
    <data name="HelpMessage_19_IgnoreProjectExtensionsSwitch" UESanitized="false" Visibility="Public">
     <value>  /ignoreprojectextensions:&lt;extensions&gt;
-                     List of extensions to ignore when determining which 
-                     project file to build. Use a semicolon or a comma 
+                     List of extensions to ignore when determining which
+                     project file to build. Use a semicolon or a comma
                      to separate multiple extensions.
                      (Short form: /ignore)
                      Example:
@@ -447,8 +447,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <data name="HelpMessage_23_ToolsVersionSwitch" UESanitized="false" Visibility="Public">
    <value>  /toolsversion:&lt;version&gt;
                      The version of the MSBuild Toolset (tasks, targets, etc.)
-                     to use during build. This version will override the 
-                     versions specified by individual projects. (Short form: 
+                     to use during build. This version will override the
+                     versions specified by individual projects. (Short form:
                      /tv)
                      Example:
                        /toolsversion:3.5
@@ -462,15 +462,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </comment>
   </data>
- 
+
   <data name="HelpMessage_20_FileLoggerSwitch" UESanitized="false" Visibility="Public">
     <value>  /fileLogger[n]     Logs the build output to a file. By default
-                     the file is in the current directory and named 
+                     the file is in the current directory and named
                      "msbuild[n].log". Events from all nodes are combined into
                      a single log. The location of the file and other
-                     parameters for the fileLogger can be specified through 
+                     parameters for the fileLogger can be specified through
                      the addition of the "/fileLoggerParameters[n]" switch.
-                     "n" if present can be a digit from 1-9, allowing up to 
+                     "n" if present can be a digit from 1-9, allowing up to
                      10 file loggers to be attached. (Short form: /fl[n])
     </value>
     <comment>
@@ -483,17 +483,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </comment>
   </data>
   <data name="HelpMessage_21_DistributedFileLoggerSwitch" UESanitized="false" Visibility="Public">
-    <value>  /distributedFileLogger                                                       
+    <value>  /distributedFileLogger
                      Logs the build output to multiple log files, one log file
                      per MSBuild node. The initial location for these files is
-                     the current directory. By default the files are called 
+                     the current directory. By default the files are called
                      "MSBuild&lt;nodeid&gt;.log". The location of the files and
-                     other parameters for the fileLogger can be specified 
+                     other parameters for the fileLogger can be specified
                      with the addition of the "/fileLoggerParameters" switch.
 
                      If a log file name is set through the fileLoggerParameters
-                     switch the distributed logger will use the fileName as a 
-                     template and append the node id to this fileName to 
+                     switch the distributed logger will use the fileName as a
+                     template and append the node id to this fileName to
                      create a log file for each node.
     </value>
     <comment>
@@ -506,9 +506,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </comment>
   </data>
   <data name="HelpMessage_22_FileLoggerParametersSwitch" UESanitized="false" Visibility="Public">
-    <value>  /fileloggerparameters[n]:&lt;parameters&gt;                                
+    <value>  /fileloggerparameters[n]:&lt;parameters&gt;
                      Provides any extra parameters for file loggers.
-                     The presence of this switch implies the 
+                     The presence of this switch implies the
                      corresponding /filelogger[n] switch.
                      "n" if present can be a digit from 1-9.
                      /fileloggerparameters is also used by any distributed
@@ -521,18 +521,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                         Append--determines if the build log will be appended
                             to or overwrite the log file. Setting the
                             switch appends the build log to the log file;
-                            Not setting the switch overwrites the 
-                            contents of an existing log file. 
+                            Not setting the switch overwrites the
+                            contents of an existing log file.
                             The default is not to append to the log file.
-                        Encoding--specifies the encoding for the file, 
+                        Encoding--specifies the encoding for the file,
                             for example, UTF-8, Unicode, or ASCII
                      Default verbosity is Detailed.
                      Examples:
                        /fileLoggerParameters:LogFile=MyLog.log;Append;
                                            Verbosity=diagnostic;Encoding=UTF-8
 
-                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum 
-                       /flp1:warningsonly;logfile=msbuild.wrn 
+                       /flp:Summary;Verbosity=minimal;LogFile=msbuild.sum
+                       /flp1:warningsonly;logfile=msbuild.wrn
                        /flp2:errorsonly;logfile=msbuild.err
     </value>
     <comment>
@@ -557,14 +557,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </value>
   </data>
   <data name="HelpMessage_25_PreprocessSwitch">
-    <value>  /preprocess[:file] 
+    <value>  /preprocess[:file]
                      Creates a single, aggregated project file by
                      inlining all the files that would be imported during a
                      build, with their boundaries marked. This can be
                      useful for figuring out what files are being imported
                      and from where, and what they will contribute to
                      the build. By default the output is written to
-                     the console window. If the path to an output file 
+                     the console window. If the path to an output file
                      is provided that will be used instead.
                      (Short form: /pp)
                      Example:
@@ -572,17 +572,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </value>
   </data>
   <data name="HelpMessage_26_DetailedSummarySwitch">
-    <value>  /detailedsummary 
+    <value>  /detailedsummary
                      Shows detailed information at the end of the build
                      about the configurations built and how they were
-                     scheduled to nodes. 
+                     scheduled to nodes.
                      (Short form: /ds)
     </value>
   </data>
   <data name="HelpMessage_27_DebuggerSwitch" UESanitized="false" Visibility="Public">
    <value>  /debug
-                     Causes a debugger prompt to appear immediately so that 
-                     Visual Studio can be attached for you to debug the 
+                     Causes a debugger prompt to appear immediately so that
+                     Visual Studio can be attached for you to debug the
                      MSBuild XML and any tasks and loggers it uses.
    </value>
   </data>
@@ -633,14 +633,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
                      The binary logger by default collects the source text of
                      project files, including all imported projects and target
-                     files encountered during the build. The optional 
+                     files encountered during the build. The optional
                      ProjectImports switch controls this behavior:
 
                       ProjectImports=None     - Don't collect the project
                                                 imports.
                       ProjectImports=Embed    - Embed project imports in the
                                                 log file.
-                      ProjectImports=ZipFile  - Save project files to 
+                      ProjectImports=ZipFile  - Save project files to
                                                 output.projectimports.zip
                                                 where output is the same name
                                                 as the binary log file name.
@@ -666,7 +666,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </value>
     <comment>
       LOCALIZATION: The following should not be localized:
-      1) "msbuild" 
+      1) "msbuild"
       2) the string "binlog" that describes the file extension
       3) all switch names and their short forms e.g. /bl and /binaryLogger
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
@@ -679,7 +679,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
     </comment>
-  </data>  
+  </data>
   <data name="InvalidLoggerError" UESanitized="false" Visibility="Public">
     <value>MSBUILD : error MSB1019: Logger switch was not correctly formed.</value>
     <comment>{StrBegin="MSBUILD : error MSB1019: "}UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
@@ -925,7 +925,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <data name="SchemaNotFoundErrorWithFile" UESanitized="true" Visibility="Public">
     <value>MSBUILD : error MSB1026: Schema file '{0}' does not exist.</value>
     <comment>{StrBegin="MSBUILD : error MSB1026: "}UE: This error is printed if the default schema does not exist or in the extremely unlikely event
-    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.  
+    that an explicit schema file was passed and existed when the command line parameters were checked but was deleted from disk before this check was made.
     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.</comment>
   </data>
  <data name="UnexpectedParametersError" UESanitized="true" Visibility="Public">
@@ -949,7 +949,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <data name="MissingIgnoreProjectExtensionsError" UESanitized="false" Visibility="Public">
     <value>MSBUILD : error MSB1035: Specify the project extensions to ignore.</value>
     <comment>{StrBegin="MSBUILD : error MSB1035: "}
-      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more 
+      UE: This happens if the user does something like "msbuild.exe /IgnoreProjectextensions". The user must pass in one or more
       project extensions to ignore e.g. "msbuild.exe /IgnoreProjectExtensions:.sln".
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
@@ -989,12 +989,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
   </comment>
   </data>
+  <data name="InvalidNodeReuseTrueValue" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : error MSB1042: Node reuse value is not valid. This version of MSBuild does not support node reuse. If specified, the node reuse switch value must be false.</value>
+    <comment>{StrBegin="MSBUILD : error MSB1042: "}
+     UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+     This error is shown when a user specifies a node reuse value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+     LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+  </comment>
+  </data>
   <data name="AbortingBuild" UESanitized="true" Visibility="Public">
     <value>Attempting to cancel the build...</value>
   </data>
   <data name="InvalidPreprocessPath">
     <value>MSBUILD : error MSB1047: File to preprocess to is not valid. {0}</value>
-    <comment>{StrBegin="MSBUILD : error MSB1047: "}</comment>    
+    <comment>{StrBegin="MSBUILD : error MSB1047: "}</comment>
   </data>
   <!-- MSB1021 and MSB1020 are also used in the engine but their copies do not have the "MSBUILD : " prefix so we must have our own -->
   <data name="LoggerCreationError" UESanitized="true" Visibility="Public">


### PR DESCRIPTION
…s OFF, but constrain the switch values to never be True. This way existing build scripts stay compatible with an MSBuild installation compiled without FEATURE_NODE_REUSE if they were passing /NodeReuse:False explicitly.