### PR TITLE
Remove enumerator boxing

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -433,7 +433,7 @@ namespace Microsoft.Build.Evaluation
             ExpanderOptions options,
             bool includeNullEntries,
             out bool isTransformExpression,
-            out IList<Tuple<string, I>> itemsFromCapture)
+            out List<Tuple<string, I>> itemsFromCapture)
         {
             return ItemExpander.ExpandExpressionCapture(this, expressionCapture, _items, elementLocation, options, includeNullEntries, out isTransformExpression, out itemsFromCapture);
         }
@@ -1697,7 +1697,7 @@ namespace Microsoft.Build.Evaluation
                     return result;
                 }
 
-                IList<Tuple<string, S>> itemsFromCapture;
+                List<Tuple<string, S>> itemsFromCapture;
                 brokeEarlyNonEmpty = ExpandExpressionCapture(expander, expressionCapture, items, elementLocation /* including null items */, options, true, out isTransformExpression, out itemsFromCapture);
 
                 if (brokeEarlyNonEmpty)
@@ -1763,7 +1763,7 @@ namespace Microsoft.Build.Evaluation
                 ExpanderOptions options,
                 bool includeNullEntries,
                 out bool isTransformExpression,
-                out IList<Tuple<string, S>> itemsFromCapture
+                out List<Tuple<string, S>> itemsFromCapture
                 )
                 where S : class, IItem
             {
@@ -1948,7 +1948,7 @@ namespace Microsoft.Build.Evaluation
                 )
                 where S : class, IItem
             {
-                IList<Tuple<string, S>> itemsFromCapture;
+                List<Tuple<string, S>> itemsFromCapture;
                 bool throwaway;
                 var brokeEarlyNonEmpty = ExpandExpressionCapture(expander, capture, evaluatedItems, elementLocation /* including null items */, options, true, out throwaway, out itemsFromCapture);
 

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -386,7 +386,7 @@ namespace Microsoft.Build.Evaluation
             {
                 _expander = _containingItemSpec.Expander;
 
-                IList<Tuple<string, I>> itemsFromCapture;
+                List<Tuple<string, I>> itemsFromCapture;
                 bool throwaway;
                 _expander.ExpandExpressionCapture(
                     Capture,


### PR DESCRIPTION
This removes ~0.2% of enumerator boxing after https://github.com/Microsoft/msbuild/pull/2437 has been merged:

![image](https://user-images.githubusercontent.com/1103906/29351189-10e75f10-82a5-11e7-8bb1-14b5d648d874.png)

![image](https://user-images.githubusercontent.com/1103906/29351247-58bdbd7a-82a5-11e7-81db-e1d62e8f53ce.png)


