### PR TITLE
Opt into new .NET Framework path handling

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -9,6 +9,7 @@
     <runtime>
       <DisableFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
+      <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -7,6 +7,7 @@
       <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
     <runtime>
+      <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
       <DisableFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/Shared/UnitTests/App.config
+++ b/src/Shared/UnitTests/App.config
@@ -9,6 +9,7 @@
   <runtime>
     <DisableFXClosureWalk enabled="true" />
     <generatePublisherEvidence enabled="false" />
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />


### PR DESCRIPTION
Fixes #2338 by opting out of .NET 4.6.2+'s backward-compatible
LegacyPathHandling. See
https://blogs.msdn.microsoft.com/jeremykuhne/2016/06/21/more-on-new-net-path-handling/
for details.