### PR TITLE
Remove duplicate include of App.config

### DIFF
--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -144,10 +144,6 @@
     <Compile Include="Instance\ProjectTaskOutputItemInstance_Tests.cs" />
     <Compile Include="Instance\ProjectTaskOutputPropertyInstance_Tests.cs" />
     <Compile Include="LazyFormattedEventArgs_Tests.cs" />
-    <None Include="..\Shared\UnitTests\App.config">
-      <Link>App.config</Link>
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup Condition="'$(NetCoreBuild)' != 'true'">
     <Reference Include="System" />


### PR DESCRIPTION
App.config was being included twice and cause a warning in the error list.