### PR TITLE
Add binding redirect for RuntimeInformation facade

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -44,11 +44,20 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
           <codeBase version="15.1.0.0" href="..\Microsoft.Build.Conversion.Core.dll"/>
         </dependentAssembly>
+
+        <!-- Redirects for facade assemblies -->
         <dependentAssembly>
           <assemblyIdentity name="System.IO.Compression" culture="neutral" publicKeyToken="b77a5c561934e089" />
           <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
           <codeBase version="4.1.2.0" href="..\System.IO.Compression.dll"/>
         </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+          <codeBase version="4.0.1.0" href="..\System.Runtime.InteropServices.RuntimeInformation.dll" />
+        </dependentAssembly>
+
+        <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -38,10 +38,18 @@
           <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
         </dependentAssembly>
+
+        <!-- Redirects for facade assemblies -->
         <dependentAssembly>
           <assemblyIdentity name="System.IO.Compression" culture="neutral" publicKeyToken="b77a5c561934e089" />
           <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
         </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+        </dependentAssembly>
+
+        <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,5 @@
 {
-  "version": "15.3",
-  "buildNumberOffset": "300",
+  "version": "15.4",
   "assemblyVersion": "15.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",


### PR DESCRIPTION
Add binding redirect for RuntimeInformation facade
Not specifying this binding redirect was causing ngen issues with a
future version of .NET was installed.

Internal tracking bug: 467584