### PR TITLE
Identify inner build in consuming project

### DIFF
--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -1,4 +1,4 @@
-﻿# The `ProjectReference` Protocol
+# The `ProjectReference` Protocol
 
 The MSBuild engine doesn't have a notion of a “project reference”—it only provides the [`MSBuild` task](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-task) to allow cross-project communication.
 
@@ -47,16 +47,19 @@ These targets are all defined in `Microsoft.Common.targets` and are defined in M
 
 If implementing a project with an “outer” (determine what properties to pass to the real build) and “inner” (fully specified) build, only `GetTargetFrameworkProperties` is required in the “outer” build. The other targets listed can be “inner” build only.
 
-* `GetTargetFrameworkProperties` determines what properties should be passed to the “main” target.
+* `GetTargetFrameworkProperties` determines what properties should be passed to the “main” target for a given `ReferringTargetFramework`.
   * **New** for MSBuild 15/Visual Studio 2017. Supports the cross-targeting feature allowing a project to have multiple `TargetFrameworks`.
   * **Conditions**: only when metadata `SkipGetTargetFrameworkProperties` for each reference is not true.
   * Skipped for `*.vcxproj` by default.
-* `GetTargetPath` should the path of the project's output, but _not_ build that output.
+  * This should return a string of the form `TargetFramework=$(NearestTargetFramework);ProjectHasSingleTargetFramework=$(_HasSingleTargetFramework);ProjectIsRidAgnostic=$(_IsRidAgnostic)`, where the value of `NearestTargetFramework` will be used to formulate `TargetFramework` for the following calls and the other two properties are booleans.
+* `GetTargetPath` should return the path of the project's output, but _not_ build that output.
   * **Conditions**: this is used for builds inside Visual Studio, but not on the command line.
   * It's also used when the property `BuildProjectReferences` is `false`, manually indicating that all `ProjectReferences` are up to date and shouldn't be (re)built.
+  * This should return a single item that is the primary output of the project, with metadata describing that output. See [`TargetPathWithTargetPlatformMoniker`](https://github.com/Microsoft/msbuild/blob/080ef976a428f6ff7bf53ca5dd4ee637b3fe949c/src/Tasks/Microsoft.Common.CurrentVersion.targets#L1834-L1842) for the default metadata.
 * **Default** targets should do the full build and return an assembly to be referenced.
   * **Conditions**: this is _not_ called when building inside Visual Studio. Instead, Visual Studio builds each project in isolation but in order, so the path returned from `GetTargetPath` can be assumed to exist at consumption time.
   * If the `ProjectReference` defines the `Targets` metadata, it is used. If not, no target is passed, and the default target of the reference (usually `Build`) is built.
+  * The return value of this target should be identical to that of `GetTargetPath`.
 * `GetNativeManifest` should return a manifest suitable for passing to the `ResolveNativeReferences` target.
 * `GetCopyToOutputDirectoryItems` should return the outputs of a project that should be copied to the output of a referencing project.
 * `Clean` should delete all outputs of the project.

--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -51,7 +51,9 @@ If implementing a project with an “outer” (determine what properties to pass
   * **New** for MSBuild 15/Visual Studio 2017. Supports the cross-targeting feature allowing a project to have multiple `TargetFrameworks`.
   * **Conditions**: only when metadata `SkipGetTargetFrameworkProperties` for each reference is not true.
   * Skipped for `*.vcxproj` by default.
-  * This should return a string of the form `TargetFramework=$(NearestTargetFramework);ProjectHasSingleTargetFramework=$(_HasSingleTargetFramework);ProjectIsRidAgnostic=$(_IsRidAgnostic)`, where the value of `NearestTargetFramework` will be used to formulate `TargetFramework` for the following calls and the other two properties are booleans.
+  * This should return either
+    * a string of the form `TargetFramework=$(NearestTargetFramework);ProjectHasSingleTargetFramework=$(_HasSingleTargetFramework);ProjectIsRidAgnostic=$(_IsRidAgnostic)`, where the value of `NearestTargetFramework` will be used to formulate `TargetFramework` for the following calls and the other two properties are booleans, or
+    * an item with metadata `DesiredTargetFrameworkProperties` (key-value pairs of the form `TargetFramework=net46`), `HasSingleTargetFramework` (boolean), and `IsRidAgnostic` (boolean).
 * `GetTargetPath` should return the path of the project's output, but _not_ build that output.
   * **Conditions**: this is used for builds inside Visual Studio, but not on the command line.
   * It's also used when the property `BuildProjectReferences` is `false`, manually indicating that all `ProjectReferences` are up to date and shouldn't be (re)built.

--- a/documentation/ProjectReference-Protocol.md
+++ b/documentation/ProjectReference-Protocol.md
@@ -31,7 +31,9 @@ There are empty hooks in the default targets for
 
 `AssignProjectConfiguration` runs when building in a solution context, and ensures that the right `Configuration` and `Platform` are assigned to each reference. For example, if a solution specifies (using the Solution Build Manager) that for a given solution configuration, a project should always be built `Release`, that is applied inside MSBuild in this target.
 
-`PrepareProjectReferences` then runs, ensuring that each referenced project exists (creating the item `@(_MSBuildProjectReferenceExistent)`) and determining the parameters it needs to produce a compatible build by calling its `GetTargetFrameworkProperties` target.
+`PrepareProjectReferences` then runs, ensuring that each referenced project exists (creating the item `@(_MSBuildProjectReferenceExistent)`).
+
+`_ComputeProjectReferenceTargetFrameworkMatches` calls `GetTargetFrameworks` in existent ProjectReferences and determines the parameters needed to produce a compatible build by calling the `AssignReferenceProperties` task for each reference that multitargets.
 
 `ResolveProjectReferences` does the bulk of the work, building the referenced projects and collecting their outputs.
 
@@ -47,8 +49,12 @@ These targets are all defined in `Microsoft.Common.targets` and are defined in M
 
 If implementing a project with an “outer” (determine what properties to pass to the real build) and “inner” (fully specified) build, only `GetTargetFrameworkProperties` is required in the “outer” build. The other targets listed can be “inner” build only.
 
+* `GetTargetFrameworks` tells referencing projects what options are available to the build.
+  * It returns an item with metadata `TargetFrameworks` indicating what TargetFrameworks are available in the project, as well as boolean metadata `HasSingleTargetFramework` and `IsRidAgnostic`.
+  * **New** in MSBuild 15.5.
 * `GetTargetFrameworkProperties` determines what properties should be passed to the “main” target for a given `ReferringTargetFramework`.
-  * **New** for MSBuild 15/Visual Studio 2017. Supports the cross-targeting feature allowing a project to have multiple `TargetFrameworks`.
+  * **Deprecated** in MSBuild 15.5.
+  * New for MSBuild 15/Visual Studio 2017. Supports the cross-targeting feature allowing a project to have multiple `TargetFrameworks`.
   * **Conditions**: only when metadata `SkipGetTargetFrameworkProperties` for each reference is not true.
   * Skipped for `*.vcxproj` by default.
   * This should return either

--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -114,6 +114,16 @@ namespace Microsoft.Build.Tasks
         public string VcxToDefaultPlatformMapping { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public partial class AssignReferenceProperties : Microsoft.Build.Tasks.TaskExtension
+    {
+        public AssignReferenceProperties() { }
+        public Microsoft.Build.Framework.ITaskItem[] AnnotatedProjectReferences { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] AssignedProjects { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string CurrentProjectTargetFramework { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
     public partial class AssignTargetPath : Microsoft.Build.Tasks.TaskExtension
     {
         public AssignTargetPath() { }

--- a/src/Tasks/AssignReferenceProperties.cs
+++ b/src/Tasks/AssignReferenceProperties.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
+
+namespace Microsoft.Build.Tasks
+{
+    public class AssignReferenceProperties : TaskExtension
+    {
+        private static readonly char[] TargetFrameworkSeparator = {';'};
+
+        public ITaskItem[] AnnotatedProjectReferences { get; set; }
+
+        [Required]
+        public string CurrentProjectTargetFramework { get; set; }
+
+        [Output]
+        public ITaskItem[] AssignedProjects { get; set; }
+
+        public override bool Execute()
+        {
+            if (AnnotatedProjectReferences == null)
+            {
+                return !Log.HasLoggedErrors;
+            }
+
+            var assignedProjects = new List<ITaskItem>(AnnotatedProjectReferences.Length);
+
+            NuGetFramework frameworkToMatch = NuGetFramework.Parse(CurrentProjectTargetFramework);
+
+            if (frameworkToMatch.IsUnsupported)
+            {
+                // TODO Log.LogErrorFromResources();
+                return false;
+            }
+
+
+            foreach (var project in AnnotatedProjectReferences)
+            {
+                assignedProjects.Add(AssignPropertiesForSingleReference(project, frameworkToMatch));
+            }
+
+            AssignedProjects = assignedProjects.ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private ITaskItem AssignPropertiesForSingleReference(ITaskItem project, NuGetFramework currentProjectTargetFramework)
+        {
+            var itemWithProperties = new TaskItem(project);
+
+            var possibleTargetFrameworks = project.GetMetadata("TargetFrameworks").Split(TargetFrameworkSeparator);
+
+            var possibleNuGetFrameworks = possibleTargetFrameworks.Select(ParseFramework).ToList();
+
+            var nearestNuGetFramework = new FrameworkReducer().GetNearest(currentProjectTargetFramework, possibleNuGetFrameworks);
+
+            if (nearestNuGetFramework != null)
+            {
+                // Note that there can be more than one spelling of the same target framework (e.g. net45 and net4.5) and 
+                // we must return a value that is spelled exactly the same way as the input. To 
+                // achieve this, we find the index of the returned framework among the set we passed to nuget and use that
+                // to retrive a value at the same position in the input.
+                //
+                // This is required to guarantee that a project can use whatever spelling appears in $(TargetFrameworks)
+                // in a condition that compares against $(TargetFramework).
+                //Log.LogError(Strings.NoCompatibleTargetFramework, ProjectFilePath, ReferringTargetFramework, string.Join("; ", possibleNuGetFrameworks));
+                int indexOfNearestFramework = possibleNuGetFrameworks.IndexOf(nearestNuGetFramework);
+                string nearestTargetFramework = possibleTargetFrameworks[indexOfNearestFramework];
+
+                if (MetadataConversionUtilities.TryConvertItemMetadataToBool(project, "HasSingleTargetFramework",
+                        out bool singleTargetFramework) && singleTargetFramework)
+                {
+                    itemWithProperties.SetMetadata("UndefineProperties", "TargetFramework"); // TODO: append
+                }
+                else
+                {
+                    // TODO: append or overwrite?
+                    itemWithProperties.SetMetadata("SetTargetFramework", $"TargetFramework={nearestTargetFramework}");
+                }
+
+                // TODO: RID stuff
+
+                itemWithProperties.SetMetadata("SkipGetTargetFrameworkProperties", "true");
+
+            }
+
+            return itemWithProperties;
+        }
+
+        private NuGetFramework ParseFramework(string name)
+        {
+            var framework = NuGetFramework.Parse(name);
+
+            if (framework == null)
+            {
+                //Log.LogError(Strings.InvalidFrameworkName, framework);
+            }
+
+            return framework;
+        }
+
+    }
+}

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -93,6 +93,7 @@
       <Link>Constants.cs</Link>
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssignReferenceProperties.cs" />
     <Compile Include="ConvertToAbsolutePath.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -557,7 +558,7 @@
     <Compile Include="AxTlbBaseTask.cs" />
     <Compile Include="BootstrapperUtil\*.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>    
+    </Compile>
     <Compile Include="ComDependencyWalker.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -20,6 +20,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(CustomBeforeMicrosoftCommonCrossTargetingTargets)" Condition="'$(CustomBeforeMicrosoftCommonCrossTargetingTargets)' != '' and Exists('$(CustomBeforeMicrosoftCommonCrossTargetingTargets)')"/>
 
+  <Target Name="GetTargetFrameworks"
+          Returns="@(_ThisProjectBuildMetadata)">
+    <ItemGroup>
+      <_ThisProjectBuildMetadata Include="$(MSBuildProjectFullPath)">
+        <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$(TargetFrameworks)</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(TargetFramework)</TargetFrameworks>
+        <HasSingleTargetFramework>true</HasSingleTargetFramework>
+        <HasSingleTargetFramework Condition="'$(IsCrossTargetingBuild)' == 'true'">false</HasSingleTargetFramework>
+        <IsRidAgnostic>true</IsRidAgnostic><!-- TODO -->
+      </_ThisProjectBuildMetadata>
+    </ItemGroup>
+  </Target>
+
   <Target Name="_ComputeTargetFrameworkItems" Returns="@(InnerOutput)">
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1522,8 +1522,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     ======================================================================================
   -->
-  <Target Name="_GetProjectReferenceTargetFrameworkProperties"
-          Outputs="%(_MSBuildProjectReferenceExistent.Identity)">
+  <Target Name="_GetProjectReferenceTargetFrameworkProperties">
     <!--
       Honor SkipGetTargetFrameworkProperties=true metadata on project references
       to mean that the project reference is known not to target multiple frameworks
@@ -1567,7 +1566,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </PropertyGroup>
 
     <MSBuild
-        Projects="%(_MSBuildProjectReferenceExistent.Identity)"
+        Projects="@(_MSBuildProjectReferenceExistent)"
         Targets="GetTargetFrameworkProperties"
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); ReferringTargetFramework=$(ReferringTargetFrameworkForProjectReferences)"
@@ -1575,30 +1574,32 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
         Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
 
-      <Output TaskParameter="TargetOutputs" PropertyName="_ProjectReferenceTargetFrameworkProperties" />
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkProperties" />
     </MSBuild>
 
     <ItemGroup>
-      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.Identity)' == '%(Identity)' and '$(_ProjectReferenceTargetFrameworkProperties)' != ''">
-        <SetTargetFramework>$(_ProjectReferenceTargetFrameworkProperties)</SetTargetFramework>
+      <!-- Build an item that has Identity matching _MSBuildProjectReferenceExistent and metadata for properties to set. -->
+      <_ProjectReferencesWithTargetFrameworkProperties Include="@(_ProjectReferenceTargetFrameworkProperties->'%(OriginalItemSpec)')">
+        <!--<DesiredTargetFrameworkProperties>$([System.String]::Copy('%(Identity)').Replace('ProjectHasSingleTargetFramework=true','').Replace('ProjectIsRidAgnostic=true','').TrimEnd(';'))</DesiredTargetFrameworkProperties>
+        <HasSingleTargetFramework>$([System.String]::Copy('%(Identity)').Contains('ProjectHasSingleTargetFramework=true'))</HasSingleTargetFramework>
+        <IsRidAgnostic>$([System.String]::Copy('%(Identity)').Contains('ProjectIsRidAgnostic=true'))</IsRidAgnostic>-->
+      </_ProjectReferencesWithTargetFrameworkProperties>
 
-        <UndefineProperties Condition="$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectHasSingleTargetFramework=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);TargetFramework;ProjectHasSingleTargetFramework</UndefineProperties>
-        <!-- Unconditionally remove the property that was set as a marker to indicate that for this call we should remove TargetFramework -->
-        <UndefineProperties Condition="!$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectHasSingleTargetFramework=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);ProjectHasSingleTargetFramework</UndefineProperties>
+      <!-- Set the project's returned TargetFramework -->
+      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' != 'true'">
+        <SetTargetFramework>@(_ProjectReferencesWithTargetFrameworkProperties->'%(DesiredTargetFrameworkProperties)')</SetTargetFramework>
+      </_MSBuildProjectReferenceExistent>
+
+      <!-- If the project has only one TF, don't specify it. It will go directly to the inner build anyway and we don't want to redundantly specify a global property, which can cause a race. -->
+      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' == 'true'">
+        <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');TargetFramework</UndefineProperties>
+      </_MSBuildProjectReferenceExistent>
+
+      <!-- If the project has only one RID, assume it's compatible with the current project and don't pass this one along. -->
+      <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(IsRidAgnostic)')' == 'true'">
+        <UndefineProperties>@(_MSBuildProjectReferenceExistent->'%(UndefineProperties)');RuntimeIdentifier</UndefineProperties>
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
-
-    <ItemGroup>
-      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.Identity)' == '%(Identity)' and '$(_ProjectReferenceTargetFrameworkProperties)' != ''">
-        <UndefineProperties Condition="$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectIsRidAgnostic=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);RuntimeIdentifier;ProjectIsRidAgnostic</UndefineProperties>
-        <!-- Unconditionally remove the property that was set as a marker to indicate that for this call we should remove RuntimeIdentifier -->
-        <UndefineProperties Condition="!$(_ProjectReferenceTargetFrameworkProperties.Contains(`ProjectIsRidAgnostic=true`))">%(_MSBuildProjectReferenceExistent.UndefineProperties);ProjectIsRidAgnostic</UndefineProperties>
-      </_MSBuildProjectReferenceExistent>
-    </ItemGroup>
-
-    <PropertyGroup>
-      <_ProjectReferenceTargetFrameworkProperties />
-    </PropertyGroup>
   </Target>
 
   <!--

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1578,12 +1578,26 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </MSBuild>
 
     <ItemGroup>
+      <!-- Backward compat: extract metadata for properties to set from a semicolon-delimited return value -->
+      <_ProjectReferenceTargetFrameworkProperties
+        Condition="'@(_ProjectReferenceTargetFrameworkProperties->Count())' > '1' and '%(_ProjectReferenceTargetFrameworkProperties.OriginalItemSpec)' != ''">
+        <DelimitedStringReturn>@(_ProjectReferenceTargetFrameworkProperties)</DelimitedStringReturn>
+      </_ProjectReferenceTargetFrameworkProperties>
+      <_ProjectReferenceTargetFrameworkProperties
+        Include="%(_ProjectReferenceTargetFrameworkProperties.OriginalItemSpec)"
+        Condition="'%(_ProjectReferenceTargetFrameworkProperties.DelimitedStringReturn)' != ''">
+        <OriginalItemSpec>%(_ProjectReferenceTargetFrameworkProperties.OriginalItemSpec)</OriginalItemSpec>
+        <DesiredTargetFrameworkProperties>$([System.String]::Copy('%(_ProjectReferenceTargetFrameworkProperties.DelimitedStringReturn)').Replace('ProjectHasSingleTargetFramework=true','').Replace('ProjectHasSingleTargetFramework=false','').Replace('ProjectIsRidAgnostic=true','').TrimEnd(';'))</DesiredTargetFrameworkProperties>
+        <HasSingleTargetFramework>$([System.String]::Copy('%(_ProjectReferenceTargetFrameworkProperties.DelimitedStringReturn)').Contains('ProjectHasSingleTargetFramework=true'))</HasSingleTargetFramework>
+        <IsRidAgnostic>$([System.String]::Copy('%(_ProjectReferenceTargetFrameworkProperties.DelimitedStringReturn)').Contains('ProjectIsRidAgnostic=true'))</IsRidAgnostic>
+      </_ProjectReferenceTargetFrameworkProperties>
+      <_ProjectReferenceTargetFrameworkProperties
+        Remove="@(_ProjectReferenceTargetFrameworkProperties)"
+        Condition="'%(_ProjectReferenceTargetFrameworkProperties.DelimitedStringReturn)' != ''" />
+
       <!-- Build an item that has Identity matching _MSBuildProjectReferenceExistent and metadata for properties to set. -->
-      <_ProjectReferencesWithTargetFrameworkProperties Include="@(_ProjectReferenceTargetFrameworkProperties->'%(OriginalItemSpec)')">
-        <!--<DesiredTargetFrameworkProperties>$([System.String]::Copy('%(Identity)').Replace('ProjectHasSingleTargetFramework=true','').Replace('ProjectIsRidAgnostic=true','').TrimEnd(';'))</DesiredTargetFrameworkProperties>
-        <HasSingleTargetFramework>$([System.String]::Copy('%(Identity)').Contains('ProjectHasSingleTargetFramework=true'))</HasSingleTargetFramework>
-        <IsRidAgnostic>$([System.String]::Copy('%(Identity)').Contains('ProjectIsRidAgnostic=true'))</IsRidAgnostic>-->
-      </_ProjectReferencesWithTargetFrameworkProperties>
+      <_ProjectReferencesWithTargetFrameworkProperties
+        Include="@(_ProjectReferenceTargetFrameworkProperties->'%(OriginalItemSpec)')" />
 
       <!-- Set the project's returned TargetFramework -->
       <_MSBuildProjectReferenceExistent Condition="'@(_ProjectReferencesWithTargetFrameworkProperties)' == '%(Identity)' and '@(_ProjectReferencesWithTargetFrameworkProperties->'%(HasSingleTargetFramework)')' != 'true'">

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1509,20 +1509,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
-  <!--
-    ====================================================================================
-                                        _GetProjectReferenceTargetFrameworkProperties
-
-    Builds the GetTargetFrameworkProperties target of all existent project references,
-    passing $(TargetFrameworkMoniker) as $(ReferringTargetFramework) and sets the
-    SetTargetFramework metadata of the project reference to the value that is returned.
-
-    This allows a cross-targeting project to select how it should be configured to
-    build against the most appropriate target for the referring target framework.
-
-    ======================================================================================
-  -->
-  <Target Name="_GetProjectReferenceTargetFrameworkProperties">
+  <Target Name="_ComputeProjectReferenceTargetFrameworkMatches" BeforeTargets="_GetProjectReferenceTargetFrameworkProperties">
     <!--
       Honor SkipGetTargetFrameworkProperties=true metadata on project references
       to mean that the project reference is known not to target multiple frameworks
@@ -1554,6 +1541,60 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </_MSBuildProjectReferenceExistent>
     </ItemGroup>
 
+
+    <!-- Get reference target framework lists -->
+    <MSBuild
+        Projects="@(_MSBuildProjectReferenceExistent)"
+        Targets="GetTargetFrameworks"
+        BuildInParallel="$(BuildInParallel)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform)"
+        ContinueOnError="!$(BuildingProject)"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove);TargetFramework;RuntimeIdentifier"
+        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' != 'true'">
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceTargetFrameworkPossibilities" />
+    </MSBuild>
+
+    <!-- For each reference, get closest match -->
+    <AssignReferenceProperties AnnotatedProjectReferences="@(_ProjectReferenceTargetFrameworkPossibilities)"
+                               CurrentProjectTargetFramework="$(TargetFrameworkMoniker)">
+      <Output ItemName="AnnotatedProjects" TaskParameter="AssignedProjects" />
+    </AssignReferenceProperties>
+
+    <ItemGroup>
+      <_MSBuildProjectReferenceExistent Remove="@(_MSBuildProjectReferenceExistent)" />
+      <_MSBuildProjectReferenceExistent Include="@(AnnotatedProjects)" />
+    </ItemGroup>
+
+    <!-- Assign metadata to ProjectReferences, including skipping old-style TF checks. -->
+  </Target>
+
+  <Target Name="GetTargetFrameworks"
+          Returns="@(_ThisProjectBuildMetadata)">
+    <ItemGroup>
+      <_ThisProjectBuildMetadata Include="$(MSBuildProjectFullPath)">
+        <TargetFrameworks Condition="'$(TargetFrameworks)' != ''">$(TargetFrameworks)</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(TargetFramework)</TargetFrameworks>
+        <HasSingleTargetFramework>true</HasSingleTargetFramework>
+        <HasSingleTargetFramework Condition="'$(IsCrossTargetingBuild)' == 'true'">false</HasSingleTargetFramework>
+        <IsRidAgnostic>true</IsRidAgnostic><!-- TODO -->
+      </_ThisProjectBuildMetadata>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ====================================================================================
+                                        _GetProjectReferenceTargetFrameworkProperties
+
+    Builds the GetTargetFrameworkProperties target of all existent project references,
+    passing $(TargetFrameworkMoniker) as $(ReferringTargetFramework) and sets the
+    SetTargetFramework metadata of the project reference to the value that is returned.
+
+    This allows a cross-targeting project to select how it should be configured to
+    build against the most appropriate target for the referring target framework.
+
+    ======================================================================================
+  -->
+  <Target Name="_GetProjectReferenceTargetFrameworkProperties">
     <!--
       Select the moniker to send to each project reference  if not already set. NugetTargetMoniker (NTM) is preferred by default over 
       TargetFrameworkMoniker (TFM) because it is required to disambiguate the UWP case where TFM is fixed at .NETCore,Version=v5.0 and 

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -169,6 +169,8 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.XslTransformation"                     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.WinMDExp"                              AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
 
+    <UsingTask TaskName="Microsoft.Build.Tasks.AssignReferenceProperties"             AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+
     <!-- Roslyn tasks are now in an assembly owned and shipped by Roslyn -->
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"                       AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"                       AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -1,34 +1,37 @@
 ﻿{
-  "frameworks": {
-    "net46": {
-      "dependencies": {
-        "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
-        "System.Collections.Immutable": "1.3.1",
-        "System.Reflection.Metadata": "1.3.0",
-        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
-      }
+    "dependencies": {
+        "NuGet.Frameworks": "4.3.0"
     },
-    "netstandard1.3": {
-      "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "System.Collections.Immutable": "1.2.0",
-        "System.Collections.NonGeneric": "4.0.1",
-        "System.Diagnostics.Process": "4.1.0",
-        "System.Diagnostics.TraceSource": "4.0.0",
-        "System.Linq.Parallel": "4.0.1",
-        "System.Reflection.Metadata": "1.3.0",
-        "System.Reflection.TypeExtensions": "4.1.0",
-        "System.Resources.Writer": "4.0.0",
-        "System.Runtime.Serialization.Primitives": "4.1.1",
-        "System.Runtime.Serialization.Xml": "4.1.1",
-        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
-        "System.Security.Cryptography.Algorithms": "4.2.0",
-        "System.Text.Encoding.CodePages" : "4.0.1",
-        "System.Threading.Thread": "4.0.0",
-        "System.Xml.XmlDocument": "4.0.1",
-        "System.Xml.XPath": "4.0.1",
-        "System.Xml.XPath.XmlDocument":  "4.0.1"
-      }
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.2.304-preview5",
+                "System.Collections.Immutable": "1.3.1",
+                "System.Reflection.Metadata": "1.3.0",
+                "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
+            }
+        },
+        "netstandard1.3": {
+            "dependencies": {
+                "NETStandard.Library": "1.6.0",
+                "System.Collections.Immutable": "1.2.0",
+                "System.Collections.NonGeneric": "4.0.1",
+                "System.Diagnostics.Process": "4.1.0",
+                "System.Diagnostics.TraceSource": "4.0.0",
+                "System.Linq.Parallel": "4.0.1",
+                "System.Reflection.Metadata": "1.3.0",
+                "System.Reflection.TypeExtensions": "4.1.0",
+                "System.Resources.Writer": "4.0.0",
+                "System.Runtime.Serialization.Primitives": "4.1.1",
+                "System.Runtime.Serialization.Xml": "4.1.1",
+                "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+                "System.Security.Cryptography.Algorithms": "4.2.0",
+                "System.Text.Encoding.CodePages": "4.0.1",
+                "System.Threading.Thread": "4.0.0",
+                "System.Xml.XmlDocument": "4.0.1",
+                "System.Xml.XPath": "4.0.1",
+                "System.Xml.XPath.XmlDocument": "4.0.1"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
This is a proposed ProjectReference protocol change and the required new target (+ dependency on NuGet.Frameworks).

This allows solving the double-evaluation-of-ProjectReferences problem by ensuring that a) every referencing project calls into the same cached `GetTargetFrameworks`-with-no-TF-set evaluation of the reference, and b) single-targeted projects will use the same evaluation for their build.

It is also cacheable, but that's not done here.

Builds on #2458, since that simplified the ProjectReference flow.