### PR TITLE
TaskItemSpecFilenameComparer cleanup

### DIFF
--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -2518,7 +2518,7 @@ namespace Microsoft.Build.Tasks
             scatterFiles = (ITaskItem[])scatterItems.ToArray(typeof(ITaskItem));
 
             // Sort for stable outputs. (These came from a hashtable, which as undefined enumeration order.)
-            Array.Sort(primaryFiles, TaskItemSpecFilenameComparer.comparer);
+            Array.Sort(primaryFiles, TaskItemSpecFilenameComparer.Comparer);
 
             // Find the copy-local items.
             FindCopyLocalItems(primaryFiles, copyLocalItems);

--- a/src/Tasks/AssemblyDependency/TaskItemSpecFilenameComparer.cs
+++ b/src/Tasks/AssemblyDependency/TaskItemSpecFilenameComparer.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Collections;
-using Microsoft.Build.Framework;
 using System.Collections.Generic;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Tasks
@@ -13,10 +12,10 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Compare two ITaskItems by the file name in their ItemSpec.
     /// </summary>
-    sealed internal class TaskItemSpecFilenameComparer : IComparer, IComparer<ITaskItem>
+    internal sealed class TaskItemSpecFilenameComparer : IComparer, IComparer<ITaskItem>
     {
-        internal readonly static IComparer comparer = new TaskItemSpecFilenameComparer();
-        internal readonly static IComparer<ITaskItem> genericComparer = new TaskItemSpecFilenameComparer();
+        internal static readonly IComparer Comparer = new TaskItemSpecFilenameComparer();
+        internal static readonly IComparer<ITaskItem> GenericComparer = new TaskItemSpecFilenameComparer();
 
         /// <summary>
         /// Private construct so there's only one instance.
@@ -35,7 +34,7 @@ namespace Microsoft.Build.Tasks
         /// </remarks>
         public int Compare(object o1, object o2)
         {
-            if (Object.ReferenceEquals(o1, o2))
+            if (ReferenceEquals(o1, o2))
             {
                 return 0;
             }
@@ -48,7 +47,7 @@ namespace Microsoft.Build.Tasks
 
         public int Compare(ITaskItem x, ITaskItem y)
         {
-            if (Object.ReferenceEquals(x, y))
+            if (ReferenceEquals(x, y))
             {
                 return 0;
             }
@@ -68,7 +67,7 @@ namespace Microsoft.Build.Tasks
                 yFilenameStart = 0;
             }
 
-            int fileComparison = String.Compare(xItemSpec,
+            int fileComparison = string.Compare(xItemSpec,
                 xFilenameStart,
                 yItemSpec,
                 yFilenameStart,
@@ -79,7 +78,7 @@ namespace Microsoft.Build.Tasks
                 return fileComparison;
             }
 
-            return String.Compare(xItemSpec, yItemSpec, StringComparison.OrdinalIgnoreCase);
+            return string.Compare(xItemSpec, yItemSpec, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Tasks/AssemblyDependency/TaskItemSpecFilenameComparer.cs
+++ b/src/Tasks/AssemblyDependency/TaskItemSpecFilenameComparer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Collections;
 using Microsoft.Build.Framework;
 using System.Collections.Generic;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Tasks
 {
@@ -52,16 +53,33 @@ namespace Microsoft.Build.Tasks
                 return 0;
             }
 
-            string f1 = Path.GetFileName(x.ItemSpec);
-            string f2 = Path.GetFileName(y.ItemSpec);
+            string xItemSpec = x.ItemSpec;
+            string yItemSpec = y.ItemSpec;
 
-            int fileComparison = String.Compare(f1, f2, StringComparison.OrdinalIgnoreCase);
+            int xFilenameStart = xItemSpec.LastIndexOfAny(FileMatcher.directorySeparatorCharacters);
+            if (xFilenameStart == -1)
+            {
+                xFilenameStart = 0;
+            }
+
+            int yFilenameStart = yItemSpec.LastIndexOfAny(FileMatcher.directorySeparatorCharacters);
+            if (yFilenameStart == -1)
+            {
+                yFilenameStart = 0;
+            }
+
+            int fileComparison = String.Compare(xItemSpec,
+                xFilenameStart,
+                yItemSpec,
+                yFilenameStart,
+                int.MaxValue, // all characters after the start index
+                StringComparison.OrdinalIgnoreCase);
             if (fileComparison != 0)
             {
                 return fileComparison;
             }
 
-            return String.Compare(x.ItemSpec, y.ItemSpec, StringComparison.OrdinalIgnoreCase);
+            return String.Compare(xItemSpec, yItemSpec, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -616,8 +616,8 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            resolvedReferenceAssemblies.Sort(TaskItemSpecFilenameComparer.genericComparer);
-            copyLocalReferenceAssemblies.Sort(TaskItemSpecFilenameComparer.genericComparer);
+            resolvedReferenceAssemblies.Sort(TaskItemSpecFilenameComparer.GenericComparer);
+            copyLocalReferenceAssemblies.Sort(TaskItemSpecFilenameComparer.GenericComparer);
 
             _references = resolvedReferenceAssemblies.ToArray();
             _copyLocalFiles = copyLocalReferenceAssemblies.ToArray();
@@ -647,7 +647,7 @@ namespace Microsoft.Build.Tasks
                 redistReferenceItems.Add(outputItem);
             }
 
-            redistReferenceItems.Sort(TaskItemSpecFilenameComparer.genericComparer);
+            redistReferenceItems.Sort(TaskItemSpecFilenameComparer.GenericComparer);
             _redistFiles = redistReferenceItems.ToArray();
         }
 


### PR DESCRIPTION
Avoid allocating strings for filenames, when we can take a slice of the `ItemSpec` instead.

Also some general style cleanup.