### PR TITLE
Look for MSBuild.rsp in project folder and any parent folder

### DIFF
--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -282,37 +282,11 @@ namespace Microsoft.Build.Evaluation
 
         /// <summary>
         /// Locate a file in either the directory specified or a location in the
-        /// direcorty structure above that directory.
+        /// directory structure above that directory.
         /// </summary>
         internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName)
         {
-            // Canonicalize our starting location
-            string lookInDirectory = Path.GetFullPath(startingDirectory);
-
-            do
-            {
-                // Construct the path that we will use to test against
-                string possibleFileDirectory = Path.Combine(lookInDirectory, fileName);
-
-                // If we successfully locate the file in the directory that we're
-                // looking in, simply return that location. Otherwise we'll
-                // keep moving up the tree.
-                if (File.Exists(possibleFileDirectory))
-                {
-                    // We've found the file, return the directory we found it in
-                    return lookInDirectory;
-                }
-                else
-                {
-                    // GetDirectoryName will return null when we reach the root
-                    // terminating our search
-                    lookInDirectory = Path.GetDirectoryName(lookInDirectory);
-                }
-            }
-            while (lookInDirectory != null);
-
-            // When we didn't find the location, then return an empty string
-            return String.Empty;
+            return FileUtilities.GetDirectoryNameOfFileAbove(startingDirectory, fileName);
         }
 
         /// <summary>
@@ -320,20 +294,11 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="file">The file to search for.</param>
         /// <param name="startingDirectory">An optional directory to start the search in.  The default location is the directory
-        /// of the file containing the property funciton.</param>
+        /// of the file containing the property function.</param>
         /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
         internal static string GetPathOfFileAbove(string file, string startingDirectory)
         {
-            // This method does not accept a path, only a file name
-            if(file.Any(i => i.Equals(Path.DirectorySeparatorChar) || i.Equals(Path.AltDirectorySeparatorChar)))
-            {
-                ErrorUtilities.ThrowArgument("InvalidGetPathOfFileAboveParameter", file);
-            }
-
-            // Search for a directory that contains that file
-            string directoryName = GetDirectoryNameOfFileAbove(startingDirectory, file);
-
-            return String.IsNullOrWhiteSpace(directoryName) ? String.Empty : NormalizePath(directoryName, file);
+            return FileUtilities.GetPathOfFileAbove(file, startingDirectory);
         }
 
         /// <summary>
@@ -425,7 +390,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>A canonicalized full path with the correct directory separators.</returns>
         internal static string NormalizePath(params string[] path)
         {
-            return FileUtilities.NormalizePath(Path.Combine(path));
+            return FileUtilities.NormalizePath(path);
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1773,11 +1773,11 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private static bool GatherAutoResponseFileSwitches(string path, CommandLineSwitches switchesFromAutoResponseFile)
         {
-            string autoResponseFile = Path.Combine(path, autoResponseFileName);
+            string autoResponseFile = FileUtilities.GetPathOfFileAbove(autoResponseFileName, path);
             bool found = false;
 
             // if the auto-response file does not exist, only use the switches on the command line
-            if (File.Exists(autoResponseFile))
+            if (!String.IsNullOrWhiteSpace(autoResponseFile) && File.Exists(autoResponseFile))
             {
                 found = true;
                 GatherResponseFileSwitch("@" + autoResponseFile, switchesFromAutoResponseFile);

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Build.UnitTests
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                Assert.Equal(null, FileUtilities.NormalizePath(null));
+                Assert.Equal(null, FileUtilities.NormalizePath(null, null));
             }
            );
         }


### PR DESCRIPTION
Move around GetDirectoryNameOfFileAbove so I could re-use its functionality

Unit tests to follow if we like this change