### PR TITLE
Escape or avoid escaping paths in tests

### DIFF
--- a/src/Build.OM.UnitTests/Definition/DefinitionEditing_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/DefinitionEditing_Tests.cs
@@ -704,8 +704,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     </i>
   </ItemGroup>
 </Project>"),
-                   paths[0],
-                    paths[1]);
+                   ProjectCollection.Escape(paths[0]),
+                    ProjectCollection.Escape(paths[1]));
 
                 Helpers.VerifyAssertProjectContent(expected, project.Xml);
             }
@@ -821,8 +821,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     </i>
   </ItemGroup>
 </Project>"),
-                    paths[0],
-                    paths[1]);
+                    ProjectCollection.Escape(paths[0]),
+                    ProjectCollection.Escape(paths[1]));
 
                 Helpers.VerifyAssertProjectContent(expected, project.Xml);
             }
@@ -1123,7 +1123,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     <i Include=""{0}"" />
   </ItemGroup>
 </Project>"),
-                    Path.Combine(directory, "i2.xxx"));
+                    ProjectCollection.Escape(Path.Combine(directory, "i2.xxx")));
 
                 Helpers.VerifyAssertProjectContent(expected, project.Xml);
             }
@@ -1419,7 +1419,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
     </i>
   </ItemGroup>
 </Project>"),
-                    Path.Combine(directory, "i2.xxx"));
+                    ProjectCollection.Escape(Path.Combine(directory, "i2.xxx")));
 
                 Helpers.VerifyAssertProjectContent(expected, project.Xml);
             }

--- a/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
@@ -430,8 +430,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             var projBInstance = projBEval.CreateProjectInstance();
             var projBInstanceItem = projBInstance.GetItemsByItemTypeAndEvaluatedInclude("Compile", "bItem.cs").Single();
             var projAInstanceItem = projBInstance.GetItemsByItemTypeAndEvaluatedInclude("Compile", "aItem.cs").Single();
-            Assert.Equal(ProjectCollection.Escape(projB.FullPath), projBInstanceItem.GetMetadataValue(CapturedMetadataName));
-            Assert.Equal(ProjectCollection.Escape(projA.FullPath), projAInstanceItem.GetMetadataValue(CapturedMetadataName));
+            Assert.Equal(projB.FullPath, projBInstanceItem.GetMetadataValue(CapturedMetadataName));
+            Assert.Equal(projA.FullPath, projAInstanceItem.GetMetadataValue(CapturedMetadataName));
 
             // Although GetMetadataValue returns non-null, GetMetadata returns null...
             Assert.Null(projAInstanceItem.GetMetadata(CapturedMetadataName));
@@ -472,8 +472,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             var projBInstance = projBEval.CreateProjectInstance();
             var projAInstanceItem = projBInstance.GetItemsByItemTypeAndEvaluatedInclude("Compile", "aItem.cs").Single();
             var projBInstanceItem = projBInstance.GetItemsByItemTypeAndEvaluatedInclude("CompileB", "aItem.cs").Single();
-            Assert.Equal(ProjectCollection.Escape(projA.FullPath), projAInstanceItem.GetMetadataValue(CapturedMetadataName));
-            Assert.Equal(ProjectCollection.Escape(projB.FullPath), projBInstanceItem.GetMetadataValue(CapturedMetadataName));
+            Assert.Equal(projA.FullPath, projAInstanceItem.GetMetadataValue(CapturedMetadataName));
+            Assert.Equal(projB.FullPath, projBInstanceItem.GetMetadataValue(CapturedMetadataName));
 
             Assert.True(projAInstanceItem.HasMetadata(CapturedMetadataName));
             Assert.False(projAInstanceItem.Metadata.Any());

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -2685,11 +2685,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
 
-                string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::GetDirectoryNameOfFileAbove($(StartingDirectory), $(FileToFind)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+                string result = expander.ExpandIntoStringAndUnescape(@"$([MSBuild]::GetDirectoryNameOfFileAbove($(StartingDirectory), $(FileToFind)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
                 Assert.Equal(Microsoft.Build.Shared.FileUtilities.EnsureTrailingSlash(tempPath), Microsoft.Build.Shared.FileUtilities.EnsureTrailingSlash(result));
 
-                result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::GetDirectoryNameOfFileAbove($(StartingDirectory), Hobbits))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+                result = expander.ExpandIntoStringAndUnescape(@"$([MSBuild]::GetDirectoryNameOfFileAbove($(StartingDirectory), Hobbits))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
                 Assert.Equal(String.Empty, result);
             }
@@ -2719,11 +2719,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
 
-                string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::GetPathOfFileAbove($(FileToFind)))", ExpanderOptions.ExpandProperties, mockElementLocation);
+                string result = expander.ExpandIntoStringAndUnescape(@"$([MSBuild]::GetPathOfFileAbove($(FileToFind)))", ExpanderOptions.ExpandProperties, mockElementLocation);
 
                 Assert.Equal(fileToFind, result);
 
-                result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::GetPathOfFileAbove('Hobbits'))", ExpanderOptions.ExpandProperties, mockElementLocation);
+                result = expander.ExpandIntoStringAndUnescape(@"$([MSBuild]::GetPathOfFileAbove('Hobbits'))", ExpanderOptions.ExpandProperties, mockElementLocation);
 
                 Assert.Equal(String.Empty, result);
             }
@@ -2906,11 +2906,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             Assert.Equal(
                 $"{Path.GetFullPath("one")}{Path.DirectorySeparatorChar}",
-                expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::NormalizeDirectory($(MyPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
+                expander.ExpandIntoStringAndUnescape(@"$([MSBuild]::NormalizeDirectory($(MyPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
 
             Assert.Equal(
                 $"{Path.GetFullPath(Path.Combine("one", "two"))}{Path.DirectorySeparatorChar}",
-                expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::NormalizeDirectory($(MyPath), $(MySecondPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
+                expander.ExpandIntoStringAndUnescape(@"$([MSBuild]::NormalizeDirectory($(MyPath), $(MySecondPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
         }
 
         /// <summary>


### PR DESCRIPTION
Tests were failing on one of our CI environments because they were
built from a path containing a `@` character. As long as there were no
special characters in the paths used for the tests, the tests weren't
sensitive to whether the expected values were escaped properly.

Tested with

```
TMPDIR=/Users/raines/src/msbuild/tmp@ ./cibuild.sh --scope Tested
```