### PR TITLE
Build known target in MonoTest CI

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -73,7 +73,9 @@ def imageVersionMap = ['Windows_NT':'latest-or-auto-dev15-rc',
                             }
 
                             if (runtime.startsWith("Mono")) {
-                                buildCmd += " --host Mono"
+                                // Redundantly specify target to override
+                                // "MonoTest" which cibuild.sh doesn't know
+                                buildCmd += " --host Mono --target Mono"
                             }
 
                             shell(buildCmd)
@@ -95,7 +97,9 @@ def imageVersionMap = ['Windows_NT':'latest-or-auto-dev15-rc',
                             }
 
                             if (runtime.startsWith("Mono")) {
-                                buildCmd += " --host Mono"
+                                // Redundantly specify target to override
+                                // "MonoTest" which cibuild.sh doesn't know
+                                buildCmd += " --host Mono --target Mono"
                             }
 
                             shell(buildCmd)


### PR DESCRIPTION
I messed up in #2394 and didn't notice because I expected the MonoTest config to fail.

It did, but for the wrong reason: it wasn't building correctly and bailed out immediately.

That's because `cibuild.sh` didn't recognize the `MonoTest` runtime. Because it doesn't exist!

Fixing this by redundantly specifying `--target Mono` in mono flavor jobs. Since the last argument wins, this fixes the specification while keeping the code closer to what we want its final form to be.