### PR TITLE
Fix resource string for MSB3493

### DIFF
--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2093,8 +2093,8 @@
     <comment>{StrBegin="MSB3491: "}</comment>
   </data>
   <data name="WriteLinesToFile.SkippingUnchangedFile">
-    <value>MSB3493: </value>
-    <comment>{StrBegin="Skipping write to file "{0}" because content would not change."}</comment>
+    <value>MSB3493: Skipping write to file "{0}" because content would not change.</value>
+    <comment>{StrBegin="MSB3493: "}</comment>
   </data>
   <!--
         The GetReferenceAssemblyPaths message bucket is: MSB3642 - MSB3646.


### PR DESCRIPTION
Before:

```
Using "WriteLinesToFile" task from assembly "Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
Task "WriteLinesToFile"
  MSB3493:
```

After:

```
Using "WriteLinesToFile" task from assembly "Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
Task "WriteLinesToFile"
  MSB3493: Skipping write to file "Bar" because content would not change.
```