### PR TITLE
Reduce allocations in ExpandExpressionCaptureIntoStringBuilder

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1958,8 +1958,16 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 // if the capture.Separator is not null, then ExpandExpressionCapture would have joined the items using that separator itself
-                builder.Append(string.Join(";", itemsFromCapture.Select(i => i.Item1)));
+                foreach (var item in itemsFromCapture)
+                {
+                    builder.Append(item.Item1);
+                    builder.Append(';');
+                }
 
+                // Remove trailing separator
+                if (builder.Length > 0)
+                    builder.Length--;
+                
                 return false;
             }
 

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1964,8 +1964,8 @@ namespace Microsoft.Build.Evaluation
                     builder.Append(';');
                 }
 
-                // Remove trailing separator
-                if (builder.Length > 0)
+                // Remove trailing separator if we added one
+                if (itemsFromCapture.Count > 0)
                     builder.Length--;
                 
                 return false;

--- a/src/Shared/ReuseableStringBuilder.cs
+++ b/src/Shared/ReuseableStringBuilder.cs
@@ -51,6 +51,11 @@ namespace Microsoft.Build.Shared
         public int Length
         {
             get { return ((_borrowedBuilder == null) ? 0 : _borrowedBuilder.Length); }
+            set
+            {
+                LazyPrepare();
+                _borrowedBuilder.Length = value;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This reduces allocations by 3% by avoiding the Join by slightly increasing allocations in Append.

Before:
![image](https://user-images.githubusercontent.com/1103906/29350695-e9980006-82a2-11e7-8d84-3e2e298596e7.png)

After:
![image](https://user-images.githubusercontent.com/1103906/29350710-f455e7d8-82a2-11e7-83a8-692f25749c7d.png)

Scenario is attempting to mimic a solution wide design-time build from here: https://github.com/dotnet/project-system/issues/2712.
