### PR TITLE
Revert GenAPI Package Update

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -2563,8 +2563,8 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupConfiguration2 : Microsoft.VisualStudio.Setup.Configuration.ISetupConfiguration
     {
-        Microsoft.VisualStudio.Setup.Configuration.IEnumSetupInstances EnumAllInstances();
         void _VtblGap1_3() { }
+        Microsoft.VisualStudio.Setup.Configuration.IEnumSetupInstances EnumAllInstances();
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.GuidAttribute("B41463C3-8866-43B5-BC33-2B0676F7F42E")]
@@ -2572,10 +2572,10 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupInstance
     {
+        void _VtblGap1_3() { }
         string GetDisplayName(int lcid=0);
         string GetInstallationPath();
         string GetInstallationVersion();
-        void _VtblGap1_3() { }
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.GuidAttribute("89143C9A-05AF-49B0-B717-72E218A2185C")]
@@ -2583,8 +2583,8 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupInstance2 : Microsoft.VisualStudio.Setup.Configuration.ISetupInstance
     {
-        Microsoft.VisualStudio.Setup.Configuration.InstanceState GetState();
         void _VtblGap1_8() { }
+        Microsoft.VisualStudio.Setup.Configuration.InstanceState GetState();
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.CoClassAttribute(typeof(object))]

--- a/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
+++ b/ref/net46/Microsoft.Build.Utilities.Core/Microsoft.Build.Utilities.Core.cs
@@ -614,8 +614,8 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupConfiguration2 : Microsoft.VisualStudio.Setup.Configuration.ISetupConfiguration
     {
-        Microsoft.VisualStudio.Setup.Configuration.IEnumSetupInstances EnumAllInstances();
         void _VtblGap1_3() { }
+        Microsoft.VisualStudio.Setup.Configuration.IEnumSetupInstances EnumAllInstances();
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.GuidAttribute("B41463C3-8866-43B5-BC33-2B0676F7F42E")]
@@ -623,10 +623,10 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupInstance
     {
+        void _VtblGap1_3() { }
         string GetDisplayName(int lcid=0);
         string GetInstallationPath();
         string GetInstallationVersion();
-        void _VtblGap1_3() { }
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.GuidAttribute("89143C9A-05AF-49B0-B717-72E218A2185C")]
@@ -634,8 +634,8 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupInstance2 : Microsoft.VisualStudio.Setup.Configuration.ISetupInstance
     {
-        Microsoft.VisualStudio.Setup.Configuration.InstanceState GetState();
         void _VtblGap1_8() { }
+        Microsoft.VisualStudio.Setup.Configuration.InstanceState GetState();
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.CoClassAttribute(typeof(object))]

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -325,9 +325,9 @@ namespace Microsoft.Build.Construction
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, System.Nullable<bool> preserveFormatting) { throw null; }
-        public void Reload(bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=default(System.Nullable<bool>)) { }
-        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=default(System.Nullable<bool>)) { }
-        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=default(System.Nullable<bool>)) { }
+        public void Reload(bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
+        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
+        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
         public void Save() { }
         public void Save(System.IO.TextWriter writer) { }
         public void Save(string path) { }
@@ -1564,8 +1564,8 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupConfiguration2 : Microsoft.VisualStudio.Setup.Configuration.ISetupConfiguration
     {
-        Microsoft.VisualStudio.Setup.Configuration.IEnumSetupInstances EnumAllInstances();
         void _VtblGap1_3() { }
+        Microsoft.VisualStudio.Setup.Configuration.IEnumSetupInstances EnumAllInstances();
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.GuidAttribute("B41463C3-8866-43B5-BC33-2B0676F7F42E")]
@@ -1573,10 +1573,10 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupInstance
     {
+        void _VtblGap1_3() { }
         string GetDisplayName(int lcid=0);
         string GetInstallationPath();
         string GetInstallationVersion();
-        void _VtblGap1_3() { }
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.GuidAttribute("89143C9A-05AF-49B0-B717-72E218A2185C")]
@@ -1584,8 +1584,8 @@ namespace Microsoft.VisualStudio.Setup.Configuration
     [System.Runtime.InteropServices.TypeIdentifierAttribute]
     public partial interface ISetupInstance2 : Microsoft.VisualStudio.Setup.Configuration.ISetupInstance
     {
-        Microsoft.VisualStudio.Setup.Configuration.InstanceState GetState();
         void _VtblGap1_8() { }
+        Microsoft.VisualStudio.Setup.Configuration.InstanceState GetState();
     }
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
     [System.Runtime.InteropServices.CoClassAttribute(typeof(object))]

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -325,9 +325,9 @@ namespace Microsoft.Build.Construction
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { throw null; }
         public static Microsoft.Build.Construction.ProjectRootElement Open(string path, Microsoft.Build.Evaluation.ProjectCollection projectCollection, System.Nullable<bool> preserveFormatting) { throw null; }
-        public void Reload(bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=default(System.Nullable<bool>)) { }
-        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=default(System.Nullable<bool>)) { }
-        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=default(System.Nullable<bool>)) { }
+        public void Reload(bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
+        public void ReloadFrom(string path, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
+        public void ReloadFrom(System.Xml.XmlReader reader, bool throwIfUnsavedChanges=true, System.Nullable<bool> preserveFormatting=null) { }
         public void Save() { }
         public void Save(System.IO.TextWriter writer) { }
         public void Save(string path) { }

--- a/src/.nuget/project.json
+++ b/src/.nuget/project.json
@@ -5,7 +5,7 @@
     "NuSpec.ReferenceGenerator": "1.4.2",
     "Microsoft.Net.Compilers": "2.3.1",
     "MicroBuild.Core": "0.2.0",
-    "Microsoft.DotNet.BuildTools.GenAPI": "1.0.0-beta3-01902-02"
+    "Microsoft.DotNet.BuildTools.GenAPI": "1.0.0-beta2-00731-01"
   },
   "frameworks": {
     "net46": {}

--- a/targets/GenApi.targets
+++ b/targets/GenApi.targets
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GenerateReferenceAssemblySources)' == 'true'">
-    <GenApiVersion Condition="'$(GenApiVersion)' == ''">1.0.0-beta3-01902-02</GenApiVersion>
+    <GenApiVersion Condition="'$(GenApiVersion)' == ''">1.0.0-beta2-00731-01</GenApiVersion>
     <GenApiDir Condition="'$(GenApiDir)' == ''">$(ToolPackagesDir)\Microsoft.DotNet.BuildTools.GenApi\$(GenApiVersion)\</GenApiDir>
     <GenApiTFM Condition="'$(GenApiTFM)' == '' And '$(NetCoreBuild)' != 'true'">net46</GenApiTFM>
     <GenApiTFM Condition="'$(GenApiTFM)' == '' And '$(NetCoreBuild)' == 'true'">netstandard1.3</GenApiTFM>


### PR DESCRIPTION
Resolves a build error during GenAPI caused by the copy of
System.IO.FileSystem.dll in the new GenAPI package being bad (it's not
signed). Reverting back to the old version.