### PR TITLE
Single-quote Exec command line on *nix

### DIFF
--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -606,10 +606,10 @@ namespace Microsoft.Build.Tasks
             if (NativeMethodsShared.IsUnixLike)
             {
                 commandLine.AppendSwitch("-c");
-                commandLine.AppendTextUnquoted(" \"\"\"");
+                commandLine.AppendTextUnquoted(" \"");
                 commandLine.AppendTextUnquoted("export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; . ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
-                commandLine.AppendTextUnquoted("\"\"\"");
+                commandLine.AppendTextUnquoted("\"");
             }
             else
             {

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -537,8 +537,8 @@ namespace Microsoft.Build.UnitTests
                 // The command we're giving is the command to spew the contents of the temp
                 // file we created above.
                 t.MockCommandLineCommands = NativeMethodsShared.IsWindows
-                                                ? ("/C type \"" + tempFile + "\"")
-                                                : (@"-c """"""cat '" + tempFile + @"'""""""");
+                                                ? $"/C type \"{tempFile}\""
+                                                : $"-c \"cat \'{tempFile}\'\"";
 
                 t.Execute();
 


### PR DESCRIPTION
Triple-quotes seem to have been expanded as 
`{empty quoted string}{single-quoted string}{empty quoted string}`
rather than special
escaping. That confused an updated version of System.Diagnostic.Process,
so simplifying the quoting.

See https://github.com/dotnet/corefx/issues/23496#issuecomment-324519381 for context.