### PR TITLE
Avoid allocating char[] in GetEnvironmentVariables

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -310,7 +310,6 @@
     <!-- System.Resources.ResourceManager.GetResourceSet() method is currently only in full framework -->
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCEMANAGER_GETRESOURCESET</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESX_RESOURCE_READER</DefineConstants>
-    <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_RTLMOVEMEMORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUN_EXE_IN_TESTS</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' == 'true'">$(DefineConstants);USE_MSBUILD_DLL_EXTN</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_SECURITY_PERMISSIONS</DefineConstants>

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -184,6 +184,7 @@ namespace Microsoft.Build.Internal
                     {
                         pStringBlockEnd++;
                     }
+                    long stringBlockLength = pStringBlockEnd - pStringBlock;
 
                     // Copy strings out, parsing into pairs and inserting into the table.
                     // The first few environment variable entries start with an '='!
@@ -198,7 +199,7 @@ namespace Microsoft.Build.Internal
                     // See the description of Environment Blocks in MSDN's
                     // CreateProcess page (null-terminated array of null-terminated strings).
                     // Note the =HiddenVar's aren't always at the beginning.
-                    for (int i = 0; i < pStringBlockEnd - pStringBlock; i++)
+                    for (int i = 0; i < stringBlockLength; i++)
                     {
                         int startKey = i;
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -168,23 +168,23 @@ namespace Microsoft.Build.Internal
 #if FEATURE_RTLMOVEMEMORY
             unsafe
             {
-                char* pStringBlock = null;
+                char* pEnvironmentBlock = null;
 
                 try
                 {
-                    pStringBlock = GetEnvironmentStrings();
-                    if (pStringBlock == null)
+                    pEnvironmentBlock = GetEnvironmentStrings();
+                    if (pEnvironmentBlock == null)
                     {
                         throw new OutOfMemoryException();
                     }
 
                     // Search for terminating \0\0 (two unicode \0's).
-                    char* pStringBlockEnd = pStringBlock;
-                    while (!(*pStringBlockEnd == '\0' && *(pStringBlockEnd + 1) == '\0'))
+                    char* pEnvironmentBlockEnd = pEnvironmentBlock;
+                    while (!(*pEnvironmentBlockEnd == '\0' && *(pEnvironmentBlockEnd + 1) == '\0'))
                     {
-                        pStringBlockEnd++;
+                        pEnvironmentBlockEnd++;
                     }
-                    long stringBlockLength = pStringBlockEnd - pStringBlock;
+                    long stringBlockLength = pEnvironmentBlockEnd - pEnvironmentBlock;
 
                     // Copy strings out, parsing into pairs and inserting into the table.
                     // The first few environment variable entries start with an '='!
@@ -206,12 +206,12 @@ namespace Microsoft.Build.Internal
                         // Skip to key
                         // On some old OS, the environment block can be corrupted. 
                         // Some lines will not have '=', so we need to check for '\0'. 
-                        while (*(pStringBlock + i) != '=' && *(pStringBlock + i) != '\0')
+                        while (*(pEnvironmentBlock + i) != '=' && *(pEnvironmentBlock + i) != '\0')
                         {
                             i++;
                         }
 
-                        if (*(pStringBlock + i) == '\0')
+                        if (*(pEnvironmentBlock + i) == '\0')
                         {
                             continue;
                         }
@@ -219,7 +219,7 @@ namespace Microsoft.Build.Internal
                         // Skip over environment variables starting with '='
                         if (i - startKey == 0)
                         {
-                            while (*(pStringBlock + i) != 0)
+                            while (*(pEnvironmentBlock + i) != 0)
                             {
                                 i++;
                             }
@@ -227,19 +227,19 @@ namespace Microsoft.Build.Internal
                             continue;
                         }
 
-                        string key = new string(pStringBlock, startKey, i - startKey);
+                        string key = new string(pEnvironmentBlock, startKey, i - startKey);
                         i++;
 
                         // skip over '='
                         int startValue = i;
 
-                        while (*(pStringBlock + i) != 0)
+                        while (*(pEnvironmentBlock + i) != 0)
                         {
                             // Read to end of this entry
                             i++;
                         }
 
-                        string value = new string(pStringBlock, startValue, i - startValue);
+                        string value = new string(pEnvironmentBlock, startValue, i - startValue);
 
                         // skip over 0 handled by for loop's i++
                         table[key] = value;
@@ -247,9 +247,9 @@ namespace Microsoft.Build.Internal
                 }
                 finally
                 {
-                    if (pStringBlock != null)
+                    if (pEnvironmentBlock != null)
                     {
-                        FreeEnvironmentStrings(pStringBlock);
+                        FreeEnvironmentStrings(pEnvironmentBlock);
                     }
                 }
             }

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -147,15 +147,6 @@ namespace Microsoft.Build.Internal
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static unsafe extern bool FreeEnvironmentStrings(char* pStrings);
 
-#if FEATURE_RTLMOVEMEMORY
-        /// <summary>
-        /// Move a block of chars
-        /// </summary>
-        [DllImport("kernel32.dll", EntryPoint = "RtlMoveMemory")]
-        internal static unsafe extern void CopyMemory(char* destination, char* source, uint length);
-
-#endif
-
         /// <summary>
         /// Copied from the BCL implementation to eliminate some expensive security asserts.
         /// Returns key value pairs of environment variables in a new dictionary


### PR DESCRIPTION
Fixes #2402 by walking the OS environment block return via pointer math,
rather than first copying it to a `char[]` and walking that with safe
code.