### PR TITLE
Port #2454: Check only the major version when finding VS

### DIFF
--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -227,15 +227,17 @@ namespace Microsoft.Build.Engine.UnitTests
             }
         }
 
-        [Fact]
+        [Theory]
         [Trait("Category", "nonlinuxtests")]
         [Trait("Category", "nonosxtests")]
-        public void BuildEnvironmentDetectsVisualStudioFromSetupInstance()
+        [InlineData("15.0")]
+        [InlineData("15.3")]
+        public void BuildEnvironmentDetectsVisualStudioFromSetupInstance(string visualStudioVersion)
         {
             using (var env = new EmptyVSEnviroment())
             {
-                env.WithVsInstance(new VisualStudioInstance("Invalid path", @"c:\_doesnotexist", new Version("15.0")));
-                env.WithVsInstance(new VisualStudioInstance("VS", env.TempFolderRoot, new Version("15.0")));
+                env.WithVsInstance(new VisualStudioInstance("Invalid path", @"c:\_doesnotexist", new Version(visualStudioVersion)));
+                env.WithVsInstance(new VisualStudioInstance("VS", env.TempFolderRoot, new Version(visualStudioVersion)));
 
                 // This test has no context to find MSBuild other than Visual Studio root.
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock);

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Build.Shared
         {
             Version v = new Version(CurrentVisualStudioVersion);
             var instances = s_getVisualStudioInstances()
-                .Where(i => i.Version.Major == v.Major && i.Version.Minor == v.Minor && Directory.Exists(i.Path))
+                .Where(i => i.Version.Major == v.Major && Directory.Exists(i.Path))
                 .ToList();
 
             if (instances.Count == 0) return null;

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Build.Shared
         internal const string CurrentAssemblyVersion = Microsoft.VisualStudio.Internal.BrandNames.VSGeneralAssemblyVersion;
 #endif
 
-        internal const string CurrentAssemblyFileVersion = "15.3.0.0";
+        internal const string CurrentAssemblyFileVersion = "15.4.0.0";
 
         /// <summary>
         /// Current version of this MSBuild Engine assembly in the form, e.g, "12.0"


### PR DESCRIPTION
Fixes #2369 by relaxing the check to find any Visual Studio 15.*
install. This is required because Visual Studio 2017 Update 3 reports as
15.3.something, which wouldn't be found by the old code. Before Visual
Studio 15.2, a bug in VS setup caused it to report 15.0 (erroneously,
but compatibly with the old MSBuild behavior).